### PR TITLE
Moved collect_removals system to Core::PostUpdate stage

### DIFF
--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -93,6 +93,6 @@ impl<UserData: 'static + WorldQuery + Send + Sync> Plugin for RapierPhysicsPlugi
             PhysicsStages::SyncTransforms,
             physics::sync_transforms.system(),
         )
-        .add_system_to_stage(CoreStage::Last, physics::collect_removals.system());
+        .add_system_to_stage(CoreStage::PostUpdate, physics::collect_removals.system());
     }
 }


### PR DESCRIPTION
Fixes issue with removals not being propagated.

Can be tested by running the joints_despawn2 example before and after this PR.