### PR TITLE
Make our time-dependent number of timestep optional.

### DIFF
--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -106,22 +106,28 @@ impl JointBuilderComponent {
 
 /// A component to store the previous position of a body to use for
 /// interpolation between steps
-pub struct PhysicsInterpolationComponent(pub Isometry<f32>);
+pub struct PhysicsInterpolationComponent(pub Option<Isometry<f32>>);
+
+impl Default for PhysicsInterpolationComponent {
+    fn default() -> Self {
+        PhysicsInterpolationComponent(None)
+    }
+}
 
 impl PhysicsInterpolationComponent {
     /// Create a new PhysicsInterpolationComponent from a translation and rotation
     #[cfg(feature = "dim2")]
     pub fn new(translation: Vec2, rotation_angle: f32) -> Self {
-        Self(Isometry::from_parts(
+        Self(Some(Isometry::from_parts(
             Translation::from(Vector::new(translation.x(), translation.y())),
             UnitComplex::new(rotation_angle),
-        ))
+        )))
     }
 
     /// Create a new PhysicsInterpolationComponent from a translation and rotation
     #[cfg(feature = "dim3")]
     pub fn new(translation: Vec3, rotation: Quat) -> Self {
-        Self(Isometry::from_parts(
+        Self(Some(Isometry::from_parts(
             Translation::from(Vector::new(
                 translation.x(),
                 translation.y(),
@@ -133,6 +139,6 @@ impl PhysicsInterpolationComponent {
                 rotation.z(),
                 rotation.w(),
             )),
-        ))
+        )))
     }
 }

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -20,6 +20,11 @@ use rapier::pipeline::PhysicsPipeline;
 /// - Systems responsible for executing one physics timestep at each Bevy update stage.
 pub struct RapierPhysicsPlugin;
 
+/// The stage where the physics transform are output to the Bevy Transform.
+///
+/// This stage is added right before the `POST_UPDATE` stage.
+pub const TRANSFORM_SYNC_STAGE: &'static str = "rapier::transform_sync_stage";
+
 impl Plugin for RapierPhysicsPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_resource(PhysicsPipeline::new())
@@ -44,10 +49,13 @@ impl Plugin for RapierPhysicsPlugin {
             )
             .add_system_to_stage(stage::PRE_UPDATE, physics::create_joints_system.system())
             .add_system_to_stage(stage::UPDATE, physics::step_world_system.system())
-            .add_stage_before(stage::POST_UPDATE, "physics_sync")
-            .add_system_to_stage("physics_sync", physics::sync_transform_system.system())
+            .add_stage_before(stage::POST_UPDATE, TRANSFORM_SYNC_STAGE)
             .add_system_to_stage(
-                "physics_sync",
+                TRANSFORM_SYNC_STAGE,
+                physics::sync_transform_system.system(),
+            )
+            .add_system_to_stage(
+                TRANSFORM_SYNC_STAGE,
                 physics::destroy_body_and_collider_system.system(),
             );
     }

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -22,6 +22,9 @@ pub struct RapierConfiguration {
     pub physics_pipeline_active: bool,
     /// Specifies if the query pipeline is active and update the query pipeline.
     pub query_pipeline_active: bool,
+    /// Specifies if the number of physics steps run at each frame should depend
+    /// of the real-world time elapsed since the last step.
+    pub time_dependent_number_of_timesteps: bool,
 }
 
 impl Default for RapierConfiguration {
@@ -31,6 +34,7 @@ impl Default for RapierConfiguration {
             scale: 1.0,
             physics_pipeline_active: true,
             query_pipeline_active: true,
+            time_dependent_number_of_timesteps: false,
         }
     }
 }


### PR DESCRIPTION
This makes the changes introduced by https://github.com/dimforge/bevy_rapier/pull/19 optional and disabled by default.
By default the Rapier plugin will perform one timestep per render loop iteration, independently from the real time elapsed between two frames.

If `RapierConfiguration::time_dependent_number_of_timesteps` is set to `true`, then we will use the multiple-timesteps scheme implemented in #19. Since this scheme is non-trivial, it's best to keep it opt-in in order to make sure the user understands why they want this.