### PR TITLE
Make it possible to update colliders

### DIFF
--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -47,6 +47,7 @@ impl Plugin for RapierPhysicsPlugin {
                 stage::PRE_UPDATE,
                 physics::create_body_and_collider_system.system(),
             )
+            .add_system_to_stage(stage::PRE_UPDATE, physics::update_collider_system.system())
             .add_system_to_stage(stage::PRE_UPDATE, physics::create_joints_system.system())
             .add_system_to_stage(stage::UPDATE, physics::step_world_system.system())
             .add_stage_before(

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -16,7 +16,7 @@ pub fn create_collider_renders_system(
     colliders: ResMut<ColliderSet>,
     query: Query<
         (Entity, &ColliderHandleComponent, Option<&RapierRenderColor>),
-        Without<Handle<Mesh>>,
+        Or<(Without<Handle<Mesh>>, Changed<ColliderHandleComponent>)>,
     >,
 ) {
     let ground_color = Color::rgb(


### PR DESCRIPTION
This adds support for updating colliders by re-inserting a ColliderBuilder on an entity which already has a ColliderHandleComponent.

Please note that the change to the debug rendering code which updates the collider's mesh on change will not work on bevy 0.4 but will on 0.5 due to the new reliable change detection feature.