### PR TITLE
Fix for #41. support physics_pipeline_active false in all cases.

### DIFF
--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -223,7 +223,7 @@ pub fn step_world_system(
             }
             sim_to_render_time.diff -= sim_dt;
         }
-    } else {
+    } else if configuration.physics_pipeline_active {
         pipeline.step(
             &configuration.gravity,
             &integration_parameters,


### PR DESCRIPTION
Fix for #41.

Add back support for physics_pipeline_active set to false when time_dependent_number_of_timesteps is false.

Fix tested with my Kataster mini-game that found the issue when migrating to bevy_rapier 0.6.2