### PR TITLE
Keep z translation value untouched in 2d

### DIFF
--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -98,11 +98,9 @@ pub fn sync_transform_system(
         #[cfg(feature = "dim2")]
         {
             let rot = na::UnitQuaternion::new(na::Vector3::z() * pos.rotation.angle());
-            transform.set_translation(Vec3::new(
-                pos.translation.vector.x * scale.0,
-                pos.translation.vector.y * scale.0,
-                0.0,
-            ));
+            // Do not touch the 'z' part of the translation, used in Bevy for 2d layering
+            *transform.translation_mut().x_mut() = pos.translation.vector.x * scale.0;
+            *transform.translation_mut().y_mut() = pos.translation.vector.y * scale.0;
             transform.set_rotation(Quat::from_xyzw(rot.i, rot.j, rot.k, rot.w));
         }
 


### PR DESCRIPTION
After the update to bevy change on transform, we put back the zeroing of the 'z'  translation value in 2d.
This PR leaves untouched the z portion of the translation, as the 'z' value is used in bevy to do sprite layering in 2d.