### PR TITLE
Attempt to update for Bevy 0.2

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -28,7 +28,7 @@ serde-serialize = [ "rapier2d/serde-serialize" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
-bevy = "0.1"
+bevy = "0.2"
 nalgebra = "0.22"
 rapier2d = "0.1"
 concurrent-queue = "1"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -34,4 +34,4 @@ rapier2d = "0.1"
 concurrent-queue = "1"
 
 [dev-dependencies]
-bevy_fly_camera = "0.1"
+

--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -19,7 +19,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)
@@ -39,11 +39,11 @@ fn setup_graphics(mut commands: Commands, mut scale: ResMut<RapierPhysicsScale>)
 
     commands
         .spawn(LightComponents {
-            translation: Translation::new(1000.0, 100.0, 2000.0),
+            transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
         .spawn(Camera2dComponents {
-            translation: Translation::new(0.0, 200.0, 0.0),
+            transform: Transform::from_translation(Vec3::new(0.0, 200.0, 0.0)),
             ..Camera2dComponents::default()
         });
 }

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -19,7 +19,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)
@@ -40,11 +40,11 @@ fn setup_graphics(mut commands: Commands, mut scale: ResMut<RapierPhysicsScale>)
 
     commands
         .spawn(LightComponents {
-            translation: Translation::new(1000.0, 100.0, 2000.0),
+            transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
         .spawn(Camera2dComponents {
-            translation: Translation::new(0.0, 0.0, 0.0),
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
             ..Camera2dComponents::default()
         });
 }

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -21,7 +21,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)
@@ -41,11 +41,11 @@ fn setup_graphics(mut commands: Commands, mut scale: ResMut<RapierPhysicsScale>)
 
     commands
         .spawn(LightComponents {
-            translation: Translation::new(1000.0, 100.0, 2000.0),
+            transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
         .spawn(Camera2dComponents {
-            translation: Translation::new(200.0, -200.0, 0.0),
+            transform: Transform::from_translation(Vec3::new(200.0, -200.0, 0.0)),
             ..Camera2dComponents::default()
         });
 }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -34,4 +34,3 @@ rapier3d = "0.1"
 concurrent-queue = "1"
 
 [dev-dependencies]
-bevy_fly_camera = "0.1"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -28,7 +28,7 @@ serde-serialize = [ "rapier3d/serde-serialize" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
-bevy = "0.1"
+bevy = "0.2"
 nalgebra = "0.22"
 rapier3d = "0.1"
 concurrent-queue = "1"

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -19,7 +19,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)
@@ -37,11 +37,11 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 fn setup_graphics(mut commands: Commands) {
     commands
         .spawn(LightComponents {
-            translation: Translation::new(1000.0, 100.0, 2000.0),
+            transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
         .spawn(Camera3dComponents {
-            transform: Transform::new_sync_disabled(Mat4::face_toward(
+            transform: Transform::new(Mat4::face_toward(
                 Vec3::new(-30.0, 30.0, 100.0),
                 Vec3::new(0.0, 10.0, 0.0),
                 Vec3::new(0.0, 1.0, 0.0),

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -19,7 +19,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)
@@ -38,11 +38,11 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 fn setup_graphics(mut commands: Commands) {
     commands
         .spawn(LightComponents {
-            translation: Translation::new(1000.0, 100.0, 2000.0),
+            transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
         .spawn(Camera3dComponents {
-            transform: Transform::new_sync_disabled(Mat4::face_toward(
+            transform: Transform::new(Mat4::face_toward(
                 Vec3::new(0.0, 0.0, 25.0),
                 Vec3::new(0.0, 0.0, 0.0),
                 Vec3::new(0.0, 1.0, 0.0),

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -22,7 +22,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)
@@ -40,11 +40,11 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 fn setup_graphics(mut commands: Commands) {
     commands
         .spawn(LightComponents {
-            translation: Translation::new(1000.0, 100.0, 2000.0),
+            transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
         .spawn(Camera3dComponents {
-            transform: Transform::new_sync_disabled(Mat4::face_toward(
+            transform: Transform::new(Mat4::face_toward(
                 Vec3::new(15.0, 5.0, 42.0),
                 Vec3::new(13.0, 1.0, 1.0),
                 Vec3::new(0.0, 1.0, 0.0),

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -93,8 +93,7 @@ pub fn sync_transform_system(
     bodies: ResMut<RigidBodySet>,
     scale: Res<RapierPhysicsScale>,
     rigid_body: &RigidBodyHandleComponent,
-    mut translation: Mut<Translation>,
-    mut rotation: Mut<Rotation>,
+    mut transform: Mut<Transform>,
 ) {
     if let Some(rb) = bodies.get(rigid_body.handle()) {
         let pos = rb.position;
@@ -102,26 +101,24 @@ pub fn sync_transform_system(
         #[cfg(feature = "dim2")]
         {
             let rot = na::UnitQuaternion::new(na::Vector3::z() * pos.rotation.angle());
-
-            *translation.0.x_mut() = pos.translation.vector.x * scale.0;
-            *translation.0.y_mut() = pos.translation.vector.y * scale.0;
-            rotation.0 = Quat::from_xyzw(rot.i, rot.j, rot.k, rot.w);
+            transform.set_translation(Vec3::new(pos.translation.vector.x * scale.0, pos.translation.vector.y * scale.0, 0.0));
+            transform.set_rotation(Quat::from_xyzw(rot.i, rot.j, rot.k, rot.w));
         }
 
         #[cfg(feature = "dim3")]
         {
-            translation.0 = Vec3::new(
+            transform.set_translation(Vec3::new(
                 pos.translation.vector.x,
                 pos.translation.vector.y,
                 pos.translation.vector.z,
-            ) * scale.0;
+            ) * scale.0);
 
-            rotation.0 = Quat::from_xyzw(
+            transform.set_rotation(Quat::from_xyzw(
                 pos.rotation.i,
                 pos.rotation.j,
                 pos.rotation.k,
                 pos.rotation.w,
-            );
+            ));
         }
     }
 }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -89,17 +89,7 @@ pub fn create_collider_renders_system(
                     ..Default::default()
                 };
 
-                commands.insert(
-                    entity,
-                    (
-                        ground_pbr.mesh,
-                        ground_pbr.material,
-                        ground_pbr.main_pass,
-                        ground_pbr.draw,
-                        ground_pbr.render_pipelines,
-                        ground_pbr.transform,
-                    ),
-                );
+                commands.insert(entity, ground_pbr);
             }
         }
     }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -85,6 +85,7 @@ pub fn create_collider_renders_system(
                 let ground_pbr = PbrComponents {
                     mesh: meshes.add(mesh),
                     material: materials.add(color.into()),
+                    transform: Transform::from_non_uniform_scale(scale),
                     ..Default::default()
                 };
 
@@ -97,9 +98,6 @@ pub fn create_collider_renders_system(
                         ground_pbr.draw,
                         ground_pbr.render_pipelines,
                         ground_pbr.transform,
-                        ground_pbr.translation,
-                        ground_pbr.rotation,
-                        NonUniformScale(scale),
                     ),
                 );
             }

--- a/src_debug_ui/systems.rs
+++ b/src_debug_ui/systems.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use rapier::pipeline::PhysicsPipeline;
 
 pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font_handle = asset_server.load("assets/FiraSans-Bold.ttf").unwrap();
+    let font_handle = asset_server.load("../assets/FiraSans-Bold.ttf").unwrap();
     commands
         // 2d camera
         .spawn(UiCameraComponents::default())


### PR DESCRIPTION
This is my attempt at updating bevy_rapier to work with [Bevy 0.2.x](https://bevyengine.org/news/bevy-0-2/)

- On macOS _with_ this PR, the examples all run with a blank white screen and debug output of many lines of `queue 21` -- that's not...ideal.
- On macOS _without_ this PR (using Bevy 0.1.x), the examples were already crashing with this error:
```
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', /Users/nathan/.cargo/registry/src/github.com-1ecc6299db9ec823/bevy_text-0.1.3/src/font_atlas_set.rs:53:42
```

Everything _builds_, but I don't know if it is functioning correctly.  I am able to get a personal project to _build_ with this PR on my mac, but it doesn't seem to _do_ anything. It might be user error in my personal project, or perhaps this upgrade attempt is faulty.  I've never used bevy_rapier (or rapier) before today.

Hopefully this proves helpful, as I'd love to add some physics to my project.