### PR TITLE
Interpolate simulation state at render time

### DIFF
--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use rapier::dynamics::{JointHandle, JointParams, RigidBodyHandle};
 use rapier::geometry::ColliderHandle;
+use rapier::math::Isometry;
 
 /// A component representing a rigid-body that is being handled by
 /// a Rapier physics World.
@@ -98,3 +99,7 @@ impl JointBuilderComponent {
         }
     }
 }
+
+/// A component to store the previous position of a body to use for
+/// interpolation between steps
+pub struct PhysicsInterpolationComponent(pub Isometry<f32>);

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -1,7 +1,8 @@
 use bevy::prelude::*;
 use rapier::dynamics::{JointHandle, JointParams, RigidBodyHandle};
 use rapier::geometry::ColliderHandle;
-use rapier::math::Isometry;
+use rapier::math::{Translation, Vector, Isometry};
+use rapier::na::{Quaternion, UnitQuaternion};
 
 /// A component representing a rigid-body that is being handled by
 /// a Rapier physics World.
@@ -103,3 +104,13 @@ impl JointBuilderComponent {
 /// A component to store the previous position of a body to use for
 /// interpolation between steps
 pub struct PhysicsInterpolationComponent(pub Isometry<f32>);
+
+impl PhysicsInterpolationComponent {
+    /// Create a new PhysicsInterpolationComponent from a translation and rotation
+    pub fn new(translation: Vec3, rotation: Quat) -> Self {
+        Self(Isometry::from_parts(
+            Translation::from(Vector::new(translation.x(), translation.y(), translation.z())),
+            UnitQuaternion::from_quaternion(Quaternion::new(rotation.x(), rotation.y(), rotation.z(), rotation.w())),
+        ))
+    }
+}

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -1,5 +1,5 @@
 use crate::physics;
-use crate::physics::{EventQueue, RapierConfiguration};
+use crate::physics::{EventQueue, RapierConfiguration, SimulationToRenderTime};
 use crate::rapier::pipeline::QueryPipeline;
 use bevy::prelude::*;
 use rapier::dynamics::{IntegrationParameters, JointSet, RigidBodySet};
@@ -30,6 +30,7 @@ impl Plugin for RapierPhysicsPlugin {
             .add_resource(ColliderSet::new())
             .add_resource(JointSet::new())
             .add_resource(EventQueue::new(true))
+            .add_resource(SimulationToRenderTime::default())
             // TODO: can we avoid this map? We are only using this
             // to avoid some borrowing issue when joints creations
             // are needed.

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -68,3 +68,10 @@ impl EventHandler for EventQueue {
         let _ = self.contact_events.push(event);
     }
 }
+
+/// Difference between simulation and rendering time
+#[derive(Default)]
+pub struct SimulationToRenderTime {
+    /// Difference between simulation and rendering time
+    pub diff: f32,
+}

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -144,6 +144,7 @@ pub fn sync_transform_system(
     sim_to_render_time: Res<SimulationToRenderTime>,
     bodies: ResMut<RigidBodySet>,
     configuration: Res<RapierConfiguration>,
+    integration_parameters: Res<IntegrationParameters>,
     mut interpolation_query: Query<(
         &RigidBodyHandleComponent,
         &PhysicsInterpolationComponent,
@@ -154,10 +155,12 @@ pub fn sync_transform_system(
     >,
 ) {
     let dt = sim_to_render_time.diff;
+    let sim_dt = integration_parameters.dt();
+    let alpha = dt / sim_dt;
     for (rigid_body, previous_pos, mut transform) in &mut interpolation_query.iter() {
         if let Some(rb) = bodies.get(rigid_body.handle()) {
             // Predict position and orientation at render time
-            let pos = previous_pos.0.lerp_slerp(&rb.position, dt);
+            let pos = previous_pos.0.lerp_slerp(&rb.position, alpha);
             #[cfg(feature = "dim2")]
             sync_transform_2d(pos, configuration.scale, &mut transform);
 

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -84,7 +84,7 @@ pub fn step_world_system(
     sim_to_render_time.diff += time.delta_seconds;
 
     let sim_dt = integration_parameters.dt();
-    while sim_to_render_time.diff > sim_dt {
+    while sim_to_render_time.diff >= sim_dt {
         if configuration.physics_pipeline_active {
             if sim_to_render_time.diff < 2.0 * sim_dt {
                 // This is the last simulation step to be executed in the loop

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -86,7 +86,10 @@ pub fn step_world_system(
     let sim_dt = integration_parameters.dt();
     while sim_to_render_time.diff >= sim_dt {
         if configuration.physics_pipeline_active {
-            if sim_to_render_time.diff < 2.0 * sim_dt {
+            // NOTE: in this comparison we do the same computations we
+            // will do for the next `while` iteration test, to make sure we
+            // don't get bit by potential float inaccuracy.
+            if sim_to_render_time.diff - sim_dt < sim_dt {
                 // This is the last simulation step to be executed in the loop
                 // Update the previous state transforms
                 for (body_handle, mut previous_state) in &mut query.iter() {


### PR DESCRIPTION
This commit follows the suggestion from:

https://www.gafferongames.com/post/fix_your_timestep/

The problem is that the simulation is stepped with a fixed time step, as it
should be to maintain simulation stability. However, the time step of each game
loop may vary based on external factors to the physics engine. For example, if
the timestep is 1/60 but the game loop iterates at a faster rate, then the
physics simulation will appear to advance faster than real-time.

The idea for the solution is that the renderer / game loop 'produces' time, and
the simulation consumes it. As such, a new resource has been added to keep
track of the amount of time produced and consumed. It represents how far ahead
of the simulation the rendering is.

The step_world_system has been modified to add Time.delta_seconds to the
SimulationToRenderTime resource, and then if there is more than a time step of
time to simulate, we loop through stepping the simulation and subtracting the
simulation time step from the resource until there is less than a time step of
time remaining to simulate.

As noted in the article, if this was all we did then the motion of objects due
to physics would look jittery. We have to interpolate the positions and
orientations of simulated objects between each simulation step. The
sync_transform_system has been modified to lerp and slerp the position and rotation of
each body based on its previous and current simulation position and rotation.