### PR TITLE
Added RapierConfiguration resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+- Rapier configuration
+  - Replaced `Gravity` and `RapierPhysicsScale` resources with a unique `RapierConfiguration` resource.
+  - Added an `active` attribute to `RapierConfiguration` allowing to pause the physic simulation.
+

--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -2,7 +2,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
-use bevy_rapier2d::physics::{RapierPhysicsPlugin, RapierPhysicsScale};
+use bevy_rapier2d::physics::{RapierConfiguration, RapierPhysicsPlugin};
 use bevy_rapier2d::render::RapierRenderPlugin;
 use rapier2d::dynamics::RigidBodyBuilder;
 use rapier2d::geometry::ColliderBuilder;
@@ -34,8 +34,8 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut scale: ResMut<RapierPhysicsScale>) {
-    scale.0 = 10.0;
+fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+    configuration.scale = 10.0;
 
     commands
         .spawn(LightComponents {

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -2,7 +2,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
-use bevy_rapier2d::physics::{EventQueue, RapierPhysicsPlugin, RapierPhysicsScale};
+use bevy_rapier2d::physics::{EventQueue, RapierConfiguration, RapierPhysicsPlugin};
 use bevy_rapier2d::render::RapierRenderPlugin;
 use rapier2d::dynamics::RigidBodyBuilder;
 use rapier2d::geometry::ColliderBuilder;
@@ -35,8 +35,8 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut scale: ResMut<RapierPhysicsScale>) {
-    scale.0 = 15.0;
+fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+    configuration.scale = 15.0;
 
     commands
         .spawn(LightComponents {

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -2,7 +2,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
-use bevy_rapier2d::physics::{JointBuilderComponent, RapierPhysicsPlugin, RapierPhysicsScale};
+use bevy_rapier2d::physics::{JointBuilderComponent, RapierConfiguration, RapierPhysicsPlugin};
 use bevy_rapier2d::render::RapierRenderPlugin;
 use nalgebra::Point2;
 use rapier::dynamics::{BallJoint, BodyStatus};
@@ -36,8 +36,8 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut scale: ResMut<RapierPhysicsScale>) {
-    scale.0 = 12.0;
+fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+    configuration.scale = 12.0;
 
     commands
         .spawn(LightComponents {

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -1,9 +1,8 @@
 use crate::physics;
-use crate::physics::{EventQueue, Gravity, RapierPhysicsScale};
+use crate::physics::{EventQueue, RapierConfiguration};
 use bevy::prelude::*;
 use rapier::dynamics::{IntegrationParameters, JointSet, RigidBodySet};
 use rapier::geometry::{BroadPhase, ColliderSet, NarrowPhase};
-use rapier::math::Vector;
 use rapier::pipeline::PhysicsPipeline;
 
 /// A plugin responsible for setting up a full Rapier physics simulation pipeline and resources.
@@ -21,14 +20,13 @@ pub struct RapierPhysicsPlugin;
 impl Plugin for RapierPhysicsPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_resource(PhysicsPipeline::new())
+            .add_resource(RapierConfiguration::default())
             .add_resource(IntegrationParameters::default())
-            .add_resource(Gravity(Vector::y() * -9.81))
             .add_resource(BroadPhase::new())
             .add_resource(NarrowPhase::new())
             .add_resource(RigidBodySet::new())
             .add_resource(ColliderSet::new())
             .add_resource(JointSet::new())
-            .add_resource(RapierPhysicsScale(1.0))
             .add_resource(EventQueue::new(true))
             // TODO: can we avoid this map? We are only using this
             // to avoid some borrowing issue when joints creations

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -3,15 +3,27 @@ use crate::rapier::pipeline::EventHandler;
 use concurrent_queue::ConcurrentQueue;
 use rapier::math::Vector;
 
-#[derive(Copy, Clone)]
-/// A component describing a scale ration between the physics world and the bevy transforms.
-///
-/// This resource will affect the transform synchronization between Bevy and Rapier.
-/// Each Rapier rigid-body position will have its coordinates multiplied by this scale factor.
-pub struct RapierPhysicsScale(pub f32);
+/// A resource for specifying configuration information for the physics simulation
+pub struct RapierConfiguration {
+    /// Specifying the gravity of the physics simulation.
+    pub gravity: Vector<f32>,
+    /// Specifies a scale ratio between the physics world and the bevy transforms.
+    /// This will affect the transform synchronization between Bevy and Rapier.
+    /// Each Rapier rigid-body position will have its coordinates multiplied by this scale factor.
+    pub scale: f32,
+    /// Specifies if the physics simulation is active and update the physics world.
+    pub active: bool,
+}
 
-/// A resource for specifying the gravity of the physics simulation.
-pub struct Gravity(pub Vector<f32>);
+impl Default for RapierConfiguration {
+    fn default() -> Self {
+        Self {
+            gravity: Vector::y() * -9.81,
+            scale: 1.0,
+            active: true,
+        }
+    }
+}
 
 // TODO: it may be more efficient to use crossbeam channel.
 // However crossbeam channels cause a Segfault (I have not

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -1,4 +1,4 @@
-use crate::physics::{ColliderHandleComponent, RapierPhysicsScale};
+use crate::physics::{ColliderHandleComponent, RapierConfiguration};
 use crate::render::RapierRenderColor;
 use bevy::prelude::*;
 use rapier::dynamics::RigidBodySet;
@@ -9,7 +9,7 @@ pub fn create_collider_renders_system(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    scale: Res<RapierPhysicsScale>,
+    configuration: Res<RapierConfiguration>,
     bodies: Res<RigidBodySet>,
     colliders: ResMut<ColliderSet>,
     mut query: Query<
@@ -76,7 +76,7 @@ pub fn create_collider_renders_system(
                     Shape::Cuboid(c) => Vec3::from_slice_unaligned(c.half_extents.as_slice()),
                     Shape::Ball(b) => Vec3::new(b.radius, b.radius, b.radius),
                     _ => unimplemented!(),
-                } * scale.0;
+                } * configuration.scale;
 
                 // NOTE: we can't have both the Scale and NonUniformScale components.
                 // However PbrComponents automatically adds a Scale component. So


### PR DESCRIPTION
This resource replaces Gravity and RapierPhysicsScale, which are now  `gravity` and `scale` attribute of the `RapierConfiguration` resource
Added `active` attribute to `RapierConfiguration` to pause the physics simulation

Added a CHANGELOG.md with a format inspired from bevy CHANGELOG