### PR TITLE
Split rigid-bodies and colliders into multiple components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.0
+### Added
+- The `ColliderDebugRender` component must be added to an entity
+  containing a collider shape in order to render it.
+  
 ## 0.8.0
 ### Changed
 - Use the version 0.5.0 of Rapier.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,11 @@ members = ["bevy_rapier2d", "bevy_rapier3d"]
 codegen-units = 1
 
 [patch.crates-io]
+#nalgebra = { path = "../nalgebra" }
 #parry2d = { path = "../parry/build/parry2d" }
 #parry3d = { path = "../parry/build/parry3d" }
 #rapier2d = { path = "../rapier/build/rapier2d" }
 #rapier3d = { path = "../rapier/build/rapier3d" }
+
+rapier2d = { git = "https://github.com/dimforge/rapier" }
+rapier3d = { git = "https://github.com/dimforge/rapier" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -30,8 +30,9 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.5", default-features = false }
-nalgebra = "0.25"
-rapier2d = "0.7"
+nalgebra = { version = "0.26", features = [ "convert-glam-unchecked" ] }
+# Don't enable the default features because we don't need the ColliderSet/RigidBodySet
+rapier2d = { version = "0.8", default-features = false, features = [ "dim2", "f32" ] }
 concurrent-queue = "1"
 
 [dev-dependencies]

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -33,7 +33,6 @@ bevy = { version = "0.5", default-features = false }
 nalgebra = { version = "0.26", features = [ "convert-glam-unchecked" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = { version = "0.8", default-features = false, features = [ "dim2", "f32" ] }
-concurrent-queue = "1"
 
 [dev-dependencies]
 bevy_wgpu = "0.5"

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -1,29 +1,50 @@
 extern crate rapier2d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
 use bevy::render::pass::ClearColor;
-use bevy_rapier2d::physics::{InteractionPairFilters, RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
 use rapier::geometry::SolverFlags;
-use rapier2d::dynamics::RigidBodyBuilder;
-use rapier2d::geometry::ColliderBuilder;
-use rapier2d::pipeline::{PairFilterContext, PhysicsHooks, PhysicsHooksFlags, PhysicsPipeline};
+use rapier2d::pipeline::{PairFilterContext, PhysicsHooksFlags, PhysicsPipeline};
 use ui::DebugUiPlugin;
 
 #[path = "../../src_debug_ui/mod.rs"]
 mod ui;
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum CustomFilterTag {
+    GroupA,
+    GroupB,
+}
+
+impl CustomFilterTag {
+    fn with_id(id: usize) -> Self {
+        if id % 2 == 0 {
+            Self::GroupA
+        } else {
+            Self::GroupB
+        }
+    }
+}
 
 // A custom filter that allows contacts only between rigid-bodies with the
 // same user_data value.
 // Note that using collision groups would be a more efficient way of doing
 // this, but we use custom filters instead for demonstration purpose.
 struct SameUserDataFilter;
-impl PhysicsHooks for SameUserDataFilter {
-    fn active_hooks(&self) -> PhysicsHooksFlags {
+impl<'a> PhysicsHooksWithQuery<&'a CustomFilterTag> for SameUserDataFilter {
+    fn active_hooks(&self, _: &Query<&'a CustomFilterTag>) -> PhysicsHooksFlags {
         PhysicsHooksFlags::FILTER_CONTACT_PAIR
     }
-    fn filter_contact_pair(&self, context: &PairFilterContext) -> Option<SolverFlags> {
-        if context.rigid_body1.user_data == context.rigid_body2.user_data {
+
+    fn filter_contact_pair(
+        &self,
+        context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+        tags: &Query<&'a CustomFilterTag>,
+    ) -> Option<SolverFlags> {
+        if tags.get(context.collider1.entity()).ok().copied()
+            == tags.get(context.collider2.entity()).ok().copied()
+        {
             Some(SolverFlags::COMPUTE_IMPULSES)
         } else {
             None
@@ -42,7 +63,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_winit::WinitPlugin::default())
         .add_plugin(bevy_wgpu::WgpuPlugin::default())
-        .add_plugin(RapierPhysicsPlugin)
+        .add_plugin(RapierPhysicsPlugin::<&CustomFilterTag>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
         .add_startup_system(setup_graphics.system())
@@ -60,7 +81,7 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(0.0, 200.0, 0.0));
-    commands.spawn().insert_bundle(LightBundle {
+    commands.spawn_bundle(LightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
         light: Light {
             intensity: 100_000_000_.0,
@@ -69,29 +90,37 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
         },
         ..Default::default()
     });
-    commands.spawn().insert_bundle(camera);
+    commands.spawn_bundle(camera);
 }
 
 pub fn setup_physics(mut commands: Commands) {
     /*
      * Ground
      */
-    commands.insert_resource(InteractionPairFilters {
-        hook: Some(Box::new(SameUserDataFilter {})),
-    });
+    commands.insert_resource(PhysicsHooksWithQueryObject(Box::new(SameUserDataFilter {})));
 
     let ground_size = 10.0;
 
-    let rigid_body = RigidBodyBuilder::new_static()
-        .translation(0.0, -10.0)
-        .user_data(0);
-    let collider = ColliderBuilder::cuboid(ground_size, 1.2);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(ground_size, 1.2),
+        position: [0.0, -10.0].into(),
+        ..Default::default()
+    };
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderDebugRender::default())
+        .insert(ColliderPositionSync::Discrete)
+        .insert(CustomFilterTag::GroupA);
 
-    let rigid_body = RigidBodyBuilder::new_static().user_data(1);
-    let collider = ColliderBuilder::cuboid(ground_size, 1.2);
-    commands.spawn().insert_bundle((rigid_body, collider));
-
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(ground_size, 1.2),
+        ..Default::default()
+    };
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderDebugRender::default())
+        .insert(ColliderPositionSync::Discrete)
+        .insert(CustomFilterTag::GroupB);
     /*
      * Create the cubes
      */
@@ -101,18 +130,30 @@ pub fn setup_physics(mut commands: Commands) {
     let shift = rad * 2.0;
     let centerx = shift * (num as f32) / 2.0;
     let centery = shift / 2.0;
+    let mut color = 0;
 
     for i in 0..num {
         for j in 0usize..num * 5 {
             let x = (i as f32 + j as f32 * 0.2) * shift - centerx;
             let y = j as f32 * shift + centery + 2.0;
+            color += 1;
 
             // Build the rigid body.
-            let body = RigidBodyBuilder::new_dynamic()
-                .user_data(j as u128 % 2)
-                .translation(x, y);
-            let collider = ColliderBuilder::cuboid(rad, rad).density(1.0);
-            commands.spawn().insert_bundle((body, collider));
+            let body = RigidBodyBundle {
+                position: [x, y].into(),
+                ..Default::default()
+            };
+
+            let collider = ColliderBundle {
+                shape: ColliderShape::cuboid(rad, rad),
+                ..Default::default()
+            };
+            commands
+                .spawn_bundle(body)
+                .insert_bundle(collider)
+                .insert(ColliderDebugRender::with_id(color % 2))
+                .insert(ColliderPositionSync::Discrete)
+                .insert(CustomFilterTag::with_id(color));
         }
     }
 }

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -52,12 +52,15 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
         .insert_bundle(OrthographicCameraBundle::new_2d());
 }
 
-fn display_events(events: Res<EventQueue>) {
-    while let Ok(intersection_event) = events.intersection_events.pop() {
+fn display_events(
+    mut intersection_events: EventReader<IntersectionEvent>,
+    mut contact_events: EventReader<ContactEvent>,
+) {
+    for intersection_event in intersection_events.iter() {
         println!("Received intersection event: {:?}", intersection_event);
     }
 
-    while let Ok(contact_event) = events.contact_events.pop() {
+    for contact_event in contact_events.iter() {
         println!("Received contact event: {:?}", contact_event);
     }
 }

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -1,11 +1,9 @@
 extern crate rapier2d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
 use bevy::render::pass::ClearColor;
-use bevy_rapier2d::physics::{EventQueue, RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
-use rapier2d::dynamics::RigidBodyBuilder;
-use rapier2d::geometry::ColliderBuilder;
 use rapier2d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
 
@@ -23,7 +21,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_winit::WinitPlugin::default())
         .add_plugin(bevy_wgpu::WgpuPlugin::default())
-        .add_plugin(RapierPhysicsPlugin)
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
         .add_startup_system(setup_graphics.system())
@@ -40,7 +38,7 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 15.0;
 
-    commands.spawn().insert_bundle(LightBundle {
+    commands.spawn_bundle(LightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
         light: Light {
             intensity: 100_000_000_.0,
@@ -68,15 +66,37 @@ pub fn setup_physics(mut commands: Commands) {
     /*
      * Ground
      */
-    let rigid_body = RigidBodyBuilder::new_static();
-    let collider = ColliderBuilder::cuboid(4.0, 1.2);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(4.0, 1.2),
+        ..Default::default()
+    };
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderPositionSync::Discrete)
+        .insert(ColliderDebugRender::default());
 
-    let rigid_body = RigidBodyBuilder::new_static().translation(0.0, 5.0);
-    let collider = ColliderBuilder::cuboid(4.0, 1.2).sensor(true);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(4.0, 1.2),
+        collider_type: ColliderType::Sensor,
+        position: [0.0, 5.0].into(),
+        ..Default::default()
+    };
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderPositionSync::Discrete)
+        .insert(ColliderDebugRender::default());
 
-    let rigid_body = RigidBodyBuilder::new_dynamic().translation(0.0, 13.0);
-    let collider = ColliderBuilder::cuboid(0.5, 0.5);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let rigid_body = RigidBodyBundle {
+        position: [0.0, 13.0].into(),
+        ..Default::default()
+    };
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(0.5, 0.5),
+        ..Default::default()
+    };
+    commands
+        .spawn_bundle(rigid_body)
+        .insert_bundle(collider)
+        .insert(ColliderPositionSync::Discrete)
+        .insert(ColliderDebugRender::with_id(0));
 }

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -1,13 +1,11 @@
 extern crate rapier2d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
 use bevy::render::pass::ClearColor;
-use bevy_rapier2d::physics::{JointBuilderComponent, RapierConfiguration, RapierPhysicsPlugin};
-use bevy_rapier2d::render::RapierRenderPlugin;
 use nalgebra::Point2;
-use rapier::dynamics::{BallJoint, BodyStatus};
-use rapier2d::dynamics::RigidBodyBuilder;
-use rapier2d::geometry::ColliderBuilder;
+use rapier2d::dynamics::{BallJoint, RigidBodyType};
 use rapier2d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
 
@@ -25,7 +23,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_winit::WinitPlugin::default())
         .add_plugin(bevy_wgpu::WgpuPlugin::default())
-        .add_plugin(RapierPhysicsPlugin)
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
         .add_startup_system(setup_graphics.system())
@@ -43,7 +41,7 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(200.0, -200.0, 0.0));
-    commands.spawn().insert_bundle(LightBundle {
+    commands.spawn_bundle(LightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
         light: Light {
             intensity: 100_000_000_.0,
@@ -52,7 +50,7 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
         },
         ..Default::default()
     });
-    commands.spawn().insert_bundle(camera);
+    commands.spawn_bundle(camera);
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -69,27 +67,42 @@ pub fn setup_physics(mut commands: Commands) {
     let shift = 1.0;
 
     let mut body_entities = Vec::new();
+    let mut color = 0;
 
     for k in 0..numk {
         for i in 0..numi {
             let fk = k as f32;
             let fi = i as f32;
+            color += 1;
 
-            let status = if i == 0 && (k % 4 == 0 || k == numk - 1) {
-                BodyStatus::Static
+            let body_type = if i == 0 && (k % 4 == 0 || k == numk - 1) {
+                RigidBodyType::Static
             } else {
-                BodyStatus::Dynamic
+                RigidBodyType::Dynamic
             };
 
-            let rigid_body = RigidBodyBuilder::new(status).translation(fk * shift, -fi * shift);
-            let collider = ColliderBuilder::cuboid(rad, rad).density(1.0);
-            let child_entity = commands.spawn().insert_bundle((rigid_body, collider)).id();
+            let rigid_body = RigidBodyBundle {
+                body_type,
+                position: [fk * shift, -fi * shift].into(),
+                ..RigidBodyBundle::default()
+            };
+
+            let collider = ColliderBundle {
+                shape: ColliderShape::cuboid(rad, rad),
+                ..ColliderBundle::default()
+            };
+            let child_entity = commands
+                .spawn_bundle(rigid_body)
+                .insert_bundle(collider)
+                .insert(ColliderPositionSync::Discrete)
+                .insert(ColliderDebugRender::with_id(color))
+                .id();
 
             // Vertical joint.
             if i > 0 {
                 let parent_entity = *body_entities.last().unwrap();
                 let joint = BallJoint::new(Point2::origin(), Point2::new(0.0, shift));
-                commands.spawn().insert_bundle((JointBuilderComponent::new(
+                commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,
                     child_entity,
@@ -101,7 +114,7 @@ pub fn setup_physics(mut commands: Commands) {
                 let parent_index = body_entities.len() - numi;
                 let parent_entity = body_entities[parent_index];
                 let joint = BallJoint::new(Point2::origin(), Point2::new(-shift, 0.0));
-                commands.spawn().insert_bundle((JointBuilderComponent::new(
+                commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,
                     child_entity,

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -85,8 +85,5 @@ fn player_movement(
         // Update the velocity on the rigid_body_component,
         // the bevy_rapier plugin will update the Sprite transform.
         rb_vels.linvel = move_delta * player.0;
-        // Make sure the rigid-body is awake so it can move
-        // even if it was standing still for a while.
-        rb_activation.wake_up(true);
     }
 }

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -1,7 +1,5 @@
 use bevy::prelude::*;
-use bevy_rapier2d::physics::{RapierConfiguration, RapierPhysicsPlugin, RigidBodyHandleComponent};
-use bevy_rapier2d::rapier::dynamics::{RigidBodyBuilder, RigidBodySet};
-use bevy_rapier2d::rapier::geometry::ColliderBuilder;
+use bevy_rapier2d::prelude::*;
 use bevy_rapier2d::rapier::na::Vector2;
 
 fn main() {
@@ -17,11 +15,11 @@ fn main() {
         .add_plugin(bevy_wgpu::WgpuPlugin::default())
         .add_startup_system(spawn_player.system())
         .add_system(player_movement.system())
-        .add_plugin(RapierPhysicsPlugin)
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .run();
 }
 
-// The float value is the player movemnt speed in 'pixels/second'.
+// The float value is the player movement speed in 'pixels/second'.
 struct Player(f32);
 
 fn spawn_player(
@@ -53,25 +51,29 @@ fn spawn_player(
             sprite: Sprite::new(Vec2::new(sprite_size_x, sprite_size_y)),
             ..Default::default()
         })
-        .insert(RigidBodyBuilder::new_dynamic())
-        .insert(ColliderBuilder::cuboid(
-            collider_size_x / 2.0,
-            collider_size_y / 2.0,
-        ))
+        .insert_bundle(RigidBodyBundle::default())
+        .insert_bundle(ColliderBundle {
+            position: [collider_size_x / 2.0, collider_size_y / 2.0].into(),
+            ..Default::default()
+        })
+        .insert(ColliderPositionSync::Discrete)
+        .insert(ColliderDebugRender::with_id(0))
         .insert(Player(300.0));
 }
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
     rapier_parameters: Res<RapierConfiguration>,
-    mut rigid_bodies: ResMut<RigidBodySet>,
-    player_info: Query<(&Player, &RigidBodyHandleComponent)>,
+    mut player_info: Query<(&Player, &mut RigidBodyVelocity, &mut RigidBodyActivation)>,
 ) {
-    for (player, rigid_body_component) in player_info.iter() {
-        let x_axis = -(keyboard_input.pressed(KeyCode::A) as i8)
-            + (keyboard_input.pressed(KeyCode::D) as i8);
-        let y_axis = -(keyboard_input.pressed(KeyCode::S) as i8)
-            + (keyboard_input.pressed(KeyCode::W) as i8);
+    for (player, mut rb_vels, mut rb_activation) in player_info.iter_mut() {
+        let up = keyboard_input.pressed(KeyCode::W) || keyboard_input.pressed(KeyCode::Up);
+        let down = keyboard_input.pressed(KeyCode::S) || keyboard_input.pressed(KeyCode::Down);
+        let left = keyboard_input.pressed(KeyCode::A) || keyboard_input.pressed(KeyCode::Left);
+        let right = keyboard_input.pressed(KeyCode::D) || keyboard_input.pressed(KeyCode::Right);
+
+        let x_axis = -(left as i8) + right as i8;
+        let y_axis = -(down as i8) + up as i8;
 
         let mut move_delta = Vector2::new(x_axis as f32, y_axis as f32);
         if move_delta != Vector2::zeros() {
@@ -82,8 +84,9 @@ fn player_movement(
 
         // Update the velocity on the rigid_body_component,
         // the bevy_rapier plugin will update the Sprite transform.
-        if let Some(rb) = rigid_bodies.get_mut(rigid_body_component.handle()) {
-            rb.set_linvel(move_delta * player.0, true);
-        }
+        rb_vels.linvel = move_delta * player.0;
+        // Make sure the rigid-body is awake so it can move
+        // even if it was standing still for a while.
+        rb_activation.wake_up(true);
     }
 }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -33,7 +33,6 @@ bevy = { version = "0.5", default-features = false }
 nalgebra = { version = "0.26", features = [ "convert-glam-unchecked" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = { version = "0.8", default-features = false, features = [ "dim3", "f32" ] }
-concurrent-queue = "1"
 
 [dev-dependencies]
 bevy_wgpu = "0.5"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -30,8 +30,9 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.5", default-features = false }
-nalgebra = "0.25"
-rapier3d = "0.7"
+nalgebra = { version = "0.26", features = [ "convert-glam-unchecked" ] }
+# Don't enable the default features because we don't need the ColliderSet/RigidBodySet
+rapier3d = { version = "0.8", default-features = false, features = [ "dim3", "f32" ] }
 concurrent-queue = "1"
 
 [dev-dependencies]

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -1,11 +1,10 @@
 extern crate rapier3d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
+use bevy_rapier3d::prelude::*;
+
 use bevy::render::pass::ClearColor;
-use bevy_rapier3d::physics::RapierPhysicsPlugin;
-use bevy_rapier3d::render::RapierRenderPlugin;
-use rapier3d::dynamics::RigidBodyBuilder;
-use rapier3d::geometry::ColliderBuilder;
+use rapier::geometry::ColliderShape;
 use rapier3d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
 
@@ -23,7 +22,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_winit::WinitPlugin::default())
         .add_plugin(bevy_wgpu::WgpuPlugin::default())
-        .add_plugin(RapierPhysicsPlugin)
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
         .add_startup_system(setup_graphics.system())
@@ -37,7 +36,7 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn().insert_bundle(LightBundle {
+    commands.spawn_bundle(LightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
         light: Light {
             intensity: 100_000.0,
@@ -46,7 +45,7 @@ fn setup_graphics(mut commands: Commands) {
         },
         ..Default::default()
     });
-    commands.spawn().insert_bundle(PerspectiveCameraBundle {
+    commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_matrix(Mat4::face_toward(
             Vec3::new(-30.0, 30.0, 100.0),
             Vec3::new(0.0, 10.0, 0.0),
@@ -63,9 +62,16 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 200.1;
     let ground_height = 0.1;
 
-    let rigid_body = RigidBodyBuilder::new_static().translation(0.0, -ground_height, 0.0);
-    let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(ground_size, ground_height, ground_size),
+        position: [0.0, -ground_height, 0.0].into(),
+        ..ColliderBundle::default()
+    };
+
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderDebugRender::default())
+        .insert(ColliderPositionSync::Discrete);
 
     /*
      * Create the cubes
@@ -79,6 +85,7 @@ pub fn setup_physics(mut commands: Commands) {
     let centerz = shift * (num / 2) as f32;
 
     let mut offset = -(num as f32) * (rad * 2.0 + rad) * 0.5;
+    let mut color = 0;
 
     for j in 0usize..20 {
         for i in 0..num {
@@ -86,11 +93,25 @@ pub fn setup_physics(mut commands: Commands) {
                 let x = i as f32 * shift - centerx + offset;
                 let y = j as f32 * shift + centery + 3.0;
                 let z = k as f32 * shift - centerz + offset;
+                color += 1;
 
                 // Build the rigid body.
-                let rigid_body = RigidBodyBuilder::new_dynamic().translation(x, y, z);
-                let collider = ColliderBuilder::cuboid(rad, rad, rad).density(1.0);
-                commands.spawn().insert_bundle((rigid_body, collider));
+                let rigid_body = RigidBodyBundle {
+                    position: [x, y, z].into(),
+                    ..RigidBodyBundle::default()
+                };
+
+                let collider = ColliderBundle {
+                    shape: ColliderShape::cuboid(rad, rad, rad),
+                    ..ColliderBundle::default()
+                };
+
+                commands
+                    .spawn()
+                    .insert_bundle(rigid_body)
+                    .insert_bundle(collider)
+                    .insert(ColliderDebugRender::with_id(color))
+                    .insert(ColliderPositionSync::Discrete);
             }
         }
 

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -1,29 +1,50 @@
 extern crate rapier3d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
+use bevy_rapier3d::prelude::*;
+
 use bevy::render::pass::ClearColor;
-use bevy_rapier3d::physics::{InteractionPairFilters, RapierPhysicsPlugin};
-use bevy_rapier3d::render::RapierRenderPlugin;
 use rapier::geometry::SolverFlags;
-use rapier3d::dynamics::RigidBodyBuilder;
-use rapier3d::geometry::ColliderBuilder;
-use rapier3d::pipeline::{PairFilterContext, PhysicsHooks, PhysicsHooksFlags, PhysicsPipeline};
+use rapier3d::pipeline::{PairFilterContext, PhysicsHooksFlags, PhysicsPipeline};
 use ui::DebugUiPlugin;
 
 #[path = "../../src_debug_ui/mod.rs"]
 mod ui;
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum CustomFilterTag {
+    GroupA,
+    GroupB,
+}
+
+impl CustomFilterTag {
+    fn with_id(id: usize) -> Self {
+        if id % 2 == 0 {
+            Self::GroupA
+        } else {
+            Self::GroupB
+        }
+    }
+}
 
 // A custom filter that allows contacts only between rigid-bodies with the
 // same user_data value.
 // Note that using collision groups would be a more efficient way of doing
 // this, but we use custom filters instead for demonstration purpose.
 struct SameUserDataFilter;
-impl PhysicsHooks for SameUserDataFilter {
-    fn active_hooks(&self) -> PhysicsHooksFlags {
+impl<'a> PhysicsHooksWithQuery<&'a CustomFilterTag> for SameUserDataFilter {
+    fn active_hooks(&self, _: &Query<&'a CustomFilterTag>) -> PhysicsHooksFlags {
         PhysicsHooksFlags::FILTER_CONTACT_PAIR
     }
-    fn filter_contact_pair(&self, context: &PairFilterContext) -> Option<SolverFlags> {
-        if context.rigid_body1.user_data == context.rigid_body2.user_data {
+
+    fn filter_contact_pair(
+        &self,
+        context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+        tags: &Query<&'a CustomFilterTag>,
+    ) -> Option<SolverFlags> {
+        if tags.get(context.collider1.entity()).ok().copied()
+            == tags.get(context.collider2.entity()).ok().copied()
+        {
             Some(SolverFlags::COMPUTE_IMPULSES)
         } else {
             None
@@ -42,7 +63,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_winit::WinitPlugin::default())
         .add_plugin(bevy_wgpu::WgpuPlugin::default())
-        .add_plugin(RapierPhysicsPlugin)
+        .add_plugin(RapierPhysicsPlugin::<&CustomFilterTag>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
         .add_startup_system(setup_graphics.system())
@@ -56,7 +77,7 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn().insert_bundle(LightBundle {
+    commands.spawn_bundle(LightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
         light: Light {
             intensity: 100_000.0,
@@ -65,7 +86,7 @@ fn setup_graphics(mut commands: Commands) {
         },
         ..Default::default()
     });
-    commands.spawn().insert_bundle(PerspectiveCameraBundle {
+    commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_matrix(Mat4::face_toward(
             Vec3::new(-30.0, 30.0, 100.0),
             Vec3::new(0.0, 10.0, 0.0),
@@ -79,21 +100,30 @@ pub fn setup_physics(mut commands: Commands) {
     /*
      * Ground
      */
-    commands.insert_resource(InteractionPairFilters {
-        hook: Some(Box::new(SameUserDataFilter {})),
-    });
+    commands.insert_resource(PhysicsHooksWithQueryObject(Box::new(SameUserDataFilter {})));
 
     let ground_size = 10.0;
 
-    let rigid_body = RigidBodyBuilder::new_static()
-        .translation(0.0, -10.0, 0.0)
-        .user_data(0);
-    let collider = ColliderBuilder::cuboid(ground_size, 1.2, ground_size);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(ground_size, 1.2, ground_size),
+        position: [0.0, -10.0, 0.0].into(),
+        ..Default::default()
+    };
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderDebugRender::default())
+        .insert(ColliderPositionSync::Discrete)
+        .insert(CustomFilterTag::GroupA);
 
-    let rigid_body = RigidBodyBuilder::new_static().user_data(1);
-    let collider = ColliderBuilder::cuboid(ground_size, 1.2, ground_size);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(ground_size, 1.2, ground_size),
+        ..Default::default()
+    };
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderDebugRender::default())
+        .insert(ColliderPositionSync::Discrete)
+        .insert(CustomFilterTag::GroupB);
 
     /*
      * Create the cubes
@@ -104,18 +134,30 @@ pub fn setup_physics(mut commands: Commands) {
     let shift = rad * 2.0;
     let centerx = shift * (num as f32) / 2.0;
     let centery = shift / 2.0;
+    let mut color = 0;
 
     for i in 0..num {
         for j in 0usize..num * 5 {
             let x = (i as f32 + j as f32 * 0.2) * shift - centerx;
             let y = j as f32 * shift + centery + 2.0;
+            color += 1;
 
             // Build the rigid body.
-            let body = RigidBodyBuilder::new_dynamic()
-                .user_data(j as u128 % 2)
-                .translation(x, y, 0.0);
-            let collider = ColliderBuilder::cuboid(rad, rad, rad).density(1.0);
-            commands.spawn().insert_bundle((body, collider));
+            let body = RigidBodyBundle {
+                position: [x, y, 0.0].into(),
+                ..Default::default()
+            };
+
+            let collider = ColliderBundle {
+                shape: ColliderShape::cuboid(rad, rad, rad),
+                ..Default::default()
+            };
+            commands
+                .spawn_bundle(body)
+                .insert_bundle(collider)
+                .insert(ColliderDebugRender::with_id(color % 2))
+                .insert(ColliderPositionSync::Discrete)
+                .insert(CustomFilterTag::with_id(color));
         }
     }
 }

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -55,12 +55,15 @@ fn setup_graphics(mut commands: Commands) {
     });
 }
 
-fn display_events(events: Res<EventQueue>) {
-    while let Ok(intersection_event) = events.intersection_events.pop() {
+fn display_events(
+    mut intersection_events: EventReader<IntersectionEvent>,
+    mut contact_events: EventReader<ContactEvent>,
+) {
+    for intersection_event in intersection_events.iter() {
         println!("Received intersection event: {:?}", intersection_event);
     }
 
-    while let Ok(contact_event) = events.contact_events.pop() {
+    for contact_event in contact_events.iter() {
         println!("Received contact event: {:?}", contact_event);
     }
 }

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -1,12 +1,12 @@
 extern crate rapier3d as rapier; // For the debug UI.
 
 use bevy::prelude::*;
+use bevy_rapier3d::prelude::*;
+
 use bevy::render::pass::ClearColor;
-use bevy_rapier3d::physics::RapierPhysicsPlugin;
-use bevy_rapier3d::render::RapierRenderPlugin;
-use nalgebra::Vector3;
-use rapier3d::dynamics::RigidBodyBuilder;
-use rapier3d::geometry::ColliderBuilder;
+use nalgebra::{Isometry3, Vector3};
+use rapier::dynamics::RigidBodyMassPropsFlags;
+use rapier::geometry::ColliderShape;
 use rapier3d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
 
@@ -24,7 +24,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_winit::WinitPlugin::default())
         .add_plugin(bevy_wgpu::WgpuPlugin::default())
-        .add_plugin(RapierPhysicsPlugin)
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
         .add_startup_system(setup_graphics.system())
@@ -38,7 +38,7 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn().insert_bundle(LightBundle {
+    commands.spawn_bundle(LightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
         light: Light {
             intensity: 100_000.0,
@@ -47,7 +47,7 @@ fn setup_graphics(mut commands: Commands) {
         },
         ..Default::default()
     });
-    commands.spawn().insert_bundle(PerspectiveCameraBundle {
+    commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_matrix(Mat4::face_toward(
             Vec3::new(10.0, 3.0, 0.0),
             Vec3::new(0.0, 3.0, 0.0),
@@ -64,27 +64,56 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 5.0;
     let ground_height = 0.1;
 
-    let rigid_body = RigidBodyBuilder::new_static().translation(0.0, -ground_height, 0.0);
-    let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(ground_size, ground_height, ground_size),
+        position: [0.0, -ground_height, 0.0].into(),
+        ..ColliderBundle::default()
+    };
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderDebugRender::default())
+        .insert(ColliderPositionSync::Discrete);
 
     /*
      * A rectangle that only rotates along the `x` axis.
      */
-    let rigid_body = RigidBodyBuilder::new_dynamic()
-        .translation(0.0, 3.0, 0.0)
-        .lock_translations()
-        .restrict_rotations(true, false, false);
-    let collider = ColliderBuilder::cuboid(0.2, 0.6, 2.0);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let locked_dofs = RigidBodyMassPropsFlags::TRANSLATION_LOCKED
+        | RigidBodyMassPropsFlags::ROTATION_LOCKED_Y
+        | RigidBodyMassPropsFlags::ROTATION_LOCKED_Z;
+
+    let rigid_body = RigidBodyBundle {
+        position: [0.0, 3.0, 0.0].into(),
+        mass_properties: locked_dofs.into(),
+        ..RigidBodyBundle::default()
+    };
+
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(0.2, 0.6, 2.0),
+        ..ColliderBundle::default()
+    };
+    commands
+        .spawn_bundle(rigid_body)
+        .insert_bundle(collider)
+        .insert(ColliderDebugRender::with_id(0))
+        .insert(ColliderPositionSync::Discrete);
 
     /*
      * A tilted cuboid that cannot rotate.
      */
-    let rigid_body = RigidBodyBuilder::new_dynamic()
-        .translation(0.0, 5.0, 0.0)
-        .rotation(Vector3::x() * 1.0)
-        .lock_rotations();
-    let collider = ColliderBuilder::cuboid(0.6, 0.4, 0.4);
-    commands.spawn().insert_bundle((rigid_body, collider));
+    let rigid_body = RigidBodyBundle {
+        position: (Vec3::new(0.0, 5.0, 0.0), Quat::from_rotation_x(1.0)).into(),
+        mass_properties: RigidBodyMassPropsFlags::ROTATION_LOCKED.into(),
+        ..RigidBodyBundle::default()
+    };
+
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(0.6, 0.4, 0.4),
+        ..ColliderBundle::default()
+    };
+
+    commands
+        .spawn_bundle(rigid_body)
+        .insert_bundle(collider)
+        .insert(ColliderDebugRender::with_id(1))
+        .insert(ColliderPositionSync::Discrete);
 }

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -1,0 +1,183 @@
+extern crate rapier3d as rapier; // For the debug UI.
+
+use bevy::prelude::*;
+use bevy_rapier3d::prelude::*;
+
+use bevy::render::camera::Camera;
+use bevy::render::pass::ClearColor;
+use rapier::geometry::{ColliderShape, InteractionGroups, Ray};
+use rapier::pipeline::{PhysicsPipeline, QueryPipeline};
+use ui::DebugUiPlugin;
+
+#[path = "../../src_debug_ui/mod.rs"]
+mod ui;
+
+fn main() {
+    App::build()
+        .insert_resource(ClearColor(Color::rgb(
+            0xF9 as f32 / 255.0,
+            0xF9 as f32 / 255.0,
+            0xFF as f32 / 255.0,
+        )))
+        .insert_resource(Msaa::default())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(bevy_winit::WinitPlugin::default())
+        .add_plugin(bevy_wgpu::WgpuPlugin::default())
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
+        .add_plugin(RapierRenderPlugin)
+        .add_plugin(DebugUiPlugin)
+        .add_startup_system(setup_graphics.system())
+        .add_startup_system(setup_physics.system())
+        .add_startup_system(enable_physics_profiling.system())
+        .add_system(cast_ray.system())
+        .run();
+}
+
+fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
+    pipeline.counters.enable()
+}
+
+fn setup_graphics(mut commands: Commands) {
+    commands.spawn_bundle(LightBundle {
+        transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
+        light: Light {
+            intensity: 100_000.0,
+            range: 3000.0,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_matrix(Mat4::face_toward(
+            Vec3::new(-30.0, 30.0, 100.0),
+            Vec3::new(0.0, 10.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+        )),
+        ..Default::default()
+    });
+}
+
+pub fn setup_physics(mut commands: Commands) {
+    /*
+     * Ground
+     */
+    let ground_size = 200.1;
+    let ground_height = 0.1;
+
+    let collider = ColliderBundle {
+        shape: ColliderShape::cuboid(ground_size, ground_height, ground_size),
+        position: [0.0, -ground_height, 0.0].into(),
+        ..ColliderBundle::default()
+    };
+
+    commands
+        .spawn_bundle(collider)
+        .insert(ColliderDebugRender::default())
+        .insert(ColliderPositionSync::Discrete);
+
+    /*
+     * Create the cubes
+     */
+    let num = 8;
+    let rad = 1.0;
+
+    let shift = rad * 2.0 + rad;
+    let centerx = shift * (num / 2) as f32;
+    let centery = shift / 2.0;
+    let centerz = shift * (num / 2) as f32;
+
+    let mut offset = -(num as f32) * (rad * 2.0 + rad) * 0.5;
+    let mut color = 0;
+
+    for j in 0usize..20 {
+        for i in 0..num {
+            for k in 0usize..num {
+                let x = i as f32 * shift - centerx + offset;
+                let y = j as f32 * shift + centery + 3.0;
+                let z = k as f32 * shift - centerz + offset;
+                color += 1;
+
+                // Build the rigid body.
+                let rigid_body = RigidBodyBundle {
+                    position: [x, y, z].into(),
+                    ..RigidBodyBundle::default()
+                };
+
+                let collider = ColliderBundle {
+                    shape: ColliderShape::cuboid(rad, rad, rad),
+                    ..ColliderBundle::default()
+                };
+
+                commands
+                    .spawn()
+                    .insert_bundle(rigid_body)
+                    .insert_bundle(collider)
+                    .insert(ColliderDebugRender::with_id(color))
+                    .insert(ColliderPositionSync::Discrete);
+            }
+        }
+
+        offset -= 0.05 * rad * (num as f32 - 1.0);
+    }
+}
+
+fn cast_ray(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    windows: Res<Windows>,
+    query_pipeline: Res<QueryPipeline>,
+    colliders: QueryPipelineColliderComponentsQuery,
+    bodies: Query<&RigidBodyType>,
+    cameras: Query<(&Camera, &GlobalTransform)>,
+) {
+    // We will color in read the colliders hovered by the mouse.
+    for (camera, camera_transform) in cameras.iter() {
+        // First, compute a ray from the mouse position.
+        let ray = ray_from_mouse_position(windows.get_primary().unwrap(), camera, camera_transform);
+
+        // Then cast the ray. This QueryPipelineColliderComponentsSet is just
+        // an adapter so the query pipeline understands how to use the query from Bevy.
+        let colliders = QueryPipelineColliderComponentsSet(&colliders);
+        let hit = query_pipeline.cast_ray(
+            &colliders,
+            &ray,
+            100.0,
+            true,
+            InteractionGroups::default(),
+            None,
+        );
+
+        if let Some(hit) = hit {
+            // Color in red the entity we just hit.
+            // But don't color it if the rigid-body is not dynamic.
+            if bodies.get(hit.0.entity()).ok() == Some(&RigidBodyType::Dynamic) {
+                // TODO: don't create a new material every time.
+                let material = materials.add(Color::rgb(1.0, 0.0, 0.0).into());
+                commands.entity(hit.0.entity()).insert(material);
+            }
+        }
+    }
+}
+
+// Credit to @doomy on discord.
+fn ray_from_mouse_position(
+    window: &Window,
+    camera: &Camera,
+    camera_transform: &GlobalTransform,
+) -> Ray {
+    let mouse_position = window.cursor_position().unwrap_or(Vec2::new(0.0, 0.0));
+
+    let x = 2.0 * (mouse_position.x / window.width() as f32) - 1.0;
+    let y = 2.0 * (mouse_position.y / window.height() as f32) - 1.0;
+
+    let camera_inverse_matrix =
+        camera_transform.compute_matrix() * camera.projection_matrix.inverse();
+    let near = camera_inverse_matrix * Vec3::new(x, y, 0.0).extend(1.0);
+    let far = camera_inverse_matrix * Vec3::new(x, y, 1.0).extend(1.0);
+
+    let near = near.truncate() / near.w;
+    let far = far.truncate() / far.w;
+    let dir: Vec3 = far - near;
+
+    Ray::new(near.into(), dir.into())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,11 @@ pub mod render;
 
 pub mod prelude {
     pub use super::physics::{
-        ColliderBundle, ColliderComponentsSet, ColliderPositionSync, EventQueue, IntoEntity,
-        IntoHandle, JointBuilderComponent, NoUserData, PhysicsHooksWithQuery,
-        PhysicsHooksWithQueryObject, QueryPipelineColliderComponentsQuery,
-        QueryPipelineColliderComponentsSet, RapierConfiguration, RapierPhysicsPlugin,
-        RigidBodyBundle, RigidBodyComponentsSet, RigidBodyPositionSync,
+        ColliderBundle, ColliderComponentsSet, ColliderPositionSync, IntoEntity, IntoHandle,
+        JointBuilderComponent, NoUserData, PhysicsHooksWithQuery, PhysicsHooksWithQueryObject,
+        QueryPipelineColliderComponentsQuery, QueryPipelineColliderComponentsSet,
+        RapierConfiguration, RapierPhysicsPlugin, RigidBodyBundle, RigidBodyComponentsSet,
+        RigidBodyPositionSync,
     };
     pub use rapier::dynamics::{
         RigidBodyActivation, RigidBodyCcd, RigidBodyChanges, RigidBodyColliders, RigidBodyForces,
@@ -37,7 +37,7 @@ pub mod prelude {
     };
     pub use rapier::geometry::{
         ColliderBroadPhaseData, ColliderChanges, ColliderGroups, ColliderMaterial, ColliderParent,
-        ColliderPosition, ColliderShape, ColliderType,
+        ColliderPosition, ColliderShape, ColliderType, ContactEvent, IntersectionEvent,
     };
 
     #[cfg(feature = "render")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,9 @@ pub mod prelude {
     pub use super::physics::{
         ColliderBundle, ColliderComponentsSet, ColliderPositionSync, EventQueue, IntoEntity,
         IntoHandle, JointBuilderComponent, NoUserData, PhysicsHooksWithQuery,
-        PhysicsHooksWithQueryObject, RapierConfiguration, RapierPhysicsPlugin, RigidBodyBundle,
-        RigidBodyComponentsSet, RigidBodyPositionSync,
+        PhysicsHooksWithQueryObject, QueryPipelineColliderComponentsQuery,
+        QueryPipelineColliderComponentsSet, RapierConfiguration, RapierPhysicsPlugin,
+        RigidBodyBundle, RigidBodyComponentsSet, RigidBodyPositionSync,
     };
     pub use rapier::dynamics::{
         RigidBodyActivation, RigidBodyCcd, RigidBodyChanges, RigidBodyColliders, RigidBodyForces,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! defines physics plugins for the Bevy game engine.
 //!
 
-#![deny(missing_docs)]
+// #![deny(missing_docs)] // FIXME: deny this
 
 pub extern crate nalgebra as na;
 #[cfg(feature = "dim2")]
@@ -21,3 +21,24 @@ pub mod physics;
 /// Plugins, resources, and components for debug rendering.
 #[cfg(feature = "render")]
 pub mod render;
+
+pub mod prelude {
+    pub use super::physics::{
+        ColliderBundle, ColliderComponentsSet, ColliderPositionSync, EventQueue, IntoEntity,
+        IntoHandle, JointBuilderComponent, NoUserData, PhysicsHooksWithQuery,
+        PhysicsHooksWithQueryObject, RapierConfiguration, RapierPhysicsPlugin, RigidBodyBundle,
+        RigidBodyComponentsSet, RigidBodyPositionSync,
+    };
+    pub use rapier::dynamics::{
+        RigidBodyActivation, RigidBodyCcd, RigidBodyChanges, RigidBodyColliders, RigidBodyForces,
+        RigidBodyIds, RigidBodyMassProps, RigidBodyMassPropsFlags, RigidBodyPosition,
+        RigidBodyType, RigidBodyVelocity,
+    };
+    pub use rapier::geometry::{
+        ColliderBroadPhaseData, ColliderChanges, ColliderGroups, ColliderMaterial, ColliderParent,
+        ColliderPosition, ColliderShape, ColliderType,
+    };
+
+    #[cfg(feature = "render")]
+    pub use super::render::{ColliderDebugRender, RapierRenderPlugin};
+}

--- a/src/physics/collider_component_set.rs
+++ b/src/physics/collider_component_set.rs
@@ -1,0 +1,110 @@
+use super::{BundleBuilder, IntoEntity, IntoHandle};
+use bevy::prelude::*;
+use rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
+use rapier::geometry::{
+    ColliderBroadPhaseData, ColliderChanges, ColliderGroups, ColliderHandle,
+    ColliderMassProperties, ColliderMaterial, ColliderParent, ColliderPosition, ColliderShape,
+    ColliderType,
+};
+
+impl IntoHandle<ColliderHandle> for Entity {
+    fn handle(self) -> ColliderHandle {
+        ColliderHandle::from_raw_parts(self.id(), self.generation())
+    }
+}
+
+impl IntoEntity for ColliderHandle {
+    fn entity(self) -> Entity {
+        self.0.entity()
+    }
+}
+
+pub struct ColliderComponentsSet<'a, 'b, 'c>(pub ColliderComponentsQuery<'a, 'b, 'c>);
+
+pub type ColliderComponentsQuery<'a, 'b, 'c> = QuerySet<(
+    Query<
+        'a,
+        (
+            Entity,
+            &'b ColliderChanges,
+            &'b ColliderPosition,
+            &'b ColliderBroadPhaseData,
+            &'b ColliderShape,
+            &'b ColliderType,
+            &'b ColliderGroups,
+            &'b ColliderMaterial,
+            Option<&'b ColliderParent>,
+        ),
+    >,
+    Query<
+        'a,
+        (
+            Entity,
+            &'c mut ColliderChanges,
+            &'c mut ColliderPosition,
+            &'c mut ColliderBroadPhaseData,
+        ),
+    >,
+    Query<
+        'a,
+        (
+            Entity,
+            &'c mut ColliderChanges,
+            Or<(Changed<ColliderPosition>, Added<ColliderPosition>)>,
+            Or<(Changed<ColliderGroups>, Added<ColliderGroups>)>,
+            Or<(Changed<ColliderShape>, Added<ColliderShape>)>,
+            Or<(Changed<ColliderType>, Added<ColliderType>)>,
+            Option<Or<(Changed<ColliderParent>, Added<ColliderParent>)>>,
+        ),
+        Or<(
+            Changed<ColliderPosition>,
+            Added<ColliderPosition>,
+            Changed<ColliderGroups>,
+            Added<ColliderGroups>,
+            Changed<ColliderShape>,
+            Added<ColliderShape>,
+            Changed<ColliderType>,
+            Added<ColliderType>,
+            Changed<ColliderParent>,
+            Added<ColliderParent>,
+        )>,
+    >,
+)>;
+
+impl_component_set_mut!(ColliderComponentsSet, ColliderChanges, |data| data.1);
+impl_component_set_mut!(ColliderComponentsSet, ColliderPosition, |data| data.2);
+impl_component_set_mut!(ColliderComponentsSet, ColliderBroadPhaseData, |d| d.3);
+
+impl_component_set!(ColliderComponentsSet, ColliderShape, |data| data.4);
+impl_component_set!(ColliderComponentsSet, ColliderType, |data| data.5);
+impl_component_set!(ColliderComponentsSet, ColliderGroups, |data| data.6);
+impl_component_set!(ColliderComponentsSet, ColliderMaterial, |data| data.7);
+
+impl_component_set_option!(ColliderComponentsSet, ColliderParent);
+
+#[derive(Bundle)]
+pub struct ColliderBundle {
+    pub collider_type: ColliderType,
+    pub shape: ColliderShape,
+    pub position: ColliderPosition,
+    pub material: ColliderMaterial,
+    pub groups: ColliderGroups,
+    pub mass_properties: ColliderMassProperties,
+    pub changes: ColliderChanges,
+    pub bf_data: ColliderBroadPhaseData,
+}
+
+impl Default for ColliderBundle {
+    fn default() -> Self {
+        Self {
+            collider_type: ColliderType::Solid,
+            shape: ColliderShape::ball(0.5),
+            position: ColliderPosition::default(),
+            material: ColliderMaterial::default(),
+            groups: ColliderGroups::default(),
+            mass_properties: ColliderMassProperties::default(),
+            changes: ColliderChanges::default(),
+            bf_data: ColliderBroadPhaseData::default(),
+        }
+    }
+}

--- a/src/physics/collider_component_set.rs
+++ b/src/physics/collider_component_set.rs
@@ -1,4 +1,4 @@
-use super::{BundleBuilder, IntoEntity, IntoHandle};
+use super::{IntoEntity, IntoHandle};
 use bevy::prelude::*;
 use rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
 use rapier::geometry::{
@@ -18,6 +18,32 @@ impl IntoEntity for ColliderHandle {
         self.0.entity()
     }
 }
+
+pub type QueryPipelineColliderComponentsQuery<'a, 'b> = Query<
+    'a,
+    (
+        Entity,
+        &'b ColliderPosition,
+        &'b ColliderShape,
+        &'b ColliderGroups,
+    ),
+>;
+
+pub struct QueryPipelineColliderComponentsSet<'a, 'b, 'c>(
+    pub &'c QueryPipelineColliderComponentsQuery<'a, 'b>,
+);
+
+impl_component_set_wo_query_set!(
+    QueryPipelineColliderComponentsSet,
+    ColliderPosition,
+    |data| data.1
+);
+impl_component_set_wo_query_set!(QueryPipelineColliderComponentsSet, ColliderShape, |data| {
+    data.2
+});
+impl_component_set_wo_query_set!(QueryPipelineColliderComponentsSet, ColliderGroups, |data| {
+    data.3
+});
 
 pub struct ColliderComponentsSet<'a, 'b, 'c>(pub ColliderComponentsQuery<'a, 'b, 'c>);
 

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -135,3 +135,28 @@ impl PhysicsInterpolationComponent {
         )))
     }
 }
+
+#[derive(Copy, Clone, Debug)]
+pub enum RigidBodyPositionSync {
+    Discrete,
+    Interpolated { prev_pos: Option<Isometry<f32>> },
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum ColliderPositionSync {
+    // Right now, there is only discrete for colliders.
+    // We may add more modes in the future.
+    Discrete,
+}
+
+impl Default for RigidBodyPositionSync {
+    fn default() -> Self {
+        Self::Discrete
+    }
+}
+
+impl Default for ColliderPositionSync {
+    fn default() -> Self {
+        Self::Discrete
+    }
+}

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -1,9 +1,188 @@
+pub use self::collider_component_set::*;
 pub use self::components::*;
 pub use self::plugins::*;
 pub use self::resources::*;
+pub use self::rigid_body_component_set::*;
 pub use self::systems::*;
 
+use crate::rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption};
+use crate::rapier::dynamics::JointHandle;
+use bevy::ecs::query::WorldQuery;
+use bevy::prelude::{Entity, Query, QuerySet};
+use rapier::data::Index;
+
+pub trait IntoHandle<H> {
+    fn handle(self) -> H;
+}
+
+pub trait IntoEntity {
+    fn entity(self) -> Entity;
+}
+
+impl IntoHandle<Index> for Entity {
+    fn handle(self) -> Index {
+        Index::from_raw_parts(self.id(), self.generation())
+    }
+}
+
+impl IntoEntity for Index {
+    fn entity(self) -> Entity {
+        let (id, gen) = self.into_raw_parts();
+        let bits = u64::from(gen) << 32 | u64::from(id);
+        Entity::from_bits(bits)
+    }
+}
+
+impl IntoHandle<JointHandle> for Entity {
+    fn handle(self) -> JointHandle {
+        JointHandle::from_raw_parts(self.id(), self.generation())
+    }
+}
+
+impl IntoEntity for JointHandle {
+    fn entity(self) -> Entity {
+        self.0.entity()
+    }
+}
+
+pub trait BundleBuilder {
+    type Bundle;
+    fn bundle(&self) -> Self::Bundle;
+}
+
+macro_rules! impl_component_set_mut(
+    ($ComponentsSet: ident, $T: ty, |$data: ident| $data_expr: expr) => {
+        impl<'a, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'b, 'c> {
+            #[inline(always)]
+            fn get(&self, handle: Index) -> Option<&$T> {
+                self.0.q0().get_component(handle.entity()).ok()
+            }
+        }
+
+        impl<'a, 'b, 'c> ComponentSet<$T> for $ComponentsSet<'a, 'b, 'c> {
+            #[inline(always)]
+            fn size_hint(&self) -> usize {
+                0
+            }
+
+            #[inline(always)]
+            fn for_each(&self, mut f: impl FnMut(Index, &$T)) {
+                self.0.q0().for_each(|$data| f($data.0.handle(), $data_expr))
+            }
+        }
+
+        impl<'a, 'b, 'c> ComponentSetMut<$T> for $ComponentsSet<'a, 'b, 'c> {
+            #[inline(always)]
+            fn set_internal(&mut self, handle: Index, val: $T) {
+                let _ = self.0.q1_mut().get_mut(handle.entity()).map(|mut $data| *$data_expr = val);
+            }
+
+            #[inline(always)]
+            fn map_mut_internal<Result>(
+                &mut self,
+                handle: Index,
+                f: impl FnOnce(&mut $T) -> Result,
+            ) -> Option<Result> {
+                self.0.q1_mut()
+                    .get_component_mut(handle.entity())
+                    .map(|mut data| f(&mut data))
+                    .ok()
+            }
+        }
+    }
+);
+
+macro_rules! impl_component_set(
+    ($ComponentsSet: ident, $T: ty, |$data: ident| $data_expr: expr) => {
+        impl<'a, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'b, 'c> {
+            #[inline(always)]
+            fn get(&self, handle: Index) -> Option<&$T> {
+                self.0.q0().get_component(handle.entity()).ok()
+            }
+        }
+
+        impl<'a, 'b, 'c> ComponentSet<$T> for $ComponentsSet<'a, 'b, 'c> {
+            #[inline(always)]
+            fn size_hint(&self) -> usize {
+                0
+            }
+
+            #[inline(always)]
+            fn for_each(&self, mut f: impl FnMut(Index, &$T)) {
+                self.0.q0().for_each(|$data| f($data.0.handle(), $data_expr))
+            }
+        }
+    }
+);
+
+macro_rules! impl_component_set_option(
+    ($ComponentsSet: ident, $T: ty) => {
+        impl<'a, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'b, 'c> {
+            #[inline(always)]
+            fn get(&self, handle: Index) -> Option<&$T> {
+                self.0.q0().get_component(handle.entity()).ok()
+            }
+        }
+    }
+);
+
+pub type ComponentSetQueryMut<'a, 'b, 'c, T> =
+    QuerySet<(Query<'a, (Entity, &'b T)>, Query<'a, (Entity, &'c mut T)>)>;
+
+pub struct QueryComponentSetMut<'a, 'b, 'c, T: 'static + Send + Sync>(
+    ComponentSetQueryMut<'a, 'b, 'c, T>,
+);
+
+impl<'a, 'b, 'c, T: 'static + Send + Sync> ComponentSetOption<T>
+    for QueryComponentSetMut<'a, 'b, 'c, T>
+{
+    #[inline(always)]
+    fn get(&self, handle: Index) -> Option<&T> {
+        self.0.q0().get_component(handle.entity()).ok()
+    }
+}
+
+impl<'a, 'b, 'c, T: 'static + Send + Sync> ComponentSet<T> for QueryComponentSetMut<'a, 'b, 'c, T> {
+    #[inline(always)]
+    fn size_hint(&self) -> usize {
+        0
+    }
+
+    #[inline(always)]
+    fn for_each(&self, mut f: impl FnMut(Index, &T)) {
+        self.0.q0().for_each(|data| f(data.0.handle(), &data.1))
+    }
+}
+
+impl<'a, 'b, 'c, T: 'static + Send + Sync> ComponentSetMut<T>
+    for QueryComponentSetMut<'a, 'b, 'c, T>
+{
+    #[inline(always)]
+    fn set_internal(&mut self, handle: Index, val: T) {
+        let _ = self
+            .0
+            .q1_mut()
+            .get_mut(handle.entity())
+            .map(|mut data| *data.1 = val);
+    }
+
+    #[inline(always)]
+    fn map_mut_internal<Result>(
+        &mut self,
+        handle: Index,
+        f: impl FnOnce(&mut T) -> Result,
+    ) -> Option<Result> {
+        self.0
+            .q1_mut()
+            .get_component_mut(handle.entity())
+            .map(|mut data| f(&mut data))
+            .ok()
+    }
+}
+
+mod collider_component_set;
 mod components;
 mod plugins;
 mod resources;
+mod rigid_body_component_set;
 mod systems;

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -7,7 +7,6 @@ pub use self::systems::*;
 
 use crate::rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption};
 use crate::rapier::dynamics::JointHandle;
-use bevy::ecs::query::WorldQuery;
 use bevy::prelude::{Entity, Query, QuerySet};
 use rapier::data::Index;
 
@@ -87,6 +86,29 @@ macro_rules! impl_component_set_mut(
                     .get_component_mut(handle.entity())
                     .map(|mut data| f(&mut data))
                     .ok()
+            }
+        }
+    }
+);
+
+macro_rules! impl_component_set_wo_query_set(
+    ($ComponentsSet: ident, $T: ty, |$data: ident| $data_expr: expr) => {
+        impl<'a, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'b, 'c> {
+            #[inline(always)]
+            fn get(&self, handle: Index) -> Option<&$T> {
+                self.0.get_component(handle.entity()).ok()
+            }
+        }
+
+        impl<'a, 'b, 'c> ComponentSet<$T> for $ComponentsSet<'a, 'b, 'c> {
+            #[inline(always)]
+            fn size_hint(&self) -> usize {
+                0
+            }
+
+            #[inline(always)]
+            fn for_each(&self, mut f: impl FnMut(Index, &$T)) {
+                self.0.for_each(|$data| f($data.0.handle(), $data_expr))
             }
         }
     }

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -3,7 +3,10 @@ use crate::physics::{
     EventQueue, JointsEntityMap, ModificationTracker, PhysicsHooksWithQueryObject,
     RapierConfiguration, SimulationToRenderTime,
 };
+use crate::prelude::IntersectionEvent;
+use crate::rapier::geometry::ContactEvent;
 use crate::rapier::pipeline::QueryPipeline;
+use bevy::app::Events;
 use bevy::ecs::query::WorldQuery;
 use bevy::prelude::*;
 use rapier::dynamics::{CCDSolver, IntegrationParameters, IslandManager, JointSet};
@@ -65,7 +68,8 @@ impl<UserData: 'static + WorldQuery + Send + Sync> Plugin for RapierPhysicsPlugi
         .insert_resource(JointSet::new())
         .insert_resource(CCDSolver::new())
         .insert_resource(PhysicsHooksWithQueryObject::<UserData>(Box::new(())))
-        .insert_resource(EventQueue::new(true))
+        .insert_resource(Events::<IntersectionEvent>::default())
+        .insert_resource(Events::<ContactEvent>::default())
         .insert_resource(SimulationToRenderTime::default())
         .insert_resource(JointsEntityMap::default())
         .insert_resource(ModificationTracker::default())

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -1,12 +1,9 @@
 use crate::physics;
 use crate::physics::{
-    EventQueue, InteractionPairFilters, JointsEntityMap, ModificationTracker,
-    PhysicsHooksWithQueryInstance, PhysicsHooksWithQueryObject, RapierConfiguration,
-    SimulationToRenderTime,
+    EventQueue, JointsEntityMap, ModificationTracker, PhysicsHooksWithQueryObject,
+    RapierConfiguration, SimulationToRenderTime,
 };
 use crate::rapier::pipeline::QueryPipeline;
-use crate::render::RapierRenderPlugin;
-use bevy::ecs::component::Component;
 use bevy::ecs::query::WorldQuery;
 use bevy::prelude::*;
 use rapier::dynamics::{CCDSolver, IntegrationParameters, IslandManager, JointSet};

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -1,7 +1,7 @@
 use crate::physics;
 use crate::physics::{
-    EventQueue, JointsEntityMap, ModificationTracker, PhysicsHooksWithQueryObject,
-    RapierConfiguration, SimulationToRenderTime,
+    JointsEntityMap, ModificationTracker, PhysicsHooksWithQueryObject, RapierConfiguration,
+    SimulationToRenderTime,
 };
 use crate::prelude::IntersectionEvent;
 use crate::rapier::geometry::ContactEvent;

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -16,7 +16,6 @@ use crate::rapier::{
 };
 use bevy::ecs::query::WorldQuery;
 use bevy::prelude::*;
-use concurrent_queue::ConcurrentQueue;
 use rapier::math::Vector;
 use std::collections::HashMap;
 use std::sync::RwLock;

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -170,8 +170,8 @@ impl ModificationTracker {
             mut rb_changes,
             mut rb_activation,
             rb_pos,
-            rb_vels,
-            rb_forces,
+            _rb_vels,
+            _rb_forces,
             rb_type,
             rb_colliders,
         ) in bodies_query.q2_mut().iter_mut()
@@ -188,14 +188,13 @@ impl ModificationTracker {
             if rb_type {
                 *rb_changes |= RigidBodyChanges::TYPE;
             }
-            if rb_vels | rb_forces {
-                // Wake-up the rigid-body.
-                *rb_changes |= RigidBodyChanges::SLEEP;
-                rb_activation.wake_up(true);
-            }
             if rb_colliders {
                 *rb_changes |= RigidBodyChanges::COLLIDERS;
             }
+
+            // Wake-up the rigid-body.
+            *rb_changes |= RigidBodyChanges::SLEEP;
+            rb_activation.wake_up(true);
         }
 
         for mut rb_changes in bodies_query.q3_mut().iter_mut() {

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -2,7 +2,7 @@ use crate::physics::{
     ColliderBundle, ColliderComponentsQuery, ColliderComponentsSet, IntoEntity, IntoHandle,
     JointHandleComponent, RigidBodyComponentsQuery, RigidBodyComponentsSet,
 };
-use crate::rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption};
+use crate::rapier::data::{ComponentSet, ComponentSetMut};
 use crate::rapier::dynamics::{
     IslandManager, JointSet, RigidBodyActivation, RigidBodyChanges, RigidBodyColliders,
     RigidBodyIds, RigidBodyType,
@@ -14,7 +14,6 @@ use crate::rapier::{
     geometry::{ColliderHandle, ContactEvent, IntersectionEvent},
     pipeline::{EventHandler, PhysicsHooks},
 };
-use bevy::ecs::component::Component;
 use bevy::ecs::query::WorldQuery;
 use bevy::prelude::*;
 use concurrent_queue::ConcurrentQueue;
@@ -96,26 +95,6 @@ impl EventHandler for EventQueue {
 pub struct SimulationToRenderTime {
     /// Difference between simulation and rendering time
     pub diff: f32,
-}
-
-/// Custom filters for intersection and contact pairs.
-pub struct InteractionPairFilters {
-    /// Custom physics hooks
-    pub hook: Option<
-        Box<
-            for<'a, 'b, 'c, 'd, 'e, 'f> PhysicsHooks<
-                RigidBodyComponentsSet<'a, 'b, 'c>,
-                ColliderComponentsSet<'d, 'e, 'f>,
-            >,
-        >,
-    >,
-}
-
-impl InteractionPairFilters {
-    /// A new interaction pair filter with no custom intersection and contact pair filters.
-    pub fn new() -> Self {
-        Self { hook: None }
-    }
 }
 
 /// HashMaps of Bevy Entity to Rapier handles

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -1,8 +1,21 @@
+use crate::physics::{
+    ColliderBundle, ColliderComponentsQuery, ColliderComponentsSet, IntoEntity, IntoHandle,
+    JointHandleComponent, RigidBodyComponentsQuery, RigidBodyComponentsSet,
+};
+use crate::rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption};
+use crate::rapier::dynamics::{
+    IslandManager, JointSet, RigidBodyActivation, RigidBodyChanges, RigidBodyColliders,
+    RigidBodyIds, RigidBodyType,
+};
+use crate::rapier::geometry::{ColliderChanges, SolverFlags};
+use crate::rapier::pipeline::{ContactModificationContext, PairFilterContext, PhysicsHooksFlags};
 use crate::rapier::{
     dynamics::{JointHandle, RigidBodyHandle},
     geometry::{ColliderHandle, ContactEvent, IntersectionEvent},
     pipeline::{EventHandler, PhysicsHooks},
 };
+use bevy::ecs::component::Component;
+use bevy::ecs::query::WorldQuery;
 use bevy::prelude::*;
 use concurrent_queue::ConcurrentQueue;
 use rapier::math::Vector;
@@ -88,7 +101,14 @@ pub struct SimulationToRenderTime {
 /// Custom filters for intersection and contact pairs.
 pub struct InteractionPairFilters {
     /// Custom physics hooks
-    pub hook: Option<Box<dyn PhysicsHooks>>,
+    pub hook: Option<
+        Box<
+            for<'a, 'b, 'c, 'd, 'e, 'f> PhysicsHooks<
+                RigidBodyComponentsSet<'a, 'b, 'c>,
+                ColliderComponentsSet<'d, 'e, 'f>,
+            >,
+        >,
+    >,
 }
 
 impl InteractionPairFilters {
@@ -100,11 +120,291 @@ impl InteractionPairFilters {
 
 /// HashMaps of Bevy Entity to Rapier handles
 #[derive(Default)]
-pub struct EntityMaps {
-    /// HashMap of Bevy Entity to Rapier RigidBodyHandle
-    pub(crate) bodies: HashMap<Entity, RigidBodyHandle>,
-    /// HashMap of Bevy Entity to Rapier ColliderHandle
-    pub(crate) colliders: HashMap<Entity, ColliderHandle>,
-    /// HashMap of Bevy Entity to Rapier JointHandle
-    pub(crate) joints: HashMap<Entity, JointHandle>,
+pub struct JointsEntityMap(pub(crate) HashMap<Entity, JointHandle>);
+
+pub struct ModificationTracker {
+    pub(crate) modified_bodies: Vec<RigidBodyHandle>,
+    pub(crate) modified_colliders: Vec<ColliderHandle>,
+    pub(crate) removed_bodies: Vec<RigidBodyHandle>,
+    pub(crate) removed_colliders: Vec<ColliderHandle>,
+    // NOTE: right now, this actually contains an Entity instead of the JointHandle.
+    //       but we will switch to JointHandle soon.
+    pub(crate) removed_joints: Vec<JointHandle>,
+    // We need to maintain these two because we have to access them
+    // when an entity containing a collider/rigid-body has been despawn.
+    pub(crate) body_colliders: HashMap<RigidBodyHandle, Vec<ColliderHandle>>,
+    pub(crate) colliders_parent: HashMap<ColliderHandle, RigidBodyHandle>,
+}
+
+impl Default for ModificationTracker {
+    fn default() -> Self {
+        Self {
+            modified_bodies: vec![],
+            modified_colliders: vec![],
+            removed_bodies: vec![],
+            removed_colliders: vec![],
+            removed_joints: vec![],
+            body_colliders: HashMap::new(),
+            colliders_parent: HashMap::new(),
+        }
+    }
+}
+
+impl ModificationTracker {
+    pub fn clear_modified_and_removed(&mut self) {
+        self.modified_colliders.clear();
+        self.modified_bodies.clear();
+        self.removed_bodies.clear();
+        self.removed_colliders.clear();
+        self.removed_joints.clear();
+    }
+
+    pub fn detect_modifications(
+        &mut self,
+        bodies_query: &mut RigidBodyComponentsQuery,
+        colliders_query: &mut ColliderComponentsQuery,
+    ) {
+        // Detect modifications.
+        for (
+            entity,
+            mut rb_changes,
+            mut rb_activation,
+            rb_pos,
+            rb_vels,
+            rb_forces,
+            rb_type,
+            rb_colliders,
+        ) in bodies_query.q2_mut().iter_mut()
+        {
+            if !rb_changes.contains(RigidBodyChanges::MODIFIED) {
+                self.modified_bodies.push(entity.handle());
+            }
+
+            *rb_changes |= RigidBodyChanges::MODIFIED;
+
+            if rb_pos {
+                *rb_changes |= RigidBodyChanges::POSITION;
+            }
+            if rb_type {
+                *rb_changes |= RigidBodyChanges::TYPE;
+            }
+            if rb_vels | rb_forces {
+                // Wake-up the rigid-body.
+                *rb_changes |= RigidBodyChanges::SLEEP;
+                rb_activation.wake_up(true);
+            }
+            if rb_colliders {
+                *rb_changes |= RigidBodyChanges::COLLIDERS;
+            }
+        }
+
+        for mut rb_changes in bodies_query.q3_mut().iter_mut() {
+            *rb_changes |= RigidBodyChanges::SLEEP;
+        }
+
+        for (entity, mut co_changes, co_pos, co_groups, co_shape, co_type, co_parent) in
+            colliders_query.q2_mut().iter_mut()
+        {
+            if !co_changes.contains(ColliderChanges::MODIFIED) {
+                self.modified_colliders.push(entity.handle());
+            }
+
+            *co_changes |= ColliderChanges::MODIFIED;
+
+            if co_pos {
+                *co_changes |= ColliderChanges::POSITION;
+            }
+            if co_groups {
+                *co_changes |= ColliderChanges::GROUPS;
+            }
+            if co_shape {
+                *co_changes |= ColliderChanges::SHAPE;
+            }
+            if co_type {
+                *co_changes |= ColliderChanges::TYPE;
+            }
+            if co_parent == Some(true) {
+                *co_changes |= ColliderChanges::PARENT;
+            }
+        }
+    }
+
+    pub fn detect_removals(
+        &mut self,
+        removed_bodies: RemovedComponents<RigidBodyChanges>,
+        removed_colliders: RemovedComponents<ColliderChanges>,
+        removed_joints: RemovedComponents<JointHandleComponent>,
+    ) {
+        self.removed_bodies.extend(
+            removed_bodies
+                .iter()
+                .map(|e| IntoHandle::<RigidBodyHandle>::handle(e)),
+        );
+        self.removed_colliders.extend(
+            removed_colliders
+                .iter()
+                .map(|e| IntoHandle::<ColliderHandle>::handle(e)),
+        );
+        self.removed_joints.extend(
+            removed_joints
+                .iter()
+                .map(|e| IntoHandle::<JointHandle>::handle(e)),
+        );
+    }
+
+    pub fn propagate_removals<Bodies>(
+        &mut self,
+        commands: &mut Commands,
+        islands: &mut IslandManager,
+        bodies: &mut Bodies,
+        joints: &mut JointSet,
+        joints_map: &mut JointsEntityMap,
+    ) where
+        Bodies: ComponentSetMut<RigidBodyChanges>
+            + ComponentSetMut<RigidBodyColliders>
+            + ComponentSetMut<RigidBodyActivation> // Needed for joint removal.
+            + ComponentSetMut<RigidBodyIds> // Needed for joint removal.
+            + ComponentSet<RigidBodyType>, // Needed for joint removal.
+    {
+        for removed_body in self.removed_bodies.iter() {
+            if let Some(colliders) = self.body_colliders.remove(removed_body) {
+                for collider in colliders {
+                    commands
+                        .entity(collider.entity())
+                        .remove_bundle::<ColliderBundle>();
+                    self.removed_colliders.push(collider);
+                }
+            }
+        }
+
+        for removed_collider in self.removed_colliders.iter() {
+            if let Some(parent) = self.colliders_parent.remove(removed_collider) {
+                let rb_changes: Option<RigidBodyChanges> = bodies.get(parent.0).copied();
+
+                if let Some(mut rb_changes) = rb_changes {
+                    // Keep track of the fact the collider will be modified.
+                    if !rb_changes.contains(RigidBodyChanges::MODIFIED) {
+                        self.modified_bodies.push(parent);
+                    }
+
+                    // Detach the collider from the rigid-body.
+                    bodies.map_mut_internal(parent.0, |rb_colliders: &mut RigidBodyColliders| {
+                        rb_colliders.detach_collider(&mut rb_changes, *removed_collider);
+                    });
+
+                    // Set the new rigid-body changes flags.
+                    bodies.set_internal(parent.0, rb_changes);
+
+                    // Update the body's colliders map `self.body_colliders`.
+                    let body_colliders = self.body_colliders.get_mut(&parent).unwrap();
+                    if let Some(i) = body_colliders.iter().position(|c| *c == *removed_collider) {
+                        body_colliders.swap_remove(i);
+                    }
+                }
+            }
+        }
+
+        for removed_joints in self.removed_joints.iter() {
+            let joint_handle = joints_map.0.remove(&removed_joints.entity());
+            if let Some(joint_handle) = joint_handle {
+                joints.remove(joint_handle, islands, bodies, true);
+            }
+        }
+    }
+}
+
+pub trait PhysicsHooksWithQuery<UserData: WorldQuery>: Send + Sync {
+    fn active_hooks(&self, user_data: &Query<UserData>) -> PhysicsHooksFlags;
+
+    fn filter_contact_pair(
+        &self,
+        _context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+        _user_data: &Query<UserData>,
+    ) -> Option<SolverFlags> {
+        None
+    }
+
+    fn filter_intersection_pair(
+        &self,
+        _context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+        _user_data: &Query<UserData>,
+    ) -> bool {
+        false
+    }
+
+    fn modify_solver_contacts(
+        &self,
+        _context: &mut ContactModificationContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+        _user_data: &Query<UserData>,
+    ) {
+    }
+}
+
+impl<T, UserData> PhysicsHooksWithQuery<UserData> for T
+where
+    T: for<'a, 'b, 'c, 'd, 'e, 'f> PhysicsHooks<
+        RigidBodyComponentsSet<'a, 'b, 'c>,
+        ColliderComponentsSet<'d, 'e, 'f>,
+    >,
+    UserData: WorldQuery,
+{
+    fn active_hooks(&self, _: &Query<UserData>) -> PhysicsHooksFlags {
+        PhysicsHooks::active_hooks(self)
+    }
+
+    fn filter_intersection_pair(
+        &self,
+        context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+        _: &Query<UserData>,
+    ) -> bool {
+        PhysicsHooks::filter_intersection_pair(self, context)
+    }
+
+    fn modify_solver_contacts(
+        &self,
+        context: &mut ContactModificationContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+        _: &Query<UserData>,
+    ) {
+        PhysicsHooks::modify_solver_contacts(self, context)
+    }
+}
+
+pub struct PhysicsHooksWithQueryObject<UserData: WorldQuery>(
+    pub Box<dyn PhysicsHooksWithQuery<UserData>>,
+);
+
+pub(crate) struct PhysicsHooksWithQueryInstance<'a, 'b, UserData: WorldQuery> {
+    pub user_data: Query<'a, UserData>,
+    pub hooks: &'b dyn PhysicsHooksWithQuery<UserData>,
+}
+
+impl<'aa, 'bb, 'a, 'b, 'c, 'd, 'e, 'f, UserData: WorldQuery>
+    PhysicsHooks<RigidBodyComponentsSet<'a, 'b, 'c>, ColliderComponentsSet<'d, 'e, 'f>>
+    for PhysicsHooksWithQueryInstance<'aa, 'bb, UserData>
+{
+    fn active_hooks(&self) -> PhysicsHooksFlags {
+        self.hooks.active_hooks(&self.user_data)
+    }
+
+    fn filter_contact_pair(
+        &self,
+        context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+    ) -> Option<SolverFlags> {
+        self.hooks.filter_contact_pair(context, &self.user_data)
+    }
+
+    fn filter_intersection_pair(
+        &self,
+        context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+    ) -> bool {
+        self.hooks
+            .filter_intersection_pair(context, &self.user_data)
+    }
+
+    fn modify_solver_contacts(
+        &self,
+        context: &mut ContactModificationContext<RigidBodyComponentsSet, ColliderComponentsSet>,
+    ) {
+        self.hooks.modify_solver_contacts(context, &self.user_data)
+    }
 }

--- a/src/physics/rigid_body_component_set.rs
+++ b/src/physics/rigid_body_component_set.rs
@@ -1,0 +1,141 @@
+use super::{IntoEntity, IntoHandle};
+use crate::rapier::dynamics::{
+    RigidBodyActivation, RigidBodyCcd, RigidBodyChanges, RigidBodyColliders, RigidBodyDamping,
+    RigidBodyDominance, RigidBodyForces, RigidBodyHandle, RigidBodyIds, RigidBodyMassProps,
+    RigidBodyPosition, RigidBodyType, RigidBodyVelocity,
+};
+use crate::rapier::geometry::ColliderHandle;
+use bevy::prelude::*;
+use rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
+
+impl IntoHandle<RigidBodyHandle> for Entity {
+    fn handle(self) -> RigidBodyHandle {
+        RigidBodyHandle::from_raw_parts(self.id(), self.generation())
+    }
+}
+
+impl IntoEntity for RigidBodyHandle {
+    fn entity(self) -> Entity {
+        self.0.entity()
+    }
+}
+
+pub type RigidBodyComponentsQuery<'a, 'b, 'c> = QuerySet<(
+    Query<
+        'a,
+        (
+            Entity,
+            &'b RigidBodyPosition,
+            &'b RigidBodyVelocity,
+            &'b RigidBodyMassProps,
+            &'b RigidBodyIds,
+            &'b RigidBodyForces,
+            &'b RigidBodyActivation,
+            &'b RigidBodyChanges,
+            &'b RigidBodyCcd,
+            &'b RigidBodyColliders,
+            &'b RigidBodyDamping,
+            &'b RigidBodyDominance,
+            &'b RigidBodyType,
+        ),
+    >,
+    Query<
+        'a,
+        (
+            Entity,
+            &'c mut RigidBodyPosition,
+            &'c mut RigidBodyVelocity,
+            &'c mut RigidBodyMassProps,
+            &'c mut RigidBodyIds,
+            &'c mut RigidBodyForces,
+            &'c mut RigidBodyActivation,
+            &'c mut RigidBodyChanges,
+            &'c mut RigidBodyCcd,
+            // Need for handling collider removals.
+            &'c mut RigidBodyColliders,
+        ),
+    >,
+    Query<
+        'a,
+        (
+            Entity,
+            &'c mut RigidBodyChanges,
+            &'c mut RigidBodyActivation,
+            Or<(Changed<RigidBodyPosition>, Added<RigidBodyPosition>)>,
+            Or<(Changed<RigidBodyVelocity>, Added<RigidBodyVelocity>)>,
+            Or<(Changed<RigidBodyForces>, Added<RigidBodyForces>)>,
+            Or<(Changed<RigidBodyType>, Added<RigidBodyType>)>,
+            Or<(Changed<RigidBodyColliders>, Added<RigidBodyColliders>)>,
+        ),
+        Or<(
+            Changed<RigidBodyPosition>,
+            Added<RigidBodyPosition>,
+            Changed<RigidBodyVelocity>,
+            Added<RigidBodyVelocity>,
+            Changed<RigidBodyForces>,
+            Added<RigidBodyForces>,
+            Changed<RigidBodyActivation>,
+            Added<RigidBodyActivation>,
+            Changed<RigidBodyType>,
+            Added<RigidBodyType>,
+            Changed<RigidBodyColliders>,
+            Added<RigidBodyColliders>,
+        )>,
+    >,
+    Query<
+        'a,
+        &'c mut RigidBodyChanges,
+        Or<(Changed<RigidBodyActivation>, Added<RigidBodyActivation>)>,
+    >,
+)>;
+
+pub struct RigidBodyComponentsSet<'a, 'b, 'c>(pub RigidBodyComponentsQuery<'a, 'b, 'c>);
+
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyPosition, |data| data.1);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyVelocity, |data| data.2);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyMassProps, |data| data.3);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyIds, |data| data.4);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyForces, |data| data.5);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyActivation, |data| data.6);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyChanges, |data| data.7);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyCcd, |data| data.8);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyColliders, |data| data.9);
+
+impl_component_set!(RigidBodyComponentsSet, RigidBodyDamping, |data| data.10);
+impl_component_set!(RigidBodyComponentsSet, RigidBodyDominance, |data| data.11);
+impl_component_set!(RigidBodyComponentsSet, RigidBodyType, |data| data.12);
+
+#[derive(Bundle)]
+pub struct RigidBodyBundle {
+    pub body_type: RigidBodyType,
+    pub position: RigidBodyPosition,
+    pub velocity: RigidBodyVelocity,
+    pub mass_properties: RigidBodyMassProps,
+    pub forces: RigidBodyForces,
+    pub activation: RigidBodyActivation,
+    pub damping: RigidBodyDamping,
+    pub dominance: RigidBodyDominance,
+    pub ccd: RigidBodyCcd,
+    pub changes: RigidBodyChanges,
+    pub ids: RigidBodyIds,
+    pub colliders: RigidBodyColliders,
+}
+
+impl Default for RigidBodyBundle {
+    fn default() -> Self {
+        Self {
+            body_type: RigidBodyType::Dynamic,
+            position: RigidBodyPosition::default(),
+            velocity: RigidBodyVelocity::default(),
+            mass_properties: RigidBodyMassProps::default(),
+            forces: RigidBodyForces::default(),
+            activation: RigidBodyActivation::default(),
+            damping: RigidBodyDamping::default(),
+            dominance: RigidBodyDominance::default(),
+            ccd: RigidBodyCcd::default(),
+            changes: RigidBodyChanges::default(),
+            ids: RigidBodyIds::default(),
+            colliders: RigidBodyColliders::default(),
+        }
+    }
+}

--- a/src/physics/rigid_body_component_set.rs
+++ b/src/physics/rigid_body_component_set.rs
@@ -4,7 +4,6 @@ use crate::rapier::dynamics::{
     RigidBodyDominance, RigidBodyForces, RigidBodyHandle, RigidBodyIds, RigidBodyMassProps,
     RigidBodyPosition, RigidBodyType, RigidBodyVelocity,
 };
-use crate::rapier::geometry::ColliderHandle;
 use bevy::prelude::*;
 use rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
 

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -355,7 +355,7 @@ pub fn step_world_system<UserData: 'static + WorldQuery>(
     }
 
     if configuration.query_pipeline_active {
-        query_pipeline.update(
+        query_pipeline.update_generic(
             &islands,
             &mut rigid_body_components_set,
             &collider_components_set,

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -1,22 +1,21 @@
 use crate::physics::{
-    ColliderComponentsQuery, ColliderComponentsSet, ColliderHandleComponent, ColliderPositionSync,
-    ComponentSetQueryMut, EventQueue, InteractionPairFilters, IntoEntity, IntoHandle,
-    JointBuilderComponent, JointHandleComponent, JointsEntityMap, ModificationTracker,
-    PhysicsHooksWithQueryInstance, PhysicsHooksWithQueryObject, PhysicsInterpolationComponent,
-    QueryComponentSetMut, RapierConfiguration, RigidBodyComponentsQuery, RigidBodyComponentsSet,
+    ColliderComponentsQuery, ColliderComponentsSet, ColliderPositionSync, ComponentSetQueryMut,
+    EventQueue, IntoEntity, IntoHandle, JointBuilderComponent, JointHandleComponent,
+    JointsEntityMap, ModificationTracker, PhysicsHooksWithQueryInstance,
+    PhysicsHooksWithQueryObject, PhysicsInterpolationComponent, QueryComponentSetMut,
+    RapierConfiguration, RigidBodyComponentsQuery, RigidBodyComponentsSet,
     RigidBodyHandleComponent, RigidBodyPositionSync, SimulationToRenderTime,
 };
 
 use crate::rapier::dynamics::{
-    RigidBodyCcd, RigidBodyChanges, RigidBodyColliders, RigidBodyHandle, RigidBodyIds,
-    RigidBodyMassProps, RigidBodyPosition,
+    RigidBodyCcd, RigidBodyChanges, RigidBodyColliders, RigidBodyIds, RigidBodyMassProps,
+    RigidBodyPosition,
 };
 use crate::rapier::geometry::{
     ColliderBroadPhaseData, ColliderChanges, ColliderMassProperties, ColliderParent,
     ColliderPosition, ColliderShape,
 };
-use crate::rapier::pipeline::{PhysicsHooks, QueryPipeline};
-use bevy::ecs::component::Component;
+use crate::rapier::pipeline::QueryPipeline;
 use bevy::ecs::query::WorldQuery;
 use bevy::prelude::*;
 use rapier::dynamics::{CCDSolver, IntegrationParameters, IslandManager, JointSet};
@@ -137,7 +136,7 @@ pub fn create_joints_system(
     mut joints: ResMut<JointSet>,
     mut joints_entity_map: ResMut<JointsEntityMap>,
     query: Query<(Entity, &JointBuilderComponent)>,
-    mut bodies: ComponentSetQueryMut<RigidBodyIds>,
+    bodies: ComponentSetQueryMut<RigidBodyIds>,
 ) {
     let mut bodies = QueryComponentSetMut(bodies);
 
@@ -255,7 +254,7 @@ pub fn step_world_system<UserData: 'static + WorldQuery>(
                 if sim_to_render_time.diff - sim_dt < sim_dt {
                     // This is the last simulation step to be executed in the loop
                     // Update the previous state transforms
-                    for (body_handle, mut previous_state) in query.iter_mut() {
+                    for (_body_handle, _previous_state) in query.iter_mut() {
                         // TODO ECS: how to do this?
                         // if let Some(body) = bodies.get(body_handle.handle()) {
                         //     previous_state.0 = Some(*body.position());

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -131,55 +131,6 @@ pub fn attach_bodies_and_colliders_system(
     // }
 }
 
-#[test]
-fn test_joint_creation_ordering() {
-    use super::RapierPhysicsPlugin;
-    #[cfg(feature = "dim2")]
-    use na::Point2;
-    #[cfg(feature = "dim3")]
-    use na::Point3;
-    use rapier::dynamics::BallJoint;
-
-    let mut app = App::build();
-    app.init_resource::<Time>().add_plugin(RapierPhysicsPlugin);
-
-    let rigid_body_1 = RigidBodyBuilder::new_dynamic();
-    let rigid_body_2 = RigidBodyBuilder::new_dynamic();
-
-    let body_1_entity = app.world_mut().spawn().insert(rigid_body_1).id();
-
-    let body_2_entity = app.world_mut().spawn().insert(rigid_body_2).id();
-
-    #[cfg(feature = "dim2")]
-    let joint = BallJoint::new(Point2::origin(), Point2::origin());
-    #[cfg(feature = "dim3")]
-    let joint = BallJoint::new(Point3::origin(), Point3::origin());
-
-    let joint_entity = app
-        .world_mut()
-        .spawn()
-        .insert_bundle((JointBuilderComponent::new(
-            joint,
-            body_1_entity,
-            body_2_entity,
-        ),))
-        .id();
-
-    app.app.update();
-
-    let joint_handle = app
-        .world_mut()
-        .get::<JointHandleComponent>(joint_entity)
-        .unwrap()
-        .handle();
-
-    let entity_maps = app.world_mut().get_resource::<EntityMaps>().unwrap();
-    assert_eq!(entity_maps.joints[&joint_entity], joint_handle);
-
-    let joint_set = app.world_mut().get_resource::<JointSet>().unwrap();
-    assert!(joint_set.get(joint_handle).is_some());
-}
-
 /// System responsible for creating Rapier joints from their builder resources.
 pub fn create_joints_system(
     mut commands: Commands,

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -1,211 +1,134 @@
 use crate::physics::{
-    ColliderHandleComponent, EntityMaps, EventQueue, InteractionPairFilters, JointBuilderComponent,
-    JointHandleComponent, PhysicsInterpolationComponent, RapierConfiguration,
-    RigidBodyHandleComponent, SimulationToRenderTime,
+    ColliderComponentsQuery, ColliderComponentsSet, ColliderHandleComponent, ColliderPositionSync,
+    ComponentSetQueryMut, EventQueue, InteractionPairFilters, IntoEntity, IntoHandle,
+    JointBuilderComponent, JointHandleComponent, JointsEntityMap, ModificationTracker,
+    PhysicsHooksWithQueryInstance, PhysicsHooksWithQueryObject, PhysicsInterpolationComponent,
+    QueryComponentSetMut, RapierConfiguration, RigidBodyComponentsQuery, RigidBodyComponentsSet,
+    RigidBodyHandleComponent, RigidBodyPositionSync, SimulationToRenderTime,
 };
 
-use crate::rapier::pipeline::{PhysicsHooks, QueryPipeline};
-use bevy::prelude::*;
-use rapier::dynamics::{
-    CCDSolver, IntegrationParameters, JointSet, RigidBodyBuilder, RigidBodySet,
+use crate::rapier::dynamics::{
+    RigidBodyCcd, RigidBodyChanges, RigidBodyColliders, RigidBodyHandle, RigidBodyIds,
+    RigidBodyMassProps, RigidBodyPosition,
 };
-use rapier::geometry::{BroadPhase, ColliderBuilder, ColliderSet, NarrowPhase};
+use crate::rapier::geometry::{
+    ColliderBroadPhaseData, ColliderChanges, ColliderMassProperties, ColliderParent,
+    ColliderPosition, ColliderShape,
+};
+use crate::rapier::pipeline::{PhysicsHooks, QueryPipeline};
+use bevy::ecs::component::Component;
+use bevy::ecs::query::WorldQuery;
+use bevy::prelude::*;
+use rapier::dynamics::{CCDSolver, IntegrationParameters, IslandManager, JointSet};
+use rapier::geometry::{BroadPhase, NarrowPhase};
 use rapier::math::Isometry;
 use rapier::pipeline::PhysicsPipeline;
 
 /// System responsible for creating a Rapier rigid-body and collider from their
 /// builder resources.
-pub fn create_body_and_collider_system(
+pub fn attach_bodies_and_colliders_system(
     mut commands: Commands,
-    mut bodies: ResMut<RigidBodySet>,
-    mut colliders: ResMut<ColliderSet>,
-    mut entity_maps: ResMut<EntityMaps>,
-    standalone_body_query: Query<(Entity, &RigidBodyBuilder), Without<ColliderBuilder>>,
-    body_and_collider_query: Query<(Entity, &RigidBodyBuilder, &ColliderBuilder)>,
-    parented_collider_query: Query<(Entity, &Parent, &ColliderBuilder), Without<RigidBodyBuilder>>,
-) {
-    for (entity, body_builder) in standalone_body_query.iter() {
-        let handle = bodies.insert(body_builder.build());
-        commands
-            .entity(entity)
-            .insert(RigidBodyHandleComponent::from(handle))
-            .remove::<RigidBodyBuilder>();
-        entity_maps.bodies.insert(entity, handle);
-    }
-
-    for (entity, body_builder, collider_builder) in body_and_collider_query.iter() {
-        let handle = bodies.insert(body_builder.build());
-        commands
-            .entity(entity)
-            .insert(RigidBodyHandleComponent::from(handle))
-            .remove::<RigidBodyBuilder>();
-        entity_maps.bodies.insert(entity, handle);
-
-        let handle = colliders.insert(collider_builder.build(), handle, &mut bodies);
-        commands
-            .entity(entity)
-            .insert(ColliderHandleComponent::from(handle))
-            .remove::<ColliderBuilder>();
-        entity_maps.colliders.insert(entity, handle);
-    }
-
-    for (entity, parent, collider_builder) in parented_collider_query.iter() {
-        if let Some(body_handle) = entity_maps.bodies.get(&parent.0) {
-            let handle = colliders.insert(collider_builder.build(), *body_handle, &mut bodies);
-            commands
-                .entity(entity)
-                .insert(ColliderHandleComponent::from(handle))
-                .remove::<ColliderBuilder>();
-            entity_maps.colliders.insert(entity, handle);
-        } // warn here? panic here? do nothing?
-    }
-}
-
-/// System responsible for replacing colliders on existing bodies when a new
-/// builder is added.
-///
-/// NOTE: This only adds new colliders, the old collider is actually removed
-/// by `destroy_body_and_collider_system`
-pub fn update_collider_system(
-    mut commands: Commands,
-    mut bodies: ResMut<RigidBodySet>,
-    mut colliders: ResMut<ColliderSet>,
-    mut entity_maps: ResMut<EntityMaps>,
-    with_body_query: Query<
-        (Entity, &RigidBodyHandleComponent, &ColliderBuilder),
-        With<ColliderHandleComponent>,
-    >,
-    without_body_query: Query<
-        (Entity, &Parent, &ColliderBuilder),
+    mut modif_tracker: ResMut<ModificationTracker>,
+    mut body_query: Query<(
+        // Rigid-bodies.
+        &mut RigidBodyChanges,
+        &mut RigidBodyCcd,
+        &mut RigidBodyColliders,
+        &mut RigidBodyMassProps,
+        &RigidBodyPosition,
+    )>,
+    mut colliders_query: Query<
         (
-            Without<RigidBodyHandleComponent>,
-            With<ColliderHandleComponent>,
+            Entity,
+            Option<&Parent>,
+            // Collider.
+            &mut ColliderChanges,
+            &mut ColliderBroadPhaseData,
+            &mut ColliderPosition,
+            &ColliderShape,
+            &ColliderMassProperties,
         ),
+        Without<ColliderParent>,
     >,
 ) {
-    for (entity, body_handle, collider_builder) in with_body_query.iter() {
-        let handle = colliders.insert(collider_builder.build(), body_handle.handle(), &mut bodies);
-        commands
-            .entity(entity)
-            .insert(ColliderHandleComponent::from(handle));
-        commands.entity(entity).remove::<ColliderBuilder>();
-        entity_maps.colliders.insert(entity, handle);
-    }
+    for (
+        collider_entity,
+        parent_entity,
+        mut co_changes,
+        mut co_bf_data,
+        mut co_pos,
+        co_shape,
+        co_mprops,
+    ) in colliders_query.iter_mut()
+    {
+        let body_entity;
 
-    for (entity, parent, collider_builder) in without_body_query.iter() {
-        if let Some(body_handle) = entity_maps.bodies.get(&parent.0) {
-            let handle = colliders.insert(collider_builder.build(), *body_handle, &mut bodies);
-            commands
-                .entity(entity)
-                .insert(ColliderHandleComponent::from(handle));
-            commands.entity(entity).remove::<ColliderBuilder>();
-            entity_maps.colliders.insert(entity, handle);
+        if body_query.get_mut(collider_entity).is_ok() {
+            // The body and collider are attached to the same entity.
+            body_entity = collider_entity;
+        } else if let Some(parent_entity) = parent_entity {
+            body_entity = parent_entity.0;
+        } else {
+            continue;
+        }
+
+        if let Ok((mut rb_changes, mut rb_ccd, mut rb_colliders, mut rb_mprops, rb_pos)) =
+            body_query.get_mut(body_entity)
+        {
+            // Contract:
+            // - Reset collider's references.
+            // - Set collider's parent handle.
+            // - Attach the collider to the body.
+            let co_parent = ColliderParent {
+                pos_wrt_parent: co_pos.0,
+                handle: body_entity.handle(),
+            };
+
+            // Update the modification tracker.
+            // NOTE: this must be done before the `.attach_collider` because
+            //       `.attach_collider` will set the `MODIFIED` flag.
+            if !rb_changes.contains(RigidBodyChanges::MODIFIED) {
+                modif_tracker.modified_bodies.push(body_entity.handle());
+            }
+
+            modif_tracker
+                .body_colliders
+                .entry(body_entity.handle())
+                .or_insert(vec![])
+                .push(collider_entity.handle());
+            modif_tracker
+                .colliders_parent
+                .insert(collider_entity.handle(), body_entity.handle());
+
+            *co_changes = ColliderChanges::default();
+            *co_bf_data = ColliderBroadPhaseData::default();
+            rb_colliders.attach_collider(
+                &mut rb_changes,
+                &mut rb_ccd,
+                &mut rb_mprops,
+                &rb_pos,
+                collider_entity.handle(),
+                &mut co_pos,
+                &co_parent,
+                &co_shape,
+                &co_mprops,
+            );
+
+            commands.entity(collider_entity).insert(co_parent);
         }
     }
-}
 
-#[test]
-fn test_create_body_and_collider_system() {
-    use bevy::ecs::schedule::Schedule;
-
-    let mut world = World::new();
-
-    world.insert_resource(RigidBodySet::new());
-    world.insert_resource(ColliderSet::new());
-    world.insert_resource(EntityMaps::default());
-
-    let body_and_collider_entity = world
-        .spawn()
-        .insert_bundle((RigidBodyBuilder::new_dynamic(), ColliderBuilder::ball(1.0)))
-        .id();
-
-    let body_only_entity = world
-        .spawn()
-        .insert_bundle((
-            RigidBodyBuilder::new_static(),
-            Parent(body_and_collider_entity),
-        ))
-        .id();
-
-    let parented_collider_entity_1 = world
-        .spawn()
-        .insert_bundle((Parent(body_and_collider_entity), ColliderBuilder::ball(0.5)))
-        .id();
-
-    let parented_collider_entity_2 = world
-        .spawn()
-        .insert_bundle((Parent(body_only_entity), ColliderBuilder::ball(0.25)))
-        .id();
-
-    let mut schedule = Schedule::default();
-    schedule.add_stage("physics_test", SystemStage::parallel());
-    schedule.add_system_to_stage("physics_test", create_body_and_collider_system.system());
-    schedule.run(&mut world);
-
-    let body_set = world.get_resource::<RigidBodySet>().unwrap();
-    let collider_set = world.get_resource::<ColliderSet>().unwrap();
-    let entity_maps = world.get_resource::<EntityMaps>().unwrap();
-
-    // body attached alongside collider
-    let attached_body_handle = world
-        .get::<RigidBodyHandleComponent>(body_and_collider_entity)
-        .unwrap()
-        .handle();
-    assert_eq!(
-        entity_maps.bodies[&body_and_collider_entity],
-        attached_body_handle
-    );
-    assert!(body_set.get(attached_body_handle).unwrap().is_dynamic());
-
-    // collider attached from same entity
-    let collider_handle = world
-        .get::<ColliderHandleComponent>(body_and_collider_entity)
-        .unwrap()
-        .handle();
-    assert_eq!(
-        entity_maps.colliders[&body_and_collider_entity],
-        collider_handle
-    );
-    let collider = collider_set.get(collider_handle).unwrap();
-    assert_eq!(attached_body_handle, collider.parent());
-    assert_eq!(collider.shape().as_ball().unwrap().radius, 1.0);
-
-    // collider attached to child entity of body with collider
-    let collider_handle = world
-        .get::<ColliderHandleComponent>(parented_collider_entity_1)
-        .unwrap()
-        .handle();
-    assert_eq!(
-        entity_maps.colliders[&parented_collider_entity_1],
-        collider_handle
-    );
-    let collider = collider_set.get(collider_handle).unwrap();
-    assert_eq!(attached_body_handle, collider.parent());
-    assert_eq!(collider.shape().as_ball().unwrap().radius, 0.5);
-
-    // standalone body with no collider, jointed to the attached body
-    let standalone_body_handle = world
-        .get::<RigidBodyHandleComponent>(body_only_entity)
-        .unwrap()
-        .handle();
-    assert_eq!(
-        entity_maps.bodies[&body_only_entity],
-        standalone_body_handle
-    );
-    assert!(body_set.get(standalone_body_handle).unwrap().is_static());
-
-    // collider attached to child entity of standlone body
-    let collider_handle = world
-        .get::<ColliderHandleComponent>(parented_collider_entity_2)
-        .unwrap()
-        .handle();
-    assert_eq!(
-        entity_maps.colliders[&parented_collider_entity_2],
-        collider_handle
-    );
-    let collider = collider_set.get(collider_handle).unwrap();
-    assert_eq!(standalone_body_handle, collider.parent());
-    assert_eq!(collider.shape().as_ball().unwrap().radius, 0.25);
+    // TODO ECS
+    // for (entity, parent, collider) in parented_collider_query.iter() {
+    //     if let Some(body_handle) = joints_entity_map.bodies.get(&parent.0) {
+    //         let handle = colliders.insert(collider.build(), *body_handle, &mut bodies);
+    //         commands
+    //             .entity(entity)
+    //             .insert(ColliderHandleComponent::from(handle))
+    //             .remove::<ColliderBuilder>();
+    //         joints_entity_map.colliders.insert(entity, handle);
+    //     } // warn here? panic here? do nothing?
+    // }
 }
 
 #[test]
@@ -260,53 +183,113 @@ fn test_joint_creation_ordering() {
 /// System responsible for creating Rapier joints from their builder resources.
 pub fn create_joints_system(
     mut commands: Commands,
-    mut bodies: ResMut<RigidBodySet>,
     mut joints: ResMut<JointSet>,
-    mut entity_maps: ResMut<EntityMaps>,
+    mut joints_entity_map: ResMut<JointsEntityMap>,
     query: Query<(Entity, &JointBuilderComponent)>,
+    mut bodies: ComponentSetQueryMut<RigidBodyIds>,
 ) {
+    let mut bodies = QueryComponentSetMut(bodies);
+
     for (entity, joint) in &mut query.iter() {
-        let body1 = entity_maps.bodies.get(&joint.entity1);
-        let body2 = entity_maps.bodies.get(&joint.entity2);
-        if let (Some(body1), Some(body2)) = (body1, body2) {
-            let handle = joints.insert(&mut bodies, *body1, *body2, joint.params);
-            commands
-                .entity(entity)
-                .insert(JointHandleComponent::new(
-                    handle,
-                    joint.entity1,
-                    joint.entity2,
-                ))
-                .remove::<JointBuilderComponent>();
-            entity_maps.joints.insert(entity, handle);
+        // Make sure the rigid-bodies the joint it attached to exist.
+        if bodies
+            .0
+            .q0()
+            .get_component::<RigidBodyIds>(joint.entity1)
+            .is_err()
+            || bodies
+                .0
+                .q0()
+                .get_component::<RigidBodyIds>(joint.entity2)
+                .is_err()
+        {
+            continue;
         }
+
+        let handle = joints.insert(
+            &mut bodies,
+            joint.entity1.handle(),
+            joint.entity2.handle(),
+            joint.params,
+        );
+        commands
+            .entity(entity)
+            .insert(JointHandleComponent::new(
+                handle,
+                joint.entity1,
+                joint.entity2,
+            ))
+            .remove::<JointBuilderComponent>();
+        joints_entity_map.0.insert(entity, handle);
     }
 }
 
 /// System responsible for performing one timestep of the physics world.
-pub fn step_world_system(
+pub fn step_world_system<UserData: 'static + WorldQuery>(
+    mut commands: Commands,
     (time, mut sim_to_render_time): (Res<Time>, ResMut<SimulationToRenderTime>),
     (configuration, integration_parameters): (Res<RapierConfiguration>, Res<IntegrationParameters>),
-    filters: Res<InteractionPairFilters>,
-    mut ccd_solver: ResMut<CCDSolver>,
-    (mut pipeline, mut query_pipeline): (ResMut<PhysicsPipeline>, ResMut<QueryPipeline>),
-    (mut broad_phase, mut narrow_phase): (ResMut<BroadPhase>, ResMut<NarrowPhase>),
-    mut bodies: ResMut<RigidBodySet>,
-    mut colliders: ResMut<ColliderSet>,
-    mut joints: ResMut<JointSet>,
+    mut modifs_tracker: ResMut<ModificationTracker>,
+    (
+        mut pipeline,
+        mut query_pipeline,
+        mut islands,
+        mut broad_phase,
+        mut narrow_phase,
+        mut ccd_solver,
+        mut joints,
+        mut joints_entity_map,
+    ): (
+        ResMut<PhysicsPipeline>,
+        ResMut<QueryPipeline>,
+        ResMut<IslandManager>,
+        ResMut<BroadPhase>,
+        ResMut<NarrowPhase>,
+        ResMut<CCDSolver>,
+        ResMut<JointSet>,
+        ResMut<JointsEntityMap>,
+    ),
     events: ResMut<EventQueue>,
+    hooks: Res<PhysicsHooksWithQueryObject<UserData>>,
+    user_data: Query<UserData>,
     mut query: Query<(
         &RigidBodyHandleComponent,
         &mut PhysicsInterpolationComponent,
     )>,
+    bodies_query: RigidBodyComponentsQuery,
+    colliders_query: ColliderComponentsQuery,
+    (removed_bodies, removed_colliders, removed_joints): (
+        RemovedComponents<RigidBodyChanges>,
+        RemovedComponents<ColliderChanges>,
+        RemovedComponents<JointHandleComponent>,
+    ),
 ) {
+    use std::mem::replace;
+
     if events.auto_clear {
         events.clear();
     }
 
-    let physics_hooks: &dyn PhysicsHooks = match &filters.hook {
-        Some(f) => f.as_ref(),
-        None => &(),
+    let mut rigid_body_components_set = RigidBodyComponentsSet(bodies_query);
+    let mut collider_components_set = ColliderComponentsSet(colliders_query);
+
+    modifs_tracker.detect_removals(removed_bodies, removed_colliders, removed_joints);
+    modifs_tracker.detect_modifications(
+        &mut rigid_body_components_set.0,
+        &mut collider_components_set.0,
+    );
+    modifs_tracker.propagate_removals(
+        &mut commands,
+        &mut islands,
+        &mut rigid_body_components_set,
+        &mut joints,
+        &mut joints_entity_map,
+    );
+    islands.cleanup_removed_rigid_bodies(&mut rigid_body_components_set);
+
+    let physics_hooks = PhysicsHooksWithQueryInstance {
+        user_data,
+        hooks: &*hooks.0,
     };
 
     if configuration.time_dependent_number_of_timesteps {
@@ -322,146 +305,157 @@ pub fn step_world_system(
                     // This is the last simulation step to be executed in the loop
                     // Update the previous state transforms
                     for (body_handle, mut previous_state) in query.iter_mut() {
-                        if let Some(body) = bodies.get(body_handle.handle()) {
-                            previous_state.0 = Some(*body.position());
-                        }
+                        // TODO ECS: how to do this?
+                        // if let Some(body) = bodies.get(body_handle.handle()) {
+                        //     previous_state.0 = Some(*body.position());
+                        // }
                     }
                 }
-                pipeline.step(
+
+                pipeline.step_generic(
                     &configuration.gravity,
                     &integration_parameters,
+                    &mut islands,
                     &mut broad_phase,
                     &mut narrow_phase,
-                    &mut bodies,
-                    &mut colliders,
+                    &mut rigid_body_components_set,
+                    &mut collider_components_set,
+                    &mut replace(&mut modifs_tracker.modified_bodies, vec![]),
+                    &mut replace(&mut modifs_tracker.modified_colliders, vec![]),
+                    &mut replace(&mut modifs_tracker.removed_colliders, vec![]),
                     &mut joints,
                     &mut ccd_solver,
-                    physics_hooks,
+                    &physics_hooks,
                     &*events,
                 );
+
+                modifs_tracker.clear_modified_and_removed();
             }
             sim_to_render_time.diff -= sim_dt;
         }
     } else if configuration.physics_pipeline_active {
-        pipeline.step(
+        pipeline.step_generic(
             &configuration.gravity,
             &integration_parameters,
+            &mut islands,
             &mut broad_phase,
             &mut narrow_phase,
-            &mut bodies,
-            &mut colliders,
+            &mut rigid_body_components_set,
+            &mut collider_components_set,
+            &mut replace(&mut modifs_tracker.modified_bodies, vec![]),
+            &mut replace(&mut modifs_tracker.modified_colliders, vec![]),
+            &mut replace(&mut modifs_tracker.removed_colliders, vec![]),
             &mut joints,
             &mut ccd_solver,
-            physics_hooks,
+            &physics_hooks,
             &*events,
         );
+
+        modifs_tracker.clear_modified_and_removed();
     }
 
     if configuration.query_pipeline_active {
-        query_pipeline.update(&mut bodies, &colliders);
+        query_pipeline.update(
+            &islands,
+            &mut rigid_body_components_set,
+            &collider_components_set,
+        );
     }
 }
 
 #[cfg(feature = "dim2")]
 pub(crate) fn sync_transform(pos: &Isometry<f32>, scale: f32, transform: &mut Transform) {
+    let (tra, rot) = (*pos).into();
     // Do not touch the 'z' part of the translation, used in Bevy for 2d layering
-    transform.translation.x = pos.translation.vector.x * scale;
-    transform.translation.y = pos.translation.vector.y * scale;
-
-    let rot = na::UnitQuaternion::new(na::Vector3::z() * pos.rotation.angle());
-    transform.rotation = Quat::from_xyzw(rot.i, rot.j, rot.k, rot.w);
+    transform.translation.x = tra.x * scale;
+    transform.translation.y = tra.y * scale;
+    transform.rotation = rot;
 }
 
 #[cfg(feature = "dim3")]
 pub(crate) fn sync_transform(pos: &Isometry<f32>, scale: f32, transform: &mut Transform) {
-    transform.translation = Vec3::new(
-        pos.translation.vector.x,
-        pos.translation.vector.y,
-        pos.translation.vector.z,
-    ) * scale;
-    transform.rotation = Quat::from_xyzw(
-        pos.rotation.i,
-        pos.rotation.j,
-        pos.rotation.k,
-        pos.rotation.w,
-    );
+    let (tra, rot) = (*pos).into();
+    transform.translation = tra * scale;
+    transform.rotation = rot;
 }
 
 /// System responsible for writing the rigid-bodies positions into the Bevy translation and rotation components.
-pub fn sync_transform_system(
+pub fn sync_transforms(
     sim_to_render_time: Res<SimulationToRenderTime>,
-    bodies: ResMut<RigidBodySet>,
     configuration: Res<RapierConfiguration>,
     integration_parameters: Res<IntegrationParameters>,
-    mut interpolation_query: Query<(
-        &RigidBodyHandleComponent,
-        &PhysicsInterpolationComponent,
-        &mut Transform,
+    rigid_body_sync_mode: Query<&RigidBodyPositionSync>,
+    // TODO: add some Changed filters to only sync when something moved?
+    mut sync_query: QuerySet<(
+        Query<(&RigidBodyPosition, &RigidBodyPositionSync, &mut Transform)>,
+        Query<(
+            &ColliderPosition,
+            &ColliderPositionSync,
+            Option<&ColliderParent>,
+            &mut Transform,
+            Option<&mut GlobalTransform>,
+        )>,
     )>,
-    mut direct_query: Query<
-        (&RigidBodyHandleComponent, &mut Transform),
-        Without<PhysicsInterpolationComponent>,
-    >,
 ) {
     let dt = sim_to_render_time.diff;
     let sim_dt = integration_parameters.dt;
     let alpha = dt / sim_dt;
-    for (rigid_body, previous_pos, mut transform) in interpolation_query.iter_mut() {
-        if let Some(rb) = bodies.get(rigid_body.handle()) {
-            // Predict position and orientation at render time
-            let mut pos = *rb.position();
 
-            if configuration.time_dependent_number_of_timesteps && previous_pos.0.is_some() {
-                pos = previous_pos.0.unwrap().lerp_slerp(rb.position(), alpha);
+    // Sync bodies.
+    for (rb_pos, sync_mode, mut transform) in sync_query.q0_mut().iter_mut() {
+        match sync_mode {
+            RigidBodyPositionSync::Discrete => {
+                sync_transform(&rb_pos.position, configuration.scale, &mut transform)
             }
+            RigidBodyPositionSync::Interpolated { prev_pos } => {
+                // Predict position and orientation at render time
+                let mut pos = rb_pos.position;
 
-            sync_transform(&pos, configuration.scale, &mut transform);
+                if configuration.time_dependent_number_of_timesteps && prev_pos.is_some() {
+                    pos = prev_pos.unwrap().lerp_slerp(&rb_pos.position, alpha);
+                }
+
+                sync_transform(&pos, configuration.scale, &mut transform);
+            }
         }
     }
-    for (rigid_body, mut transform) in direct_query.iter_mut() {
-        if let Some(rb) = bodies.get(rigid_body.handle()) {
-            sync_transform(rb.position(), configuration.scale, &mut transform);
+
+    // Sync colliders.
+    for (co_pos, _, co_parent, mut transform, mut global_transform) in
+        sync_query.q1_mut().iter_mut()
+    {
+        if let Some(co_parent) = co_parent {
+            if rigid_body_sync_mode.get(co_parent.handle.entity()).is_ok() {
+                println!("Syncing with parent");
+                // Sync the relative position instead of the actual collider position.
+                sync_transform(
+                    &co_parent.pos_wrt_parent,
+                    configuration.scale,
+                    &mut transform,
+                );
+
+                continue;
+            }
+        }
+
+        // Otherwise, sync the global position of the collider.
+        sync_transform(&co_pos, configuration.scale, &mut transform);
+
+        if let Some(global_transform) = global_transform.as_mut() {
+            global_transform.translation = transform.translation;
+            global_transform.rotation = transform.rotation;
+            global_transform.scale = transform.scale;
         }
     }
 }
 
-/// System responsible for removing joints, colliders, and bodies that have
-/// been removed from the scene
-pub fn destroy_body_and_collider_system(
-    mut commands: Commands,
-    mut bodies: ResMut<RigidBodySet>,
-    mut colliders: ResMut<ColliderSet>,
-    mut joints: ResMut<JointSet>,
-    mut entity_maps: ResMut<EntityMaps>,
-    bodies_removed: RemovedComponents<RigidBodyHandleComponent>,
-    colliders_removed: RemovedComponents<ColliderHandleComponent>,
-    joints_removed: RemovedComponents<JointHandleComponent>,
+/// System responsible for collecting the entities with removed rigid-bodies, colliders,
+/// or joints.
+pub fn collect_removals(
+    mut modification_tracker: ResMut<ModificationTracker>,
+    removed_bodies: RemovedComponents<RigidBodyChanges>,
+    removed_colliders: RemovedComponents<ColliderChanges>,
+    removed_joints: RemovedComponents<JointHandleComponent>,
 ) {
-    for entity in bodies_removed.iter() {
-        if let Some(body_handle) = entity_maps.bodies.get(&entity) {
-            bodies.remove(*body_handle, &mut colliders, &mut joints);
-            entity_maps.bodies.remove(&entity);
-
-            // Removing a body also removes its colliders and joints. If they were
-            // not also removed then we must remove them here.
-            entity_maps.colliders.remove(&entity);
-            entity_maps.joints.remove(&entity);
-            commands
-                .entity(entity)
-                .remove::<ColliderHandleComponent>()
-                .remove::<JointHandleComponent>();
-        }
-    }
-    for entity in colliders_removed.iter() {
-        if let Some(collider_handle) = entity_maps.colliders.get(&entity) {
-            colliders.remove(*collider_handle, &mut bodies, true);
-            entity_maps.colliders.remove(&entity);
-        }
-    }
-    for entity in joints_removed.iter() {
-        if let Some(joint_handle) = entity_maps.joints.get(&entity) {
-            joints.remove(*joint_handle, &mut bodies, true);
-            entity_maps.joints.remove(&entity);
-        }
-    }
+    modification_tracker.detect_removals(removed_bodies, removed_colliders, removed_joints);
 }

--- a/src/render/components.rs
+++ b/src/render/components.rs
@@ -1,2 +1,44 @@
+use bevy::prelude::Color;
+
 /// The desired render color of a Rapier collider.
-pub struct RapierRenderColor(pub f32, pub f32, pub f32);
+#[derive(Copy, Clone)]
+pub struct ColliderDebugRender {
+    pub color: Color,
+}
+
+pub const DEFAULT_COLOR: Color = Color::BEIGE;
+pub const DEFAULT_PALETTE: [Color; 3] = [
+    Color::rgb(
+        0x98 as f32 / 255.0,
+        0xC1 as f32 / 255.0,
+        0xD9 as f32 / 255.0,
+    ),
+    Color::rgb(
+        0x05 as f32 / 255.0,
+        0x3C as f32 / 255.0,
+        0x5E as f32 / 255.0,
+    ),
+    Color::rgb(
+        0x1F as f32 / 255.0,
+        0x7A as f32 / 255.0,
+        0x8C as f32 / 255.0,
+    ),
+];
+
+impl Default for ColliderDebugRender {
+    fn default() -> Self {
+        DEFAULT_COLOR.into()
+    }
+}
+
+impl From<Color> for ColliderDebugRender {
+    fn from(color: Color) -> Self {
+        ColliderDebugRender { color }
+    }
+}
+
+impl ColliderDebugRender {
+    pub fn with_id(i: usize) -> Self {
+        DEFAULT_PALETTE[i % DEFAULT_PALETTE.len()].into()
+    }
+}

--- a/src/render/plugins.rs
+++ b/src/render/plugins.rs
@@ -10,5 +10,9 @@ impl Plugin for RapierRenderPlugin {
             CoreStage::PreUpdate,
             systems::create_collider_renders_system.system(),
         );
+        app.add_system_to_stage(
+            CoreStage::PreUpdate,
+            systems::update_collider_render_mesh.system(),
+        );
     }
 }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -1,11 +1,9 @@
-use crate::physics::{ColliderHandleComponent, IntoEntity, RapierConfiguration};
-use crate::rapier::dynamics::RigidBodyType;
-use crate::rapier::geometry::{ColliderParent, ColliderPosition, ColliderShape};
+use crate::physics::RapierConfiguration;
+use crate::rapier::geometry::ColliderShape;
 use crate::render::ColliderDebugRender;
 use bevy::prelude::*;
 use bevy::render::mesh::{Indices, VertexAttributeValues};
 use rapier::geometry::ShapeType;
-use std::collections::HashMap;
 
 /// System responsible for attaching a PbrBundle to each entity having a collider.
 pub fn create_collider_renders_system(

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -1,9 +1,10 @@
-use crate::physics::{ColliderHandleComponent, RapierConfiguration};
-use crate::render::RapierRenderColor;
+use crate::physics::{ColliderHandleComponent, IntoEntity, RapierConfiguration};
+use crate::rapier::dynamics::RigidBodyType;
+use crate::rapier::geometry::{ColliderParent, ColliderPosition, ColliderShape};
+use crate::render::ColliderDebugRender;
 use bevy::prelude::*;
 use bevy::render::mesh::{Indices, VertexAttributeValues};
-use rapier::dynamics::RigidBodySet;
-use rapier::geometry::{ColliderSet, ShapeType};
+use rapier::geometry::ShapeType;
 use std::collections::HashMap;
 
 /// System responsible for attaching a PbrBundle to each entity having a collider.
@@ -12,196 +13,164 @@ pub fn create_collider_renders_system(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     configuration: Res<RapierConfiguration>,
-    bodies: Res<RigidBodySet>,
-    colliders: ResMut<ColliderSet>,
-    query: Query<
-        (Entity, &ColliderHandleComponent, Option<&RapierRenderColor>),
-        Or<(Without<Handle<Mesh>>, Changed<ColliderHandleComponent>)>,
+    colliders: Query<
+        (Entity, &ColliderShape, &ColliderDebugRender),
+        Without<Handle<Mesh>>, // Or<(Without<Handle<Mesh>>, Changed<ColliderHandleComponent>)>,
     >,
 ) {
-    let ground_color = Color::rgb(
-        0xF3 as f32 / 255.0,
-        0xD9 as f32 / 255.0,
-        0xB1 as f32 / 255.0,
-    );
+    for (entity, co_shape, co_debug) in &mut colliders.iter() {
+        if let Some((mesh, scale)) = generate_collider_mesh(co_shape) {
+            let ground_pbr = PbrBundle {
+                mesh: meshes.add(mesh),
+                material: materials.add(co_debug.color.into()),
+                transform: Transform::from_scale(scale * configuration.scale),
+                ..Default::default()
+            };
 
-    let palette = [
-        Color::rgb(
-            0x98 as f32 / 255.0,
-            0xC1 as f32 / 255.0,
-            0xD9 as f32 / 255.0,
-        ),
-        Color::rgb(
-            0x05 as f32 / 255.0,
-            0x3C as f32 / 255.0,
-            0x5E as f32 / 255.0,
-        ),
-        Color::rgb(
-            0x1F as f32 / 255.0,
-            0x7A as f32 / 255.0,
-            0x8C as f32 / 255.0,
-        ),
-    ];
-
-    let mut icolor = 0;
-    let mut body_colors = HashMap::new();
-
-    for (entity, collider, debug_color) in &mut query.iter() {
-        if let Some(collider) = colliders.get(collider.handle()) {
-            if let Some(body) = bodies.get(collider.parent()) {
-                let default_color = if body.is_static() {
-                    ground_color
-                } else {
-                    *body_colors.entry(collider.parent()).or_insert_with(|| {
-                        icolor += 1;
-                        palette[icolor % palette.len()]
-                    })
-                };
-
-                let shape = collider.shape();
-
-                let color = debug_color
-                    .map(|c| Color::rgb(c.0, c.1, c.2))
-                    .unwrap_or(default_color);
-
-                let mesh = match shape.shape_type() {
-                    #[cfg(feature = "dim3")]
-                    ShapeType::Cuboid => Mesh::from(shape::Cube { size: 2.0 }),
-                    #[cfg(feature = "dim2")]
-                    ShapeType::Cuboid => Mesh::from(shape::Quad {
-                        size: Vec2::new(2.0, 2.0),
-                        flip: false,
-                    }),
-                    ShapeType::Ball => Mesh::from(shape::Icosphere {
-                        subdivisions: 2,
-                        radius: 1.0,
-                    }),
-                    #[cfg(feature = "dim2")]
-                    ShapeType::TriMesh => {
-                        let mut mesh =
-                            Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
-                        let trimesh = shape.as_trimesh().unwrap();
-                        mesh.set_attribute(
-                            Mesh::ATTRIBUTE_POSITION,
-                            VertexAttributeValues::from(
-                                trimesh
-                                    .vertices()
-                                    .iter()
-                                    .map(|vertice| [vertice.x, vertice.y])
-                                    .collect::<Vec<_>>(),
-                            ),
-                        );
-                        mesh.set_indices(Some(Indices::U32(
-                            trimesh
-                                .indices()
-                                .iter()
-                                .flat_map(|triangle| triangle.iter())
-                                .cloned()
-                                .collect(),
-                        )));
-                        mesh
-                    }
-                    #[cfg(feature = "dim3")]
-                    ShapeType::TriMesh => {
-                        let mut mesh =
-                            Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
-                        let trimesh = shape.as_trimesh().unwrap();
-                        mesh.set_attribute(
-                            Mesh::ATTRIBUTE_POSITION,
-                            VertexAttributeValues::from(
-                                trimesh
-                                    .vertices()
-                                    .iter()
-                                    .map(|vertex| [vertex.x, vertex.y, vertex.z])
-                                    .collect::<Vec<_>>(),
-                            ),
-                        );
-                        // Compute vertex normals by averaging the normals
-                        // of every triangle they appear in.
-                        // NOTE: This is a bit shonky, but good enough for visualisation.
-                        let verts = trimesh.vertices();
-                        let mut normals: Vec<Vec3> = vec![Vec3::ZERO; trimesh.vertices().len()];
-                        for triangle in trimesh.indices().iter() {
-                            let ab = verts[triangle[1] as usize] - verts[triangle[0] as usize];
-                            let ac = verts[triangle[2] as usize] - verts[triangle[0] as usize];
-                            let normal = ab.cross(&ac);
-                            // Contribute this normal to each vertex in the triangle.
-                            for i in 0..3 {
-                                normals[triangle[i] as usize] +=
-                                    Vec3::new(normal.x, normal.y, normal.z);
-                            }
-                        }
-                        let normals: Vec<[f32; 3]> = normals
-                            .iter()
-                            .map(|normal| {
-                                let normal = normal.normalize();
-                                [normal.x, normal.y, normal.z]
-                            })
-                            .collect();
-                        mesh.set_attribute(
-                            Mesh::ATTRIBUTE_NORMAL,
-                            VertexAttributeValues::from(normals),
-                        );
-                        // There's nothing particularly meaningful we can do
-                        // for this one without knowing anything about the overall topology.
-                        mesh.set_attribute(
-                            Mesh::ATTRIBUTE_UV_0,
-                            VertexAttributeValues::from(
-                                trimesh
-                                    .vertices()
-                                    .iter()
-                                    .map(|_vertex| [0.0, 0.0])
-                                    .collect::<Vec<_>>(),
-                            ),
-                        );
-                        mesh.set_indices(Some(Indices::U32(
-                            trimesh
-                                .indices()
-                                .iter()
-                                .flat_map(|triangle| triangle.iter())
-                                .cloned()
-                                .collect(),
-                        )));
-                        mesh
-                    }
-                    _ => continue,
-                };
-
-                let scale = match shape.shape_type() {
-                    #[cfg(feature = "dim2")]
-                    ShapeType::Cuboid => {
-                        let c = shape.as_cuboid().unwrap();
-                        Vec3::new(c.half_extents.x, c.half_extents.y, 1.0)
-                    }
-                    #[cfg(feature = "dim3")]
-                    ShapeType::Cuboid => {
-                        let c = shape.as_cuboid().unwrap();
-                        Vec3::from_slice_unaligned(c.half_extents.as_slice())
-                    }
-                    ShapeType::Ball => {
-                        let b = shape.as_ball().unwrap();
-                        Vec3::new(b.radius, b.radius, b.radius)
-                    }
-                    ShapeType::TriMesh => Vec3::ONE,
-                    _ => unimplemented!(),
-                } * configuration.scale;
-
-                let mut transform = Transform::from_scale(scale);
-                crate::physics::sync_transform(
-                    collider.position_wrt_parent(),
-                    configuration.scale,
-                    &mut transform,
-                );
-
-                let ground_pbr = PbrBundle {
-                    mesh: meshes.add(mesh),
-                    material: materials.add(color.into()),
-                    transform,
-                    ..Default::default()
-                };
-
-                commands.entity(entity).insert_bundle(ground_pbr);
-            }
+            commands.entity(entity).insert_bundle(ground_pbr);
         }
     }
+}
+
+pub fn update_collider_render_mesh(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    configuration: Res<RapierConfiguration>,
+    colliders: Query<
+        (Entity, &ColliderShape),
+        (
+            Changed<ColliderShape>,
+            With<Handle<Mesh>>,
+            With<ColliderDebugRender>,
+        ),
+    >,
+) {
+    for (entity, co_shape) in colliders.iter() {
+        if let Some((mesh, scale)) = generate_collider_mesh(co_shape) {
+            // TODO: remove the old mesh asset?
+            let mesh = meshes.add(mesh);
+            let scale = Transform::from_scale(scale * configuration.scale);
+            commands.entity(entity).insert_bundle((mesh, scale));
+        }
+    }
+}
+
+fn generate_collider_mesh(co_shape: &ColliderShape) -> Option<(Mesh, Vec3)> {
+    let mesh = match co_shape.shape_type() {
+        #[cfg(feature = "dim3")]
+        ShapeType::Cuboid => Mesh::from(shape::Cube { size: 2.0 }),
+        #[cfg(feature = "dim2")]
+        ShapeType::Cuboid => Mesh::from(shape::Quad {
+            size: Vec2::new(2.0, 2.0),
+            flip: false,
+        }),
+        ShapeType::Ball => Mesh::from(shape::Icosphere {
+            subdivisions: 2,
+            radius: 1.0,
+        }),
+        #[cfg(feature = "dim2")]
+        ShapeType::TriMesh => {
+            let mut mesh = Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
+            let trimesh = co_shape.as_trimesh().unwrap();
+            mesh.set_attribute(
+                Mesh::ATTRIBUTE_POSITION,
+                VertexAttributeValues::from(
+                    trimesh
+                        .vertices()
+                        .iter()
+                        .map(|vertice| [vertice.x, vertice.y])
+                        .collect::<Vec<_>>(),
+                ),
+            );
+            mesh.set_indices(Some(Indices::U32(
+                trimesh
+                    .indices()
+                    .iter()
+                    .flat_map(|triangle| triangle.iter())
+                    .cloned()
+                    .collect(),
+            )));
+            mesh
+        }
+        #[cfg(feature = "dim3")]
+        ShapeType::TriMesh => {
+            let mut mesh = Mesh::new(bevy::render::pipeline::PrimitiveTopology::TriangleList);
+            let trimesh = co_shape.as_trimesh().unwrap();
+            mesh.set_attribute(
+                Mesh::ATTRIBUTE_POSITION,
+                VertexAttributeValues::from(
+                    trimesh
+                        .vertices()
+                        .iter()
+                        .map(|vertex| [vertex.x, vertex.y, vertex.z])
+                        .collect::<Vec<_>>(),
+                ),
+            );
+            // Compute vertex normals by averaging the normals
+            // of every triangle they appear in.
+            // NOTE: This is a bit shonky, but good enough for visualisation.
+            let verts = trimesh.vertices();
+            let mut normals: Vec<Vec3> = vec![Vec3::ZERO; trimesh.vertices().len()];
+            for triangle in trimesh.indices().iter() {
+                let ab = verts[triangle[1] as usize] - verts[triangle[0] as usize];
+                let ac = verts[triangle[2] as usize] - verts[triangle[0] as usize];
+                let normal = ab.cross(&ac);
+                // Contribute this normal to each vertex in the triangle.
+                for i in 0..3 {
+                    normals[triangle[i] as usize] += Vec3::new(normal.x, normal.y, normal.z);
+                }
+            }
+            let normals: Vec<[f32; 3]> = normals
+                .iter()
+                .map(|normal| {
+                    let normal = normal.normalize();
+                    [normal.x, normal.y, normal.z]
+                })
+                .collect();
+            mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, VertexAttributeValues::from(normals));
+            // There's nothing particularly meaningful we can do
+            // for this one without knowing anything about the overall topology.
+            mesh.set_attribute(
+                Mesh::ATTRIBUTE_UV_0,
+                VertexAttributeValues::from(
+                    trimesh
+                        .vertices()
+                        .iter()
+                        .map(|_vertex| [0.0, 0.0])
+                        .collect::<Vec<_>>(),
+                ),
+            );
+            mesh.set_indices(Some(Indices::U32(
+                trimesh
+                    .indices()
+                    .iter()
+                    .flat_map(|triangle| triangle.iter())
+                    .cloned()
+                    .collect(),
+            )));
+            mesh
+        }
+        _ => return None,
+    };
+
+    let scale = match co_shape.shape_type() {
+        #[cfg(feature = "dim2")]
+        ShapeType::Cuboid => {
+            let c = co_shape.as_cuboid().unwrap();
+            Vec3::new(c.half_extents.x, c.half_extents.y, 1.0)
+        }
+        #[cfg(feature = "dim3")]
+        ShapeType::Cuboid => {
+            let c = co_shape.as_cuboid().unwrap();
+            Vec3::from_slice_unaligned(c.half_extents.as_slice())
+        }
+        ShapeType::Ball => {
+            let b = co_shape.as_ball().unwrap();
+            Vec3::new(b.radius, b.radius, b.radius)
+        }
+        ShapeType::TriMesh => Vec3::ONE,
+        _ => unimplemented!(),
+    };
+
+    Some((mesh, scale))
 }

--- a/src_debug_ui/systems.rs
+++ b/src_debug_ui/systems.rs
@@ -9,7 +9,7 @@ pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn()
         .insert_bundle(UiCameraBundle::default());
     // texture
-    commands.spawn().insert_bundle(TextBundle {
+    commands.spawn_bundle(TextBundle {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             ..Default::default()
@@ -19,7 +19,7 @@ pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                 value: "Physics time0.1234567890".to_string(),
                 style: TextStyle {
                     font: font_handle,
-                    font_size: 30.0,
+                    font_size: 15.0,
                     color: Color::BLACK,
                     ..Default::default()
                 },
@@ -32,7 +32,44 @@ pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 pub fn text_update_system(pipeline: Res<PhysicsPipeline>, mut query: Query<&mut Text>) {
+    let profile_string = format!(
+        r#"Total: {:.2}ms
+Collision detection: {:.2}ms
+|_ Broad-phase: {:.2}ms
+   Narrow-phase: {:.2}ms
+Island computation: {:.2}ms
+Solver: {:.2}ms
+|_ Velocity assembly: {:.2}ms
+   Velocity resolution: {:.2}ms
+   Velocity integration: {:.2}ms
+   Position assembly: {:.2}ms
+   Position resolution: {:.2}ms
+CCD: {:.2}ms
+|_ # of substeps: {}
+   TOI computation: {:.2}ms
+   Broad-phase: {:.2}ms
+   Narrow-phase: {:.2}ms
+   Solver: {:.2}ms"#,
+        pipeline.counters.step_time(),
+        pipeline.counters.collision_detection_time(),
+        pipeline.counters.broad_phase_time(),
+        pipeline.counters.narrow_phase_time(),
+        pipeline.counters.island_construction_time(),
+        pipeline.counters.solver_time(),
+        pipeline.counters.solver.velocity_assembly_time.time(),
+        pipeline.counters.velocity_resolution_time(),
+        pipeline.counters.solver.velocity_update_time.time(),
+        pipeline.counters.solver.position_assembly_time.time(),
+        pipeline.counters.position_resolution_time(),
+        pipeline.counters.ccd_time(),
+        pipeline.counters.ccd.num_substeps,
+        pipeline.counters.ccd.toi_computation_time.time(),
+        pipeline.counters.ccd.broad_phase_time.time(),
+        pipeline.counters.ccd.narrow_phase_time.time(),
+        pipeline.counters.ccd.solver_time.time(),
+    );
+
     for mut text in query.iter_mut() {
-        text.sections[0].value = format!("Physics time: {:.2}", pipeline.counters.step_time())
+        text.sections[0].value = profile_string.clone();
     }
 }


### PR DESCRIPTION
This is a significant change to the way this Plugin works. This replaces the `RigidBody` and `Collider` by actual components that can be used in a more idiomatic way using Bevy queries. In particular, the creation of a rigid-body is now done by inserting a `RigidBodyBundle` that looks like this:

```rust
#[derive(Bundle)]
pub struct RigidBodyBundle {
    pub body_type: RigidBodyType,
    pub position: RigidBodyPosition,
    pub velocity: RigidBodyVelocity,
    pub mass_properties: RigidBodyMassProps,
    pub forces: RigidBodyForces,
    pub activation: RigidBodyActivation,
    pub damping: RigidBodyDamping,
    pub dominance: RigidBodyDominance,
    pub ccd: RigidBodyCcd,
    pub changes: RigidBodyChanges,
    pub ids: RigidBodyIds,
    pub colliders: RigidBodyColliders,
}
```
And creating a collider is done by inserting a `ColliderBundle` that looks like this:
```rust
#[derive(Bundle)]
pub struct ColliderBundle {
    pub collider_type: ColliderType,
    pub shape: ColliderShape,
    pub position: ColliderPosition,
    pub material: ColliderMaterial,
    pub groups: ColliderGroups,
    pub mass_properties: ColliderMassProperties,
    pub changes: ColliderChanges,
    pub bf_data: ColliderBroadPhaseData,
}
```
There is also an optional `ColliderParent` component that will attach a collider to a rigid-body. This component can either be added by the user, or is automatically added by the plugin if the `ColliderBundle` is on the same entity, or on a child of an entity, that contains a `RigidBodyBundle`.

All these components can be queried and modified at will using regular Bevy queries, and Rapier will be able to use them as well. However, there must not be removed individually (they are all mandatory for now, we will soften this restriction in the future).

This means that there will no longer be any `RigidBody, Collider, RigidBodyBuilder, ColliderBuilder, RigidBodySet, ColliderSet` structures that were very alien to the Bevy API.

Note however that the `JointSet` remains. It will be replaced by actual components to in the future, it's just a matter of time.
 