### PR TITLE
Remove EntityToBody resource

### DIFF
--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -1,5 +1,5 @@
 use crate::physics;
-use crate::physics::{EntityToBody, EventQueue, Gravity, RapierPhysicsScale};
+use crate::physics::{EventQueue, Gravity, RapierPhysicsScale};
 use bevy::prelude::*;
 use rapier::dynamics::{IntegrationParameters, JointSet, RigidBodySet};
 use rapier::geometry::{BroadPhase, ColliderSet, NarrowPhase};
@@ -33,7 +33,6 @@ impl Plugin for RapierPhysicsPlugin {
             // TODO: can we avoid this map? We are only using this
             // to avoid some borrowing issue when joints creations
             // are needed.
-            .add_resource(EntityToBody::new())
             .add_system_to_stage_front(
                 stage::PRE_UPDATE,
                 physics::create_body_and_collider_system.system(),

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -1,10 +1,7 @@
 use crate::rapier::geometry::{ContactEvent, ProximityEvent};
 use crate::rapier::pipeline::EventHandler;
-use bevy::ecs::Entity;
 use concurrent_queue::ConcurrentQueue;
-use rapier::dynamics::RigidBodyHandle;
 use rapier::math::Vector;
-use std::collections::HashMap;
 
 #[derive(Copy, Clone)]
 /// A component describing a scale ration between the physics world and the bevy transforms.
@@ -12,18 +9,6 @@ use std::collections::HashMap;
 /// This resource will affect the transform synchronization between Bevy and Rapier.
 /// Each Rapier rigid-body position will have its coordinates multiplied by this scale factor.
 pub struct RapierPhysicsScale(pub f32);
-
-/// A map between bevy's entities and Rapier's handles.
-///
-/// This map will likely be removed in the future.
-pub struct EntityToBody(pub(crate) HashMap<Entity, RigidBodyHandle>);
-
-impl EntityToBody {
-    /// Create a new empty map.
-    pub fn new() -> Self {
-        EntityToBody(HashMap::new())
-    }
-}
 
 /// A resource for specifying the gravity of the physics simulation.
 pub struct Gravity(pub Vector<f32>);


### PR DESCRIPTION
In the code, this resource was said to be 'temporary'.
I have replaced the use of this resource with an additional query in the system needing it.
I think this does the job, examples are running fine.
