### PR TITLE
Search all parents of a collider entity for a rigid body

### DIFF
--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -92,6 +92,9 @@ fn test_create_body_and_collider_system() {
     let parented_collider_entity_2 =
         world.spawn((Parent(body_only_entity), ColliderBuilder::ball(0.25)));
 
+    let parented_collider_entity_3 =
+        world.spawn((Parent(parented_collider_entity_2), ColliderBuilder::ball(0.25)));
+
     let mut schedule = Schedule::default();
     schedule.add_stage("physics_test", SystemStage::parallel());
     schedule.add_system_to_stage("physics_test", create_body_and_collider_system.system());
@@ -156,6 +159,19 @@ fn test_create_body_and_collider_system() {
         .handle();
     assert_eq!(
         entity_maps.colliders[&parented_collider_entity_2],
+        collider_handle
+    );
+    let collider = collider_set.get(collider_handle).unwrap();
+    assert_eq!(standalone_body_handle, collider.parent());
+    assert_eq!(collider.shape().as_ball().unwrap().radius, 0.25);
+
+    // collider attached to child entity of a child of a standalone body
+    let collider_handle = world
+        .get::<ColliderHandleComponent>(parented_collider_entity_3)
+        .unwrap()
+        .handle();
+    assert_eq!(
+        entity_maps.colliders[&parented_collider_entity_3],
         collider_handle
     );
     let collider = collider_set.get(collider_handle).unwrap();

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -6,7 +6,9 @@ use crate::physics::{
 
 use crate::rapier::pipeline::QueryPipeline;
 use bevy::prelude::*;
-use rapier::dynamics::{IntegrationParameters, JointSet, RigidBodyBuilder, RigidBodyHandle, RigidBodySet};
+use rapier::dynamics::{
+    IntegrationParameters, JointSet, RigidBodyBuilder, RigidBodyHandle, RigidBodySet,
+};
 use rapier::geometry::{BroadPhase, ColliderBuilder, ColliderSet, NarrowPhase};
 use rapier::math::Isometry;
 use rapier::pipeline::PhysicsPipeline;
@@ -57,7 +59,7 @@ fn get_parent_rigid_body<'a>(
     parent_query: &Query<&Parent>,
     parent: &Parent,
 ) -> Option<&'a RigidBodyHandle> {
-    if let Some(body_handle) = entity_maps.bodies.get(&parent.0){
+    if let Some(body_handle) = entity_maps.bodies.get(&parent.0) {
         return Some(body_handle);
     }
 
@@ -92,8 +94,10 @@ fn test_create_body_and_collider_system() {
     let parented_collider_entity_2 =
         world.spawn((Parent(body_only_entity), ColliderBuilder::ball(0.25)));
 
-    let parented_collider_entity_3 =
-        world.spawn((Parent(parented_collider_entity_2), ColliderBuilder::ball(0.25)));
+    let parented_collider_entity_3 = world.spawn((
+        Parent(parented_collider_entity_2),
+        ColliderBuilder::ball(0.25),
+    ));
 
     let mut schedule = Schedule::default();
     schedule.add_stage("physics_test", SystemStage::parallel());


### PR DESCRIPTION
Currently if a child entity has no RigidBody, `bevy_rapier` will check its parent and attach the collider to its parent's RigidBody.

This PR will recursively search up the bevy hierarchy, checking each parent until it finds one with a RigidBodyHandle.