### PR TITLE
Move the physics sync systems to run before POST_UPDATE

### DIFF
--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -44,9 +44,10 @@ impl Plugin for RapierPhysicsPlugin {
             )
             .add_system_to_stage(stage::PRE_UPDATE, physics::create_joints_system.system())
             .add_system_to_stage(stage::UPDATE, physics::step_world_system.system())
-            .add_system_to_stage(stage::POST_UPDATE, physics::sync_transform_system.system())
+            .add_stage_before(stage::POST_UPDATE, "physics_sync")
+            .add_system_to_stage("physics_sync", physics::sync_transform_system.system())
             .add_system_to_stage(
-                stage::POST_UPDATE,
+                "physics_sync",
                 physics::destroy_body_and_collider_system.system(),
             );
     }


### PR DESCRIPTION
When using rapier with entity hierarchies it is important that rapier's sync happen before the transform hierarchy runs so that children's GlobalTransforms are correctly synced to their parent's Transform.

Previously rapier's sync was in the POST_UPDATE and likely would run after the hierarchy system. This change simply adds a stage before POST_UPDATE and puts they rapier systems there so the order is guaranteed.