### PR TITLE
Update to bevy v0.4.0

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -28,11 +28,11 @@ serde-serialize = [ "rapier2d/serde-serialize" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.3", default-features = false, features = ["render"] }
+bevy = { version = "0.4", default-features = false, features = ["render"] }
 nalgebra = "0.23"
 rapier2d = "0.4"
 concurrent-queue = "1"
 
 [dev-dependencies]
-bevy_wgpu = "0.3.0"
-bevy_winit = { version = "0.3.0", features = [ "x11" ] }
+bevy_wgpu = "0.4.0"
+bevy_winit = { version = "0.4.0", features = [ "x11" ] }

--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -36,21 +36,21 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+fn setup_graphics(commands: &mut Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 10.0;
 
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents {
+        .spawn(Camera2dBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 200.0, 0.0)),
-            ..Camera2dComponents::default()
+            ..Camera2dBundle::default()
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Ground
      */

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -52,21 +52,21 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+fn setup_graphics(commands: &mut Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 10.0;
 
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents {
+        .spawn(Camera2dBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 200.0, 0.0)),
-            ..Camera2dComponents::default()
+            ..Camera2dBundle::default()
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Ground
      */

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -43,21 +43,21 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+fn setup_graphics(commands: &mut Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 10.0;
 
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents {
+        .spawn(Camera2dBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 200.0, 0.0)),
-            ..Camera2dComponents::default()
+            ..Camera2dBundle::default()
         });
 }
 
-pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource>) {
+pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResource>) {
     /*
      * Ground
      */
@@ -111,8 +111,8 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
     }
 }
 
-pub fn despawn(mut commands: Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
-    if time.seconds_since_startup > 5.0 {
+pub fn despawn(commands: &mut Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
+    if time.seconds_since_startup() > 5.0 {
         for entity in &despawn.entities {
             println!("Despawning ground entity");
             commands.despawn(*entity);

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -37,17 +37,17 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+fn setup_graphics(commands: &mut Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 15.0;
 
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents {
+        .spawn(Camera2dBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
-            ..Camera2dComponents::default()
+            ..Camera2dBundle::default()
         });
 }
 
@@ -61,7 +61,7 @@ fn display_events(events: Res<EventQueue>) {
     }
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Ground
      */

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -38,21 +38,21 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+fn setup_graphics(commands: &mut Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 12.0;
 
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents {
+        .spawn(Camera2dBundle {
             transform: Transform::from_translation(Vec3::new(200.0, -200.0, 0.0)),
-            ..Camera2dComponents::default()
+            ..Camera2dBundle::default()
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Create the balls
      */

--- a/bevy_rapier2d/examples/joints_despawn2.rs
+++ b/bevy_rapier2d/examples/joints_despawn2.rs
@@ -45,21 +45,21 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+fn setup_graphics(commands: &mut Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 12.0;
 
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents {
+        .spawn(Camera2dBundle {
             transform: Transform::from_translation(Vec3::new(200.0, -200.0, 0.0)),
-            ..Camera2dComponents::default()
+            ..Camera2dBundle::default()
         });
 }
 
-pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource>) {
+pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResource>) {
     /*
      * Create the balls
      */
@@ -132,8 +132,8 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
     }
 }
 
-pub fn despawn(mut commands: Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
-    if time.seconds_since_startup > 10.0 {
+pub fn despawn(commands: &mut Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
+    if time.seconds_since_startup() > 10.0 {
         for entity in &despawn.entities {
             println!("Despawning joint entity");
             commands.despawn(*entity);

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -36,21 +36,21 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+fn setup_graphics(commands: &mut Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 40.0;
 
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents {
+        .spawn(Camera2dBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 30.0, 0.0)),
-            ..Camera2dComponents::default()
+            ..Camera2dBundle::default()
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * The ground
      */

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -36,21 +36,21 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
+fn setup_graphics(commands: &mut Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 10.0;
 
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents {
+        .spawn(Camera2dBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 200.0, 0.0)),
-            ..Camera2dComponents::default()
+            ..Camera2dBundle::default()
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Ground
      */

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -28,11 +28,11 @@ serde-serialize = [ "rapier3d/serde-serialize" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.3", default-features = false, features = ["render"] }
+bevy = { version = "0.4", default-features = false, features = ["render"] }
 nalgebra = "0.23"
 rapier3d = "0.4"
 concurrent-queue = "1"
 
 [dev-dependencies]
-bevy_wgpu = "0.3.0"
-bevy_winit = { version = "0.3.0", features = [ "x11" ] }
+bevy_wgpu = "0.4.0"
+bevy_winit = { version = "0.4.0", features = [ "x11" ] }

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -36,13 +36,13 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands) {
+fn setup_graphics(commands: &mut Commands) {
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(-30.0, 30.0, 100.0),
                 Vec3::new(0.0, 10.0, 0.0),
@@ -52,7 +52,7 @@ fn setup_graphics(mut commands: Commands) {
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Ground
      */

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -52,13 +52,13 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands) {
+fn setup_graphics(commands: &mut Commands) {
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(-30.0, 30.0, 100.0),
                 Vec3::new(0.0, 10.0, 0.0),
@@ -68,7 +68,7 @@ fn setup_graphics(mut commands: Commands) {
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Ground
      */

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -43,13 +43,13 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands) {
+fn setup_graphics(commands: &mut Commands) {
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(-30.0, 30.0, 100.0),
                 Vec3::new(0.0, 10.0, 0.0),
@@ -59,7 +59,7 @@ fn setup_graphics(mut commands: Commands) {
         });
 }
 
-pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource>) {
+pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResource>) {
     /*
      * Ground
      */
@@ -104,8 +104,8 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
     }
 }
 
-pub fn despawn(mut commands: Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
-    if time.seconds_since_startup > 5.0 {
+pub fn despawn(commands: &mut Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
+    if time.seconds_since_startup() > 5.0 {
         if let Some(entity) = despawn.entity {
             println!("Despawning ground entity");
             commands.despawn(entity);

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -37,13 +37,13 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands) {
+fn setup_graphics(commands: &mut Commands) {
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(0.0, 0.0, 25.0),
                 Vec3::new(0.0, 0.0, 0.0),
@@ -63,7 +63,7 @@ fn display_events(events: Res<EventQueue>) {
     }
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Ground
      */

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -39,13 +39,13 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands) {
+fn setup_graphics(commands: &mut Commands) {
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(15.0, 5.0, 42.0),
                 Vec3::new(13.0, 1.0, 1.0),
@@ -265,9 +265,9 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
     }
 }
 
-pub fn setup_physics(mut commands: Commands) {
-    create_prismatic_joints(&mut commands, Point3::new(20.0, 10.0, 0.0), 5);
-    create_revolute_joints(&mut commands, Point3::new(20.0, 0.0, 0.0), 3);
-    create_fixed_joints(&mut commands, Point3::new(0.0, 10.0, 0.0), 5);
-    create_ball_joints(&mut commands, 15);
+pub fn setup_physics(commands: &mut Commands) {
+    create_prismatic_joints(commands, Point3::new(20.0, 10.0, 0.0), 5);
+    create_revolute_joints(commands, Point3::new(20.0, 0.0, 0.0), 3);
+    create_fixed_joints(commands, Point3::new(0.0, 10.0, 0.0), 5);
+    create_ball_joints(commands, 15);
 }

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -46,13 +46,13 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands) {
+fn setup_graphics(commands: &mut Commands) {
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(15.0, 5.0, 42.0),
                 Vec3::new(13.0, 1.0, 1.0),
@@ -323,15 +323,15 @@ fn create_ball_joints(commands: &mut Commands, num: usize, despawn: &mut ResMut<
     }
 }
 
-pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource>) {
-    create_prismatic_joints(&mut commands, Point3::new(20.0, 10.0, 0.0), 5, &mut despawn);
-    create_revolute_joints(&mut commands, Point3::new(20.0, 0.0, 0.0), 3, &mut despawn);
-    create_fixed_joints(&mut commands, Point3::new(0.0, 10.0, 0.0), 5, &mut despawn);
-    create_ball_joints(&mut commands, 15, &mut despawn);
+pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResource>) {
+    create_prismatic_joints(commands, Point3::new(20.0, 10.0, 0.0), 5, &mut despawn);
+    create_revolute_joints(commands, Point3::new(20.0, 0.0, 0.0), 3, &mut despawn);
+    create_fixed_joints(commands, Point3::new(0.0, 10.0, 0.0), 5, &mut despawn);
+    create_ball_joints(commands, 15, &mut despawn);
 }
 
-pub fn despawn(mut commands: Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
-    if time.seconds_since_startup > 10.0 {
+pub fn despawn(commands: &mut Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
+    if time.seconds_since_startup() > 10.0 {
         for entity in &despawn.entities {
             println!("Despawning joint entity");
             commands.despawn(*entity);

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -37,13 +37,13 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands) {
+fn setup_graphics(commands: &mut Commands) {
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(10.0, 3.0, 0.0),
                 Vec3::new(0.0, 3.0, 0.0),
@@ -53,7 +53,7 @@ fn setup_graphics(mut commands: Commands) {
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * The ground
      */

--- a/bevy_rapier3d/examples/multiple_colliders3.rs
+++ b/bevy_rapier3d/examples/multiple_colliders3.rs
@@ -36,13 +36,13 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
     pipeline.counters.enable()
 }
 
-fn setup_graphics(mut commands: Commands) {
+fn setup_graphics(commands: &mut Commands) {
     commands
-        .spawn(LightComponents {
+        .spawn(LightBundle {
             transform: Transform::from_translation(Vec3::new(1000.0, 100.0, 2000.0)),
             ..Default::default()
         })
-        .spawn(Camera3dComponents {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(Mat4::face_toward(
                 Vec3::new(-30.0, 30.0, 100.0),
                 Vec3::new(0.0, 10.0, 0.0),
@@ -52,7 +52,7 @@ fn setup_graphics(mut commands: Commands) {
         });
 }
 
-pub fn setup_physics(mut commands: Commands) {
+pub fn setup_physics(commands: &mut Commands) {
     /*
      * Ground
      */

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -119,7 +119,7 @@ impl PhysicsInterpolationComponent {
     #[cfg(feature = "dim2")]
     pub fn new(translation: Vec2, rotation_angle: f32) -> Self {
         Self(Some(Isometry::from_parts(
-            Translation::from(Vector::new(translation.x(), translation.y())),
+            Translation::from(Vector::new(translation.x, translation.y)),
             UnitComplex::new(rotation_angle),
         )))
     }
@@ -128,16 +128,9 @@ impl PhysicsInterpolationComponent {
     #[cfg(feature = "dim3")]
     pub fn new(translation: Vec3, rotation: Quat) -> Self {
         Self(Some(Isometry::from_parts(
-            Translation::from(Vector::new(
-                translation.x(),
-                translation.y(),
-                translation.z(),
-            )),
+            Translation::from(Vector::new(translation.x, translation.y, translation.z)),
             UnitQuaternion::from_quaternion(Quaternion::new(
-                rotation.x(),
-                rotation.y(),
-                rotation.z(),
-                rotation.w(),
+                rotation.x, rotation.y, rotation.z, rotation.w,
             )),
         )))
     }

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -43,13 +43,17 @@ impl Plugin for RapierPhysicsPlugin {
             // TODO: can we avoid this map? We are only using this
             // to avoid some borrowing issue when joints creations
             // are needed.
-            .add_system_to_stage_front(
+            .add_system_to_stage(
                 stage::PRE_UPDATE,
                 physics::create_body_and_collider_system.system(),
             )
             .add_system_to_stage(stage::PRE_UPDATE, physics::create_joints_system.system())
             .add_system_to_stage(stage::UPDATE, physics::step_world_system.system())
-            .add_stage_before(stage::POST_UPDATE, TRANSFORM_SYNC_STAGE)
+            .add_stage_before(
+                stage::POST_UPDATE,
+                TRANSFORM_SYNC_STAGE,
+                SystemStage::parallel(),
+            )
             .add_system_to_stage(
                 TRANSFORM_SYNC_STAGE,
                 physics::sync_transform_system.system(),

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -14,13 +14,13 @@ use rapier::pipeline::PhysicsPipeline;
 /// System responsible for creating a Rapier rigid-body and collider from their
 /// builder resources.
 pub fn create_body_and_collider_system(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut bodies: ResMut<RigidBodySet>,
     mut colliders: ResMut<ColliderSet>,
     mut entity_maps: ResMut<EntityMaps>,
-    standalone_body_query: Query<Without<ColliderBuilder, (Entity, &RigidBodyBuilder)>>,
+    standalone_body_query: Query<(Entity, &RigidBodyBuilder), Without<ColliderBuilder>>,
     body_and_collider_query: Query<(Entity, &RigidBodyBuilder, &ColliderBuilder)>,
-    parented_collider_query: Query<Without<RigidBodyBuilder, (Entity, &Parent, &ColliderBuilder)>>,
+    parented_collider_query: Query<(Entity, &Parent, &ColliderBuilder), Without<RigidBodyBuilder>>,
 ) {
     for (entity, body_builder) in standalone_body_query.iter() {
         let handle = bodies.insert(body_builder.build());
@@ -76,9 +76,9 @@ fn test_create_body_and_collider_system() {
         world.spawn((Parent(body_only_entity), ColliderBuilder::ball(0.25)));
 
     let mut schedule = Schedule::default();
-    schedule.add_stage("physics_test");
+    schedule.add_stage("physics_test", SystemStage::parallel());
     schedule.add_system_to_stage("physics_test", create_body_and_collider_system.system());
-    schedule.run(&mut world, &mut resources);
+    schedule.initialize_and_run(&mut world, &mut resources);
 
     let body_set = resources.get::<RigidBodySet>().unwrap();
     let collider_set = resources.get::<ColliderSet>().unwrap();
@@ -148,7 +148,7 @@ fn test_create_body_and_collider_system() {
 
 /// System responsible for creating Rapier joints from their builder resources.
 pub fn create_joints_system(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut bodies: ResMut<RigidBodySet>,
     mut joints: ResMut<JointSet>,
     mut entity_maps: ResMut<EntityMaps>,
@@ -191,7 +191,7 @@ pub fn step_world_system(
     }
 
     if configuration.time_dependent_number_of_timesteps {
-        sim_to_render_time.diff += time.delta_seconds;
+        sim_to_render_time.diff += time.delta_seconds();
 
         let sim_dt = integration_parameters.dt();
         while sim_to_render_time.diff >= sim_dt {
@@ -246,8 +246,8 @@ pub fn step_world_system(
 #[cfg(feature = "dim2")]
 pub(crate) fn sync_transform(pos: &Isometry<f32>, scale: f32, transform: &mut Transform) {
     // Do not touch the 'z' part of the translation, used in Bevy for 2d layering
-    *transform.translation.x_mut() = pos.translation.vector.x * scale;
-    *transform.translation.y_mut() = pos.translation.vector.y * scale;
+    transform.translation.x = pos.translation.vector.x * scale;
+    transform.translation.y = pos.translation.vector.y * scale;
 
     let rot = na::UnitQuaternion::new(na::Vector3::z() * pos.rotation.angle());
     transform.rotation = Quat::from_xyzw(rot.i, rot.j, rot.k, rot.w);
@@ -280,7 +280,8 @@ pub fn sync_transform_system(
         &mut Transform,
     )>,
     mut direct_query: Query<
-        Without<PhysicsInterpolationComponent, (&RigidBodyHandleComponent, &mut Transform)>,
+        (&RigidBodyHandleComponent, &mut Transform),
+        Without<PhysicsInterpolationComponent>,
     >,
 ) {
     let dt = sim_to_render_time.diff;
@@ -308,7 +309,7 @@ pub fn sync_transform_system(
 /// System responsible for removing joints, colliders, and bodies that have
 /// been removed from the scene
 pub fn destroy_body_and_collider_system(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut bodies: ResMut<RigidBodySet>,
     mut colliders: ResMut<ColliderSet>,
     mut joints: ResMut<JointSet>,

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -7,16 +7,17 @@ use rapier::dynamics::RigidBodySet;
 use rapier::geometry::{ColliderSet, ShapeType};
 use std::collections::HashMap;
 
-/// System responsible for attaching a PbrComponents to each entity having a collider.
+/// System responsible for attaching a PbrBundle to each entity having a collider.
 pub fn create_collider_renders_system(
-    mut commands: Commands,
+    commands: &mut Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     configuration: Res<RapierConfiguration>,
     bodies: Res<RigidBodySet>,
     colliders: ResMut<ColliderSet>,
     query: Query<
-        Without<Handle<Mesh>, (Entity, &ColliderHandleComponent, Option<&RapierRenderColor>)>,
+        (Entity, &ColliderHandleComponent, Option<&RapierRenderColor>),
+        Without<Handle<Mesh>>,
     >,
 ) {
     let ground_color = Color::rgb(
@@ -130,7 +131,7 @@ pub fn create_collider_renders_system(
                     &mut transform,
                 );
 
-                let ground_pbr = PbrComponents {
+                let ground_pbr = PbrBundle {
                     mesh: meshes.add(mesh),
                     material: materials.add(color.into()),
                     transform,

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -67,7 +67,7 @@ pub fn create_collider_renders_system(
 
                 let mesh = match shape.shape_type() {
                     #[cfg(feature = "dim3")]
-                    ShapeType::Cuboid => Mesh::from(shape::Cube { size: 1.0 }),
+                    ShapeType::Cuboid => Mesh::from(shape::Cube { size: 2.0 }),
                     #[cfg(feature = "dim2")]
                     ShapeType::Cuboid => Mesh::from(shape::Quad {
                         size: Vec2::new(2.0, 2.0),

--- a/src_debug_ui/plugins.rs
+++ b/src_debug_ui/plugins.rs
@@ -6,6 +6,6 @@ pub struct DebugUiPlugin;
 impl Plugin for DebugUiPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_startup_system(systems::setup_ui.system())
-            .add_system_to_stage(stage::POST_UPDATE, systems::text_update_system.system());
+            .add_system_to_stage(stage::UPDATE, systems::text_update_system.system());
     }
 }

--- a/src_debug_ui/systems.rs
+++ b/src_debug_ui/systems.rs
@@ -1,14 +1,14 @@
 use bevy::prelude::*;
 use rapier::pipeline::PhysicsPipeline;
 
-pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
+pub fn setup_ui(commands: &mut Commands, asset_server: Res<AssetServer>) {
     let font_handle = asset_server
         .load(format!("{}/../assets/FiraSans-Bold.ttf", env!("CARGO_MANIFEST_DIR")).as_str());
     commands
         // 2d camera
-        .spawn(UiCameraComponents::default())
+        .spawn(CameraUiBundle::default())
         // texture
-        .spawn(TextComponents {
+        .spawn(TextBundle {
             style: Style {
                 align_self: AlignSelf::FlexEnd,
                 ..Default::default()
@@ -19,7 +19,9 @@ pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font_size: 30.0,
                     color: Color::BLACK,
+                    ..Default::default()
                 },
+                ..Default::default()
             },
             ..Default::default()
         });


### PR DESCRIPTION
Tests pass (my linux), it compiles (my linux). Not sure if this PR is usefull for anyone.

Big thanks to @alec-deason ( https://github.com/dimforge/bevy_rapier/pull/30 ) it was really usefull reference while i was updating bevy_rapier and i saved a lot of my time thanks to it.

- [x] Fix debug_ui timer https://github.com/bevyengine/bevy/issues/1102. Right now it is never updated if text update system is on `stages::POST_UPDATE` stage. Works if on `stages::UPDATE`.
- [x] Fix sizes of boxes in boxes3, right now it's mesh is about 2x smaller than it's colliding box.
- [x] Ensure all other examples are working same as in bevy 0.3.0