### PR TITLE
Add "render" feature

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -18,8 +18,9 @@ path = "../src/lib.rs"
 required-features = [ "dim2" ]
 
 [features]
-default = [ "dim2" ]
+default = [ "dim2", "render" ]
 dim2 = []
+render = [ "bevy/render" ]
 parallel = [ "rapier2d/parallel" ]
 simd-stable = [ "rapier2d/simd-stable" ]
 simd-nightly = [ "rapier2d/simd-nightly" ]
@@ -28,7 +29,7 @@ serde-serialize = [ "rapier2d/serde-serialize" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.4", default-features = false, features = ["render"] }
+bevy = { version = "0.4", default-features = false }
 nalgebra = "0.23"
 rapier2d = "0.4"
 concurrent-queue = "1"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -18,8 +18,9 @@ path = "../src/lib.rs"
 required-features = [ "dim3" ]
 
 [features]
-default = [ "dim3" ]
+default = [ "dim3", "render" ]
 dim3 = []
+render = [ "bevy/render" ]
 parallel = [ "rapier3d/parallel" ]
 simd-stable = [ "rapier3d/simd-stable" ]
 simd-nightly = [ "rapier3d/simd-nightly" ]
@@ -28,7 +29,7 @@ serde-serialize = [ "rapier3d/serde-serialize" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.4", default-features = false, features = ["render"] }
+bevy = { version = "0.4", default-features = false }
 nalgebra = "0.23"
 rapier3d = "0.4"
 concurrent-queue = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@ pub extern crate rapier3d as rapier;
 /// Plugins, resources, and components for physics simulation.
 pub mod physics;
 /// Plugins, resources, and components for debug rendering.
+#[cfg(feature = "render")]
 pub mod render;


### PR DESCRIPTION
This PR adds `"render"` feature that allows building without debug renderer.

Current bevy_rapier always enables `"bevy/render"` feature.
My project does not use bevy renderer - adding `bevy_rapier` to dependencies enables `bevy/render` and causes build to fail.