### PR TITLE
Add DebugColliderShape

### DIFF
--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -3,7 +3,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::physics::{RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
+use bevy_rapier2d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier2d::dynamics::RigidBodyBuilder;
 use rapier2d::geometry::ColliderBuilder;
 use rapier2d::pipeline::PhysicsPipeline;
@@ -58,19 +58,19 @@ pub fn setup_physics(commands: &mut Commands) {
 
     let rigid_body = RigidBodyBuilder::new_static();
     let collider = ColliderBuilder::cuboid(ground_size, 1.2);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     let rigid_body = RigidBodyBuilder::new_static()
         .rotation(std::f32::consts::FRAC_PI_2)
         .translation(ground_size, ground_size * 2.0);
     let collider = ColliderBuilder::cuboid(ground_size * 2.0, 1.2);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     let body = RigidBodyBuilder::new_static()
         .rotation(std::f32::consts::FRAC_PI_2)
         .translation(-ground_size, ground_size * 2.0);
     let collider = ColliderBuilder::cuboid(ground_size * 2.0, 1.2);
-    commands.spawn((body, collider));
+    commands.spawn((body, collider, DebugColliderShape::default()));
 
     /*
      * Create the cubes
@@ -90,7 +90,7 @@ pub fn setup_physics(commands: &mut Commands) {
             // Build the rigid body.
             let body = RigidBodyBuilder::new_dynamic().translation(x, y);
             let collider = ColliderBuilder::cuboid(rad, rad).density(1.0);
-            commands.spawn((body, collider));
+            commands.spawn((body, collider, DebugColliderShape::default()));
         }
     }
 }

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -3,7 +3,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::physics::{InteractionPairFilters, RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
+use bevy_rapier2d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier::geometry::{ContactPairFilter, PairFilterContext, SolverFlags};
 use rapier2d::dynamics::RigidBodyBuilder;
 use rapier2d::geometry::ColliderBuilder;
@@ -78,11 +78,11 @@ pub fn setup_physics(commands: &mut Commands) {
         .translation(0.0, -10.0)
         .user_data(0);
     let collider = ColliderBuilder::cuboid(ground_size, 1.2);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     let rigid_body = RigidBodyBuilder::new_static().user_data(1);
     let collider = ColliderBuilder::cuboid(ground_size, 1.2);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * Create the cubes
@@ -104,7 +104,7 @@ pub fn setup_physics(commands: &mut Commands) {
                 .user_data(j as u128 % 2)
                 .translation(x, y);
             let collider = ColliderBuilder::cuboid(rad, rad).density(1.0);
-            commands.spawn((body, collider));
+            commands.spawn((body, collider, DebugColliderShape::default()));
         }
     }
 }

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -3,7 +3,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::physics::{RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
+use bevy_rapier2d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier2d::dynamics::RigidBodyBuilder;
 use rapier2d::geometry::ColliderBuilder;
 use rapier2d::pipeline::PhysicsPipeline;
@@ -66,7 +66,7 @@ pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResourc
     let rigid_body = RigidBodyBuilder::new_static();
     let collider = ColliderBuilder::cuboid(ground_size, 1.2);
     let entity = commands
-        .spawn((rigid_body, collider))
+        .spawn((rigid_body, collider, DebugColliderShape::default()))
         .current_entity()
         .unwrap();
     despawn.entities.push(entity);
@@ -76,7 +76,7 @@ pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResourc
         .translation(ground_size, ground_size * 2.0);
     let collider = ColliderBuilder::cuboid(ground_size * 2.0, 1.2);
     let entity = commands
-        .spawn((rigid_body, collider))
+        .spawn((rigid_body, collider, DebugColliderShape::default()))
         .current_entity()
         .unwrap();
     despawn.entities.push(entity);
@@ -85,7 +85,10 @@ pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResourc
         .rotation(std::f32::consts::FRAC_PI_2)
         .translation(-ground_size, ground_size * 2.0);
     let collider = ColliderBuilder::cuboid(ground_size * 2.0, 1.2);
-    let entity = commands.spawn((body, collider)).current_entity().unwrap();
+    let entity = commands
+        .spawn((body, collider, DebugColliderShape::default()))
+        .current_entity()
+        .unwrap();
     despawn.entities.push(entity);
 
     /*
@@ -106,7 +109,7 @@ pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResourc
             // Build the rigid body.
             let body = RigidBodyBuilder::new_dynamic().translation(x, y);
             let collider = ColliderBuilder::cuboid(rad, rad).density(1.0);
-            commands.spawn((body, collider));
+            commands.spawn((body, collider, DebugColliderShape::default()));
         }
     }
 }

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -3,7 +3,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::physics::{EventQueue, RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
+use bevy_rapier2d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier2d::dynamics::RigidBodyBuilder;
 use rapier2d::geometry::ColliderBuilder;
 use rapier2d::pipeline::PhysicsPipeline;
@@ -67,13 +67,13 @@ pub fn setup_physics(commands: &mut Commands) {
      */
     let rigid_body = RigidBodyBuilder::new_static();
     let collider = ColliderBuilder::cuboid(4.0, 1.2);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, 5.0);
     let collider = ColliderBuilder::cuboid(4.0, 1.2).sensor(true);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     let rigid_body = RigidBodyBuilder::new_dynamic().translation(0.0, 13.0);
     let collider = ColliderBuilder::cuboid(0.5, 0.5);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 }

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -3,7 +3,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::physics::{JointBuilderComponent, RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
+use bevy_rapier2d::render::{DebugColliderShape, RapierRenderPlugin};
 use nalgebra::Point2;
 use rapier::dynamics::{BallJoint, BodyStatus};
 use rapier2d::dynamics::RigidBodyBuilder;
@@ -81,7 +81,7 @@ pub fn setup_physics(commands: &mut Commands) {
             let rigid_body = RigidBodyBuilder::new(status).translation(fk * shift, -fi * shift);
             let collider = ColliderBuilder::cuboid(rad, rad).density(1.0);
             let child_entity = commands
-                .spawn((rigid_body, collider))
+                .spawn((rigid_body, collider, DebugColliderShape::default()))
                 .current_entity()
                 .unwrap();
 

--- a/bevy_rapier2d/examples/joints_despawn2.rs
+++ b/bevy_rapier2d/examples/joints_despawn2.rs
@@ -3,7 +3,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::physics::{JointBuilderComponent, RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
+use bevy_rapier2d::render::{DebugColliderShape, RapierRenderPlugin};
 use nalgebra::Point2;
 use rapier::dynamics::{BallJoint, BodyStatus};
 use rapier2d::dynamics::RigidBodyBuilder;
@@ -88,7 +88,7 @@ pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResourc
             let rigid_body = RigidBodyBuilder::new(status).translation(fk * shift, -fi * shift);
             let collider = ColliderBuilder::cuboid(rad, rad).density(1.0);
             let child_entity = commands
-                .spawn((rigid_body, collider))
+                .spawn((rigid_body, collider, DebugColliderShape::default()))
                 .current_entity()
                 .unwrap();
 

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -3,7 +3,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::physics::{RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
+use bevy_rapier2d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier2d::dynamics::RigidBodyBuilder;
 use rapier2d::geometry::ColliderBuilder;
 use rapier2d::pipeline::PhysicsPipeline;
@@ -59,7 +59,7 @@ pub fn setup_physics(commands: &mut Commands) {
 
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, -ground_height);
     let collider = ColliderBuilder::cuboid(ground_size, ground_height);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * A rectangle that only rotate.
@@ -68,7 +68,7 @@ pub fn setup_physics(commands: &mut Commands) {
         .translation(0.0, 3.0)
         .lock_translations();
     let collider = ColliderBuilder::cuboid(2.0, 0.6);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * A tilted cuboid that cannot rotate.
@@ -78,5 +78,5 @@ pub fn setup_physics(commands: &mut Commands) {
         .rotation(1.0)
         .lock_rotations();
     let collider = ColliderBuilder::cuboid(0.6, 0.4);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 }

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -3,7 +3,7 @@ extern crate rapier2d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::physics::{RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
+use bevy_rapier2d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier2d::dynamics::RigidBodyBuilder;
 use rapier2d::geometry::ColliderBuilder;
 use rapier2d::pipeline::PhysicsPipeline;
@@ -59,7 +59,7 @@ pub fn setup_physics(commands: &mut Commands) {
 
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, -ground_height);
     let collider = ColliderBuilder::cuboid(ground_size, ground_height);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * Create the cubes
@@ -98,9 +98,9 @@ pub fn setup_physics(commands: &mut Commands) {
                     GlobalTransform::identity(),
                 ))
                 .with_children(|parent| {
-                    parent.spawn((collider1,));
-                    parent.spawn((collider2,));
-                    parent.spawn((collider3,));
+                    parent.spawn((collider1, DebugColliderShape::default()));
+                    parent.spawn((collider2, DebugColliderShape::default()));
+                    parent.spawn((collider3, DebugColliderShape::default()));
                 });
         }
 

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -3,7 +3,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::RapierPhysicsPlugin;
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier3d::dynamics::RigidBodyBuilder;
 use rapier3d::geometry::ColliderBuilder;
 use rapier3d::pipeline::PhysicsPipeline;
@@ -61,7 +61,7 @@ pub fn setup_physics(commands: &mut Commands) {
 
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, -ground_height, 0.0);
     let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * Create the cubes
@@ -86,7 +86,7 @@ pub fn setup_physics(commands: &mut Commands) {
                 // Build the rigid body.
                 let rigid_body = RigidBodyBuilder::new_dynamic().translation(x, y, z);
                 let collider = ColliderBuilder::cuboid(rad, rad, rad).density(1.0);
-                commands.spawn((rigid_body, collider));
+                commands.spawn((rigid_body, collider, DebugColliderShape::default()));
             }
         }
 

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -3,7 +3,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::{InteractionPairFilters, RapierPhysicsPlugin};
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier::geometry::{ContactPairFilter, PairFilterContext, SolverFlags};
 use rapier3d::dynamics::RigidBodyBuilder;
 use rapier3d::geometry::ColliderBuilder;
@@ -80,11 +80,11 @@ pub fn setup_physics(commands: &mut Commands) {
         .translation(0.0, -10.0, 0.0)
         .user_data(0);
     let collider = ColliderBuilder::cuboid(ground_size, 1.2, ground_size);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     let rigid_body = RigidBodyBuilder::new_static().user_data(1);
     let collider = ColliderBuilder::cuboid(ground_size, 1.2, ground_size);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * Create the cubes
@@ -106,7 +106,7 @@ pub fn setup_physics(commands: &mut Commands) {
                 .user_data(j as u128 % 2)
                 .translation(x, y, 0.0);
             let collider = ColliderBuilder::cuboid(rad, rad, rad).density(1.0);
-            commands.spawn((body, collider));
+            commands.spawn((body, collider, DebugColliderShape::default()));
         }
     }
 }

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -3,7 +3,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::RapierPhysicsPlugin;
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier3d::dynamics::RigidBodyBuilder;
 use rapier3d::geometry::ColliderBuilder;
 use rapier3d::pipeline::PhysicsPipeline;
@@ -69,7 +69,7 @@ pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResourc
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, -ground_height, 0.0);
     let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
     let ground_entity = commands
-        .spawn((rigid_body, collider))
+        .spawn((rigid_body, collider, DebugColliderShape::default()))
         .current_entity()
         .unwrap();
     despawn.entity = Some(ground_entity);
@@ -96,7 +96,7 @@ pub fn setup_physics(commands: &mut Commands, mut despawn: ResMut<DespawnResourc
                 // Build the rigid body.
                 let rigid_body = RigidBodyBuilder::new_dynamic().translation(x, y, z);
                 let collider = ColliderBuilder::cuboid(rad, rad, rad).density(1.0);
-                commands.spawn((rigid_body, collider));
+                commands.spawn((rigid_body, collider, DebugColliderShape::default()));
             }
         }
 

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -3,7 +3,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::{EventQueue, RapierPhysicsPlugin};
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier3d::dynamics::RigidBodyBuilder;
 use rapier3d::geometry::ColliderBuilder;
 use rapier3d::pipeline::PhysicsPipeline;
@@ -69,13 +69,13 @@ pub fn setup_physics(commands: &mut Commands) {
      */
     let rigid_body = RigidBodyBuilder::new_static();
     let collider = ColliderBuilder::cuboid(4.0, 1.2, 1.2);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, 5.0, 0.0);
     let collider = ColliderBuilder::cuboid(4.0, 1.2, 1.0).sensor(true);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     let rigid_body = RigidBodyBuilder::new_dynamic().translation(0.0, 13.0, 0.0);
     let collider = ColliderBuilder::cuboid(0.5, 0.5, 0.5);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 }

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -4,7 +4,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::{JointBuilderComponent, RapierPhysicsPlugin};
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use na::{Isometry3, Point3, Unit, Vector3};
 use rapier::dynamics::{BallJoint, BodyStatus, FixedJoint, PrismaticJoint, RevoluteJoint};
 use rapier3d::dynamics::RigidBodyBuilder;
@@ -69,7 +69,7 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Point3<f32>, num: us
         let rigid_body = RigidBodyBuilder::new_dynamic().translation(origin.x, origin.y, z);
         let collider = ColliderBuilder::cuboid(rad, rad, rad).density(density);
         let curr_child = commands
-            .spawn((rigid_body, collider))
+            .spawn((rigid_body, collider, DebugColliderShape::default()))
             .current_entity()
             .unwrap();
 
@@ -122,7 +122,7 @@ fn create_revolute_joints(commands: &mut Commands, origin: Point3<f32>, num: usi
             let rigid_body = RigidBodyBuilder::new_dynamic().position(positions[k]);
             let collider = ColliderBuilder::cuboid(rad, rad, rad).density(density);
             handles[k] = commands
-                .spawn((rigid_body, collider))
+                .spawn((rigid_body, collider, DebugColliderShape::default()))
                 .current_entity()
                 .unwrap();
         }
@@ -175,7 +175,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Point3<f32>, num: usize)
             );
             let collider = ColliderBuilder::ball(rad).density(1.0);
             let child_entity = commands
-                .spawn((rigid_body, collider))
+                .spawn((rigid_body, collider, DebugColliderShape::default()))
                 .current_entity()
                 .unwrap();
 

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -4,7 +4,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::{JointBuilderComponent, RapierPhysicsPlugin};
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use na::{Isometry3, Point3, Unit, Vector3};
 use rapier::dynamics::{BallJoint, BodyStatus, FixedJoint, PrismaticJoint, RevoluteJoint};
 use rapier3d::dynamics::RigidBodyBuilder;
@@ -81,7 +81,7 @@ fn create_prismatic_joints(
         let rigid_body = RigidBodyBuilder::new_dynamic().translation(origin.x, origin.y, z);
         let collider = ColliderBuilder::cuboid(rad, rad, rad).density(density);
         let curr_child = commands
-            .spawn((rigid_body, collider))
+            .spawn((rigid_body, collider, DebugColliderShape::default()))
             .current_entity()
             .unwrap();
 
@@ -145,7 +145,7 @@ fn create_revolute_joints(
             let rigid_body = RigidBodyBuilder::new_dynamic().position(positions[k]);
             let collider = ColliderBuilder::cuboid(rad, rad, rad).density(density);
             handles[k] = commands
-                .spawn((rigid_body, collider))
+                .spawn((rigid_body, collider, DebugColliderShape::default()))
                 .current_entity()
                 .unwrap();
         }
@@ -221,7 +221,7 @@ fn create_fixed_joints(
             );
             let collider = ColliderBuilder::ball(rad).density(1.0);
             let child_entity = commands
-                .spawn((rigid_body, collider))
+                .spawn((rigid_body, collider, DebugColliderShape::default()))
                 .current_entity()
                 .unwrap();
 

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -3,7 +3,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::RapierPhysicsPlugin;
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use nalgebra::Vector3;
 use rapier3d::dynamics::RigidBodyBuilder;
 use rapier3d::geometry::ColliderBuilder;
@@ -62,7 +62,7 @@ pub fn setup_physics(commands: &mut Commands) {
 
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, -ground_height, 0.0);
     let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * A rectangle that only rotates along the `x` axis.
@@ -72,7 +72,7 @@ pub fn setup_physics(commands: &mut Commands) {
         .lock_translations()
         .restrict_rotations(true, false, false);
     let collider = ColliderBuilder::cuboid(0.2, 0.6, 2.0);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * A tilted cuboid that cannot rotate.
@@ -82,5 +82,5 @@ pub fn setup_physics(commands: &mut Commands) {
         .rotation(Vector3::x() * 1.0)
         .lock_rotations();
     let collider = ColliderBuilder::cuboid(0.6, 0.4, 0.4);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 }

--- a/bevy_rapier3d/examples/multiple_colliders3.rs
+++ b/bevy_rapier3d/examples/multiple_colliders3.rs
@@ -3,7 +3,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::RapierPhysicsPlugin;
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier3d::dynamics::RigidBodyBuilder;
 use rapier3d::geometry::ColliderBuilder;
 use rapier3d::pipeline::PhysicsPipeline;
@@ -61,7 +61,7 @@ pub fn setup_physics(commands: &mut Commands) {
 
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, -ground_height, 0.0);
     let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     /*
      * Create the cubes
@@ -109,9 +109,9 @@ pub fn setup_physics(commands: &mut Commands) {
                         GlobalTransform::identity(),
                     ))
                     .with_children(|parent| {
-                        parent.spawn((collider1,));
-                        parent.spawn((collider2,));
-                        parent.spawn((collider3,));
+                        parent.spawn((collider1, DebugColliderShape::default()));
+                        parent.spawn((collider2, DebugColliderShape::default()));
+                        parent.spawn((collider3, DebugColliderShape::default()));
                     });
             }
         }

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -5,7 +5,7 @@ use std::f32::consts::TAU;
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier3d::physics::RapierPhysicsPlugin;
-use bevy_rapier3d::render::RapierRenderPlugin;
+use bevy_rapier3d::render::{DebugColliderShape, RapierRenderPlugin};
 use rapier3d::dynamics::{IntegrationParameters, RigidBodyBuilder};
 use rapier3d::geometry::ColliderBuilder;
 use rapier3d::pipeline::PhysicsPipeline;
@@ -82,7 +82,7 @@ pub fn setup_physics(commands: &mut Commands) {
     }
     let rigid_body = RigidBodyBuilder::new_static().translation(0.0, 0.0, 0.0);
     let collider = ColliderBuilder::trimesh(vertices, indices);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     // Create a bowl with a cosine cross-section,
     // so that we can join the end of the ramp smoothly
@@ -122,7 +122,7 @@ pub fn setup_physics(commands: &mut Commands) {
         bowl_size.z / 2.0 - ramp_size.z / 2.0,
     );
     let collider = ColliderBuilder::trimesh(vertices, indices);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 }
 
 struct BallState {
@@ -169,7 +169,7 @@ fn ball_spawner(
         0.0,
     );
     let collider = ColliderBuilder::ball(rad).restitution(0.5);
-    commands.spawn((rigid_body, collider));
+    commands.spawn((rigid_body, collider, DebugColliderShape::default()));
 
     ball_state.balls_spawned += 1;
 }

--- a/src/render/components.rs
+++ b/src/render/components.rs
@@ -1,2 +1,19 @@
-/// The desired render color of a Rapier collider.
-pub struct RapierRenderColor(pub f32, pub f32, pub f32);
+use bevy::prelude::*;
+use rapier::geometry::ColliderHandle;
+
+/// The marker component to render a collider shape.
+pub struct DebugColliderShape {
+    /// The desired render color of a Rapier collider.
+    pub color: Option<Color>,
+    /// The collider handle
+    pub(in crate) collider_handle: Option<ColliderHandle>,
+}
+
+impl Default for DebugColliderShape {
+    fn default() -> Self {
+        Self {
+            color: None,
+            collider_handle: None,
+        }
+    }
+}

--- a/src/render/plugins.rs
+++ b/src/render/plugins.rs
@@ -8,6 +8,10 @@ impl Plugin for RapierRenderPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_system_to_stage(
             stage::PRE_UPDATE,
+            systems::detect_changed_debug_components_system.system(),
+        )
+        .add_system_to_stage(
+            stage::PRE_UPDATE,
             systems::create_collider_renders_system.system(),
         );
     }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -64,162 +64,163 @@ pub fn create_collider_renders_system(
     let mut body_colors = HashMap::new();
 
     for (entity, debug) in query.iter() {
-        if let Some((collider, body)) = debug.collider_handle.and_then(|collider_handle| {
-            colliders
-                .get(collider_handle)
-                .and_then(|collider| bodies.get(collider.parent()).map(|body| (collider, body)))
-        }) {
-            let color = debug.color.unwrap_or_else(|| {
-                if body.is_static() {
-                    ground_color
-                } else {
-                    *body_colors.entry(collider.parent()).or_insert_with(|| {
-                        icolor += 1;
-                        palette[icolor % palette.len()]
-                    })
-                }
-            });
-
-            let shape = collider.shape();
-
-            let mesh = match shape.shape_type() {
-                #[cfg(feature = "dim3")]
-                ShapeType::Cuboid => Mesh::from(shape::Cube { size: 2.0 }),
-                #[cfg(feature = "dim2")]
-                ShapeType::Cuboid => Mesh::from(shape::Quad {
-                    size: Vec2::new(2.0, 2.0),
-                    flip: false,
-                }),
-                ShapeType::Ball => Mesh::from(shape::Icosphere {
-                    subdivisions: 2,
-                    radius: 1.0,
-                }),
-                #[cfg(feature = "dim2")]
-                ShapeType::TriMesh => {
-                    let mut mesh =
-                        Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
-                    let trimesh = shape.as_trimesh().unwrap();
-                    mesh.set_attribute(
-                        Mesh::ATTRIBUTE_POSITION,
-                        VertexAttributeValues::from(
-                            trimesh
-                                .vertices()
-                                .iter()
-                                .map(|vertice| [vertice.x, vertice.y])
-                                .collect::<Vec<_>>(),
-                        ),
-                    );
-                    mesh.set_indices(Some(Indices::U32(
-                        trimesh
-                            .indices()
-                            .iter()
-                            .flat_map(|triangle| triangle.iter())
-                            .cloned()
-                            .collect(),
-                    )));
-                    mesh
-                }
-                #[cfg(feature = "dim3")]
-                ShapeType::TriMesh => {
-                    let mut mesh =
-                        Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
-                    let trimesh = shape.as_trimesh().unwrap();
-                    mesh.set_attribute(
-                        Mesh::ATTRIBUTE_POSITION,
-                        VertexAttributeValues::from(
-                            trimesh
-                                .vertices()
-                                .iter()
-                                .map(|vertex| [vertex.x, vertex.y, vertex.z])
-                                .collect::<Vec<_>>(),
-                        ),
-                    );
-                    // Compute vertex normals by averaging the normals
-                    // of every triangle they appear in.
-                    // NOTE: This is a bit shonky, but good enough for visualisation.
-                    let verts = trimesh.vertices();
-                    let mut normals: Vec<Vec3> = vec![Vec3::zero(); trimesh.vertices().len()];
-                    for triangle in trimesh.indices().iter() {
-                        let ab = verts[triangle[1] as usize] - verts[triangle[0] as usize];
-                        let ac = verts[triangle[2] as usize] - verts[triangle[0] as usize];
-                        let normal = ab.cross(&ac);
-                        // Contribute this normal to each vertex in the triangle.
-                        for i in 0..3 {
-                            normals[triangle[i] as usize] +=
-                                Vec3::new(normal.x, normal.y, normal.z);
-                        }
-                    }
-                    let normals: Vec<[f32; 3]> = normals
-                        .iter()
-                        .map(|normal| {
-                            let normal = normal.normalize();
-                            [normal.x, normal.y, normal.z]
+        if let Some(collider) = debug
+            .collider_handle
+            .and_then(|collider_handle| colliders.get(collider_handle))
+        {
+            if let Some(body) = bodies.get(collider.parent()) {
+                let color = debug.color.unwrap_or_else(|| {
+                    if body.is_static() {
+                        ground_color
+                    } else {
+                        *body_colors.entry(collider.parent()).or_insert_with(|| {
+                            icolor += 1;
+                            palette[icolor % palette.len()]
                         })
-                        .collect();
-                    mesh.set_attribute(
-                        Mesh::ATTRIBUTE_NORMAL,
-                        VertexAttributeValues::from(normals),
-                    );
-                    // There's nothing particularly meaningful we can do
-                    // for this one without knowing anything about the overall topology.
-                    mesh.set_attribute(
-                        Mesh::ATTRIBUTE_UV_0,
-                        VertexAttributeValues::from(
+                    }
+                });
+
+                let shape = collider.shape();
+
+                let mesh = match shape.shape_type() {
+                    #[cfg(feature = "dim3")]
+                    ShapeType::Cuboid => Mesh::from(shape::Cube { size: 2.0 }),
+                    #[cfg(feature = "dim2")]
+                    ShapeType::Cuboid => Mesh::from(shape::Quad {
+                        size: Vec2::new(2.0, 2.0),
+                        flip: false,
+                    }),
+                    ShapeType::Ball => Mesh::from(shape::Icosphere {
+                        subdivisions: 2,
+                        radius: 1.0,
+                    }),
+                    #[cfg(feature = "dim2")]
+                    ShapeType::TriMesh => {
+                        let mut mesh =
+                            Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
+                        let trimesh = shape.as_trimesh().unwrap();
+                        mesh.set_attribute(
+                            Mesh::ATTRIBUTE_POSITION,
+                            VertexAttributeValues::from(
+                                trimesh
+                                    .vertices()
+                                    .iter()
+                                    .map(|vertice| [vertice.x, vertice.y])
+                                    .collect::<Vec<_>>(),
+                            ),
+                        );
+                        mesh.set_indices(Some(Indices::U32(
                             trimesh
-                                .vertices()
+                                .indices()
                                 .iter()
-                                .map(|_vertex| [0.0, 0.0])
-                                .collect::<Vec<_>>(),
-                        ),
-                    );
-                    mesh.set_indices(Some(Indices::U32(
-                        trimesh
-                            .indices()
+                                .flat_map(|triangle| triangle.iter())
+                                .cloned()
+                                .collect(),
+                        )));
+                        mesh
+                    }
+                    #[cfg(feature = "dim3")]
+                    ShapeType::TriMesh => {
+                        let mut mesh =
+                            Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
+                        let trimesh = shape.as_trimesh().unwrap();
+                        mesh.set_attribute(
+                            Mesh::ATTRIBUTE_POSITION,
+                            VertexAttributeValues::from(
+                                trimesh
+                                    .vertices()
+                                    .iter()
+                                    .map(|vertex| [vertex.x, vertex.y, vertex.z])
+                                    .collect::<Vec<_>>(),
+                            ),
+                        );
+                        // Compute vertex normals by averaging the normals
+                        // of every triangle they appear in.
+                        // NOTE: This is a bit shonky, but good enough for visualisation.
+                        let verts = trimesh.vertices();
+                        let mut normals: Vec<Vec3> = vec![Vec3::zero(); trimesh.vertices().len()];
+                        for triangle in trimesh.indices().iter() {
+                            let ab = verts[triangle[1] as usize] - verts[triangle[0] as usize];
+                            let ac = verts[triangle[2] as usize] - verts[triangle[0] as usize];
+                            let normal = ab.cross(&ac);
+                            // Contribute this normal to each vertex in the triangle.
+                            for i in 0..3 {
+                                normals[triangle[i] as usize] +=
+                                    Vec3::new(normal.x, normal.y, normal.z);
+                            }
+                        }
+                        let normals: Vec<[f32; 3]> = normals
                             .iter()
-                            .flat_map(|triangle| triangle.iter())
-                            .cloned()
-                            .collect(),
-                    )));
-                    mesh
-                }
-                _ => continue,
-            };
+                            .map(|normal| {
+                                let normal = normal.normalize();
+                                [normal.x, normal.y, normal.z]
+                            })
+                            .collect();
+                        mesh.set_attribute(
+                            Mesh::ATTRIBUTE_NORMAL,
+                            VertexAttributeValues::from(normals),
+                        );
+                        // There's nothing particularly meaningful we can do
+                        // for this one without knowing anything about the overall topology.
+                        mesh.set_attribute(
+                            Mesh::ATTRIBUTE_UV_0,
+                            VertexAttributeValues::from(
+                                trimesh
+                                    .vertices()
+                                    .iter()
+                                    .map(|_vertex| [0.0, 0.0])
+                                    .collect::<Vec<_>>(),
+                            ),
+                        );
+                        mesh.set_indices(Some(Indices::U32(
+                            trimesh
+                                .indices()
+                                .iter()
+                                .flat_map(|triangle| triangle.iter())
+                                .cloned()
+                                .collect(),
+                        )));
+                        mesh
+                    }
+                    _ => continue,
+                };
 
-            let scale = match shape.shape_type() {
-                #[cfg(feature = "dim2")]
-                ShapeType::Cuboid => {
-                    let c = shape.as_cuboid().unwrap();
-                    Vec3::new(c.half_extents.x, c.half_extents.y, 1.0)
-                }
-                #[cfg(feature = "dim3")]
-                ShapeType::Cuboid => {
-                    let c = shape.as_cuboid().unwrap();
-                    Vec3::from_slice_unaligned(c.half_extents.as_slice())
-                }
-                ShapeType::Ball => {
-                    let b = shape.as_ball().unwrap();
-                    Vec3::new(b.radius, b.radius, b.radius)
-                }
-                ShapeType::TriMesh => Vec3::one(),
-                _ => unimplemented!(),
-            } * configuration.scale;
+                let scale = match shape.shape_type() {
+                    #[cfg(feature = "dim2")]
+                    ShapeType::Cuboid => {
+                        let c = shape.as_cuboid().unwrap();
+                        Vec3::new(c.half_extents.x, c.half_extents.y, 1.0)
+                    }
+                    #[cfg(feature = "dim3")]
+                    ShapeType::Cuboid => {
+                        let c = shape.as_cuboid().unwrap();
+                        Vec3::from_slice_unaligned(c.half_extents.as_slice())
+                    }
+                    ShapeType::Ball => {
+                        let b = shape.as_ball().unwrap();
+                        Vec3::new(b.radius, b.radius, b.radius)
+                    }
+                    ShapeType::TriMesh => Vec3::one(),
+                    _ => unimplemented!(),
+                } * configuration.scale;
 
-            let mut transform = Transform::from_scale(scale);
+                let mut transform = Transform::from_scale(scale);
 
-            crate::physics::sync_transform(
-                collider.position_wrt_parent(),
-                configuration.scale,
-                &mut transform,
-            );
+                crate::physics::sync_transform(
+                    collider.position_wrt_parent(),
+                    configuration.scale,
+                    &mut transform,
+                );
 
-            let pbr = PbrBundle {
-                mesh: meshes.add(mesh),
-                material: materials.add(color.into()),
-                transform,
-                ..Default::default()
-            };
+                let pbr = PbrBundle {
+                    mesh: meshes.add(mesh),
+                    material: materials.add(color.into()),
+                    transform,
+                    ..Default::default()
+                };
 
-            commands.insert(entity, pbr);
+                commands.insert(entity, pbr);
+            }
         }
     }
 }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -1,5 +1,5 @@
 use crate::physics::{ColliderHandleComponent, RapierConfiguration};
-use crate::render::RapierRenderColor;
+use crate::render::DebugColliderShape;
 use bevy::prelude::*;
 #[cfg(feature = "dim2")]
 use bevy::render::mesh::{Indices, VertexAttributeValues};
@@ -7,18 +7,35 @@ use rapier::dynamics::RigidBodySet;
 use rapier::geometry::{ColliderSet, ShapeType};
 use std::collections::HashMap;
 
+/// System responsible for detecting changed debug components.
+pub fn detect_changed_debug_components_system(
+    mut debug_entities_query: Query<(&mut DebugColliderShape, Entity, Option<&Parent>)>,
+    colliders_query: Query<&ColliderHandleComponent>,
+) {
+    for (mut debug, entity, parent) in debug_entities_query.iter_mut() {
+        if let Some(collider_handle) = std::iter::once(entity)
+            .chain(parent.map(|parent| parent.0).into_iter())
+            .flat_map(|entity| colliders_query.get(entity).into_iter())
+            .next()
+        {
+            let collider_handle = Some(collider_handle.handle());
+            if debug.collider_handle != collider_handle {
+                // Mark the component as changed.
+                debug.collider_handle = collider_handle;
+            }
+        }
+    }
+}
+
 /// System responsible for attaching a PbrBundle to each entity having a collider.
 pub fn create_collider_renders_system(
     commands: &mut Commands,
+    bodies: Res<RigidBodySet>,
+    colliders: Res<ColliderSet>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     configuration: Res<RapierConfiguration>,
-    bodies: Res<RigidBodySet>,
-    colliders: ResMut<ColliderSet>,
-    query: Query<
-        (Entity, &ColliderHandleComponent, Option<&RapierRenderColor>),
-        Without<Handle<Mesh>>,
-    >,
+    query: Query<(Entity, &DebugColliderShape), Changed<DebugColliderShape>>,
 ) {
     let ground_color = Color::rgb(
         0xF3 as f32 / 255.0,
@@ -47,99 +64,99 @@ pub fn create_collider_renders_system(
     let mut icolor = 0;
     let mut body_colors = HashMap::new();
 
-    for (entity, collider, debug_color) in &mut query.iter() {
-        if let Some(collider) = colliders.get(collider.handle()) {
-            if let Some(body) = bodies.get(collider.parent()) {
-                let default_color = if body.is_static() {
+    for (entity, debug) in query.iter() {
+        if let Some((collider, body)) = debug.collider_handle.and_then(|collider_handle| {
+            colliders
+                .get(collider_handle)
+                .and_then(|collider| bodies.get(collider.parent()).map(|body| (collider, body)))
+        }) {
+            let color = debug.color.unwrap_or_else(|| {
+                if body.is_static() {
                     ground_color
                 } else {
                     *body_colors.entry(collider.parent()).or_insert_with(|| {
                         icolor += 1;
                         palette[icolor % palette.len()]
                     })
-                };
+                }
+            });
 
-                let shape = collider.shape();
-
-                let color = debug_color
-                    .map(|c| Color::rgb(c.0, c.1, c.2))
-                    .unwrap_or(default_color);
-
-                let mesh = match shape.shape_type() {
-                    #[cfg(feature = "dim3")]
-                    ShapeType::Cuboid => Mesh::from(shape::Cube { size: 2.0 }),
-                    #[cfg(feature = "dim2")]
-                    ShapeType::Cuboid => Mesh::from(shape::Quad {
-                        size: Vec2::new(2.0, 2.0),
-                        flip: false,
-                    }),
-                    ShapeType::Ball => Mesh::from(shape::Icosphere {
-                        subdivisions: 2,
-                        radius: 1.0,
-                    }),
-                    #[cfg(feature = "dim2")]
-                    ShapeType::Trimesh => {
-                        let mut mesh =
-                            Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
-                        let trimesh = shape.as_trimesh().unwrap();
-                        mesh.set_attribute(
-                            Mesh::ATTRIBUTE_POSITION,
-                            VertexAttributeValues::from(
-                                trimesh
-                                    .vertices()
-                                    .iter()
-                                    .map(|vertice| [vertice.x, vertice.y])
-                                    .collect::<Vec<_>>(),
-                            ),
-                        );
-                        mesh.set_indices(Some(Indices::U32(
+            let shape = collider.shape();
+            let mesh = match shape.shape_type() {
+                #[cfg(feature = "dim3")]
+                ShapeType::Cuboid => Mesh::from(shape::Cube { size: 2.0 }),
+                #[cfg(feature = "dim2")]
+                ShapeType::Cuboid => Mesh::from(shape::Quad {
+                    size: Vec2::new(2.0, 2.0),
+                    flip: false,
+                }),
+                ShapeType::Ball => Mesh::from(shape::Icosphere {
+                    subdivisions: 2,
+                    radius: 1.0,
+                }),
+                #[cfg(feature = "dim2")]
+                ShapeType::Trimesh => {
+                    let mut mesh =
+                        Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
+                    let trimesh = shape.as_trimesh().unwrap();
+                    mesh.set_attribute(
+                        Mesh::ATTRIBUTE_POSITION,
+                        VertexAttributeValues::from(
                             trimesh
-                                .indices()
+                                .vertices()
                                 .iter()
-                                .flat_map(|triangle| triangle.iter())
-                                .cloned()
-                                .collect(),
-                        )));
-                        mesh
-                    }
-                    _ => unimplemented!(),
-                };
+                                .map(|vertice| [vertice.x, vertice.y])
+                                .collect::<Vec<_>>(),
+                        ),
+                    );
+                    mesh.set_indices(Some(Indices::U32(
+                        trimesh
+                            .indices()
+                            .iter()
+                            .flat_map(|triangle| triangle.iter())
+                            .cloned()
+                            .collect(),
+                    )));
+                    mesh
+                }
+                _ => unimplemented!(),
+            };
 
-                let scale = match shape.shape_type() {
-                    #[cfg(feature = "dim2")]
-                    ShapeType::Cuboid => {
-                        let c = shape.as_cuboid().unwrap();
-                        Vec3::new(c.half_extents.x, c.half_extents.y, 1.0)
-                    }
-                    #[cfg(feature = "dim3")]
-                    ShapeType::Cuboid => {
-                        let c = shape.as_cuboid().unwrap();
-                        Vec3::from_slice_unaligned(c.half_extents.as_slice())
-                    }
-                    ShapeType::Ball => {
-                        let b = shape.as_ball().unwrap();
-                        Vec3::new(b.radius, b.radius, b.radius)
-                    }
-                    ShapeType::Trimesh => Vec3::one(),
-                    _ => unimplemented!(),
-                } * configuration.scale;
+            let scale = match shape.shape_type() {
+                #[cfg(feature = "dim2")]
+                ShapeType::Cuboid => {
+                    let c = shape.as_cuboid().unwrap();
+                    Vec3::new(c.half_extents.x, c.half_extents.y, 1.0)
+                }
+                #[cfg(feature = "dim3")]
+                ShapeType::Cuboid => {
+                    let c = shape.as_cuboid().unwrap();
+                    Vec3::from_slice_unaligned(c.half_extents.as_slice())
+                }
+                ShapeType::Ball => {
+                    let b = shape.as_ball().unwrap();
+                    Vec3::new(b.radius, b.radius, b.radius)
+                }
+                ShapeType::Trimesh => Vec3::one(),
+                _ => unimplemented!(),
+            } * configuration.scale;
 
-                let mut transform = Transform::from_scale(scale);
-                crate::physics::sync_transform(
-                    collider.position_wrt_parent(),
-                    configuration.scale,
-                    &mut transform,
-                );
+            let mut transform = Transform::from_scale(scale);
 
-                let ground_pbr = PbrBundle {
-                    mesh: meshes.add(mesh),
-                    material: materials.add(color.into()),
-                    transform,
-                    ..Default::default()
-                };
+            crate::physics::sync_transform(
+                collider.position_wrt_parent(),
+                configuration.scale,
+                &mut transform,
+            );
 
-                commands.insert(entity, ground_pbr);
-            }
+            let pbr = PbrBundle {
+                mesh: meshes.add(mesh),
+                material: materials.add(color.into()),
+                transform,
+                ..Default::default()
+            };
+
+            commands.insert(entity, pbr);
         }
     }
 }


### PR DESCRIPTION
Fixes #35 

This change will prevent inserting `PbrBundle` until we insert `DebugColliderShape` into the target entity or its children.
Also, 
- inserts `PbrBundle` into the same entity as `DebugColliderShape`.
- updates `PbrBundle` when the collider handle is updated.

This is a draft PR because the change is applied only to the boxes3 example.