### PR TITLE
Specify only the required set of bevy features (default-features = false)

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -28,7 +28,7 @@ serde-serialize = [ "rapier2d/serde-serialize" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
-bevy = "0.3"
+bevy = { version = "0.3", default-features = false, features = ["render"] }
 nalgebra = "0.23"
 rapier2d = "0.3"
 concurrent-queue = "1"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -28,7 +28,7 @@ serde-serialize = [ "rapier3d/serde-serialize" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
-bevy = "0.3"
+bevy = { version = "0.3", default-features = false, features = ["render"] }
 nalgebra = "0.23"
 rapier3d = "0.3"
 concurrent-queue = "1"


### PR DESCRIPTION
`bevy_rapier` doesn't actually require all bevy features to successfully build, so far only `render` is needed. This should fix #26, since `bevy_rapier` won't try to build `bevy_wgpu`, which can't be compiled for `wasm32-unknown-unknown` atm.