### PR TITLE
Instant Joint Creation

### DIFF
--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -25,6 +25,10 @@ pub struct RapierPhysicsPlugin;
 /// This stage is added right before the `POST_UPDATE` stage.
 pub const TRANSFORM_SYNC_STAGE: &'static str = "rapier::transform_sync_stage";
 
+#[derive(SystemLabel, Clone, Debug, Eq, Hash, PartialEq)]
+/// Label for create_joints_system
+pub struct CreateJointsSystem;
+
 impl Plugin for RapierPhysicsPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.insert_resource(PhysicsPipeline::new())
@@ -46,13 +50,20 @@ impl Plugin for RapierPhysicsPlugin {
             // are needed.
             .add_system_to_stage(
                 CoreStage::PreUpdate,
-                physics::create_body_and_collider_system.system(),
+                physics::create_body_and_collider_system
+                    .system()
+                    .before(CreateJointsSystem),
             )
             .add_system_to_stage(
                 CoreStage::PreUpdate,
                 physics::update_collider_system.system(),
             )
-            .add_system_to_stage(CoreStage::PreUpdate, physics::create_joints_system.system())
+            .add_system_to_stage(
+                CoreStage::PreUpdate,
+                physics::create_joints_system
+                    .system()
+                    .label(CreateJointsSystem),
+            )
             .add_system_to_stage(CoreStage::Update, physics::step_world_system.system())
             .add_stage_before(
                 CoreStage::PostUpdate,

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -208,6 +208,55 @@ fn test_create_body_and_collider_system() {
     assert_eq!(collider.shape().as_ball().unwrap().radius, 0.25);
 }
 
+#[test]
+fn test_joint_creation_ordering() {
+    use super::RapierPhysicsPlugin;
+    #[cfg(feature = "dim2")]
+    use na::Point2;
+    #[cfg(feature = "dim3")]
+    use na::Point3;
+    use rapier::dynamics::BallJoint;
+
+    let mut app = App::build();
+    app.init_resource::<Time>().add_plugin(RapierPhysicsPlugin);
+
+    let rigid_body_1 = RigidBodyBuilder::new_dynamic();
+    let rigid_body_2 = RigidBodyBuilder::new_dynamic();
+
+    let body_1_entity = app.world_mut().spawn().insert(rigid_body_1).id();
+
+    let body_2_entity = app.world_mut().spawn().insert(rigid_body_2).id();
+
+    #[cfg(feature = "dim2")]
+    let joint = BallJoint::new(Point2::origin(), Point2::origin());
+    #[cfg(feature = "dim3")]
+    let joint = BallJoint::new(Point3::origin(), Point3::origin());
+
+    let joint_entity = app
+        .world_mut()
+        .spawn()
+        .insert_bundle((JointBuilderComponent::new(
+            joint,
+            body_1_entity,
+            body_2_entity,
+        ),))
+        .id();
+
+    app.app.update();
+
+    let joint_handle = app
+        .world_mut()
+        .get::<JointHandleComponent>(joint_entity)
+        .unwrap()
+        .handle();
+
+    let entity_maps = app.world_mut().get_resource::<EntityMaps>().unwrap();
+    assert_eq!(entity_maps.joints[&joint_entity], joint_handle);
+
+    let joint_set = app.world_mut().get_resource::<JointSet>().unwrap();
+    assert!(joint_set.get(joint_handle).is_some());
+}
+
 /// System responsible for creating Rapier joints from their builder resources.
 pub fn create_joints_system(
     mut commands: Commands,

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -264,13 +264,12 @@ pub fn create_joints_system(
     mut joints: ResMut<JointSet>,
     mut entity_maps: ResMut<EntityMaps>,
     query: Query<(Entity, &JointBuilderComponent)>,
-    query_bodyhandle: Query<&RigidBodyHandleComponent>,
 ) {
     for (entity, joint) in &mut query.iter() {
-        let body1 = query_bodyhandle.get_component::<RigidBodyHandleComponent>(joint.entity1);
-        let body2 = query_bodyhandle.get_component::<RigidBodyHandleComponent>(joint.entity2);
-        if let (Ok(body1), Ok(body2)) = (body1, body2) {
-            let handle = joints.insert(&mut bodies, body1.handle(), body2.handle(), joint.params);
+        let body1 = entity_maps.bodies.get(&joint.entity1);
+        let body2 = entity_maps.bodies.get(&joint.entity2);
+        if let (Some(body1), Some(body2)) = (body1, body2) {
+            let handle = joints.insert(&mut bodies, *body1, *body2, joint.params);
             commands
                 .entity(entity)
                 .insert(JointHandleComponent::new(


### PR DESCRIPTION
Previously, if you created a joint you couldn't access it on the next tick. Due to the way they were being created you had to wait a couple of tick cycles.

This PR makes it so that joints get created directly after the body creation phase. You can now access the joints on the next tick after you create them :)