### PR TITLE
Fix examples on macOS

### DIFF
--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -19,7 +19,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -19,7 +19,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -21,7 +21,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -19,7 +19,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -19,7 +19,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -22,7 +22,7 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .add_resource(Msaa { samples: 2 })
+        .add_resource(Msaa::default())
         .add_default_plugins()
         .add_plugin(RapierPhysicsPlugin)
         .add_plugin(RapierRenderPlugin)


### PR DESCRIPTION
While working on https://github.com/dimforge/bevy_rapier/pull/10 I discovered that the examples crashed on macOS due to the chosen Msaa setting. This default should be safer (and works on macOS for me).