### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.10.0
+A new, exhaustive, user-guide for bevy_rapier has been uploaded to rapier.rs.
+
+This version is a complete rewrite of the plugin. Rigid-bodies and
+colliders are now split into components that can be queried like any other
+components. They are created by inserting a `RigidBodyBundle` and/or a `ColliderBundle`.
+
+In addition, the `Entity` type and `ColliderHandle/RigidBodyHandle` type can now be
+converted directly using `entity.handle()` or `handle.entity()`.
+
+Finally, there is now a prelude: `use bevy_rapier2d::prelude::*`.
+
+
 ## 0.9.0
 ### Added
 - The `ColliderDebugRender` component must be added to an entity

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ codegen-units = 1
 #rapier2d = { path = "../rapier/build/rapier2d" }
 #rapier3d = { path = "../rapier/build/rapier3d" }
 
-rapier2d = { git = "https://github.com/dimforge/rapier" }
-rapier3d = { git = "https://github.com/dimforge/rapier" }
+#rapier2d = { git = "https://github.com/dimforge/rapier" }
+#rapier3d = { git = "https://github.com/dimforge/rapier" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
@@ -30,9 +30,9 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.5", default-features = false }
-nalgebra = { version = "0.26", features = [ "convert-glam-unchecked" ] }
+nalgebra = { version = "0.27", features = [ "convert-glam013" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = { version = "0.8", default-features = false, features = [ "dim2", "f32" ] }
+rapier2d = { version = "0.9", default-features = false, features = [ "dim2", "f32" ] }
 
 [dev-dependencies]
 bevy_wgpu = "0.5"

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -5,7 +5,7 @@ use bevy_rapier2d::prelude::*;
 
 use bevy::render::pass::ClearColor;
 use rapier::geometry::SolverFlags;
-use rapier2d::pipeline::{PairFilterContext, PhysicsHooksFlags, PhysicsPipeline};
+use rapier2d::pipeline::{PairFilterContext, PhysicsPipeline};
 use ui::DebugUiPlugin;
 
 #[path = "../../src_debug_ui/mod.rs"]
@@ -33,10 +33,6 @@ impl CustomFilterTag {
 // this, but we use custom filters instead for demonstration purpose.
 struct SameUserDataFilter;
 impl<'a> PhysicsHooksWithQuery<&'a CustomFilterTag> for SameUserDataFilter {
-    fn active_hooks(&self, _: &Query<&'a CustomFilterTag>) -> PhysicsHooksFlags {
-        PhysicsHooksFlags::FILTER_CONTACT_PAIR
-    }
-
     fn filter_contact_pair(
         &self,
         context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
@@ -146,6 +142,7 @@ pub fn setup_physics(mut commands: Commands) {
 
             let collider = ColliderBundle {
                 shape: ColliderShape::cuboid(rad, rad),
+                flags: ActiveHooks::FILTER_CONTACT_PAIRS.into(),
                 ..Default::default()
             };
             commands

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -95,6 +95,7 @@ pub fn setup_physics(mut commands: Commands) {
     };
     let collider = ColliderBundle {
         shape: ColliderShape::cuboid(0.5, 0.5),
+        flags: (ActiveEvents::INTERSECTION_EVENTS | ActiveEvents::CONTACT_EVENTS).into(),
         ..Default::default()
     };
     commands

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -64,9 +64,9 @@ fn spawn_player(
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
     rapier_parameters: Res<RapierConfiguration>,
-    mut player_info: Query<(&Player, &mut RigidBodyVelocity, &mut RigidBodyActivation)>,
+    mut player_info: Query<(&Player, &mut RigidBodyVelocity)>,
 ) {
-    for (player, mut rb_vels, mut rb_activation) in player_info.iter_mut() {
+    for (player, mut rb_vels) in player_info.iter_mut() {
         let up = keyboard_input.pressed(KeyCode::W) || keyboard_input.pressed(KeyCode::Up);
         let down = keyboard_input.pressed(KeyCode::S) || keyboard_input.pressed(KeyCode::Down);
         let left = keyboard_input.pressed(KeyCode::A) || keyboard_input.pressed(KeyCode::Left);

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
@@ -30,9 +30,9 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.5", default-features = false }
-nalgebra = { version = "0.26", features = [ "convert-glam-unchecked" ] }
+nalgebra = { version = "0.27", features = [ "convert-glam013" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = { version = "0.8", default-features = false, features = [ "dim3", "f32" ] }
+rapier3d = { version = "0.9", default-features = false, features = [ "dim3", "f32" ] }
 
 [dev-dependencies]
 bevy_wgpu = "0.5"

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -33,10 +33,6 @@ impl CustomFilterTag {
 // this, but we use custom filters instead for demonstration purpose.
 struct SameUserDataFilter;
 impl<'a> PhysicsHooksWithQuery<&'a CustomFilterTag> for SameUserDataFilter {
-    fn active_hooks(&self, _: &Query<&'a CustomFilterTag>) -> PhysicsHooksFlags {
-        PhysicsHooksFlags::FILTER_CONTACT_PAIR
-    }
-
     fn filter_contact_pair(
         &self,
         context: &PairFilterContext<RigidBodyComponentsSet, ColliderComponentsSet>,
@@ -150,6 +146,10 @@ pub fn setup_physics(mut commands: Commands) {
 
             let collider = ColliderBundle {
                 shape: ColliderShape::cuboid(rad, rad, rad),
+                material: ColliderMaterial {
+                    active_hooks: PhysicsHooksFlags::FILTER_CONTACT_PAIR,
+                    ..Default::default()
+                },
                 ..Default::default()
             };
             commands

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -5,7 +5,7 @@ use bevy_rapier3d::prelude::*;
 
 use bevy::render::pass::ClearColor;
 use rapier::geometry::SolverFlags;
-use rapier3d::pipeline::{PairFilterContext, PhysicsHooksFlags, PhysicsPipeline};
+use rapier3d::pipeline::{PairFilterContext, PhysicsPipeline};
 use ui::DebugUiPlugin;
 
 #[path = "../../src_debug_ui/mod.rs"]
@@ -146,10 +146,7 @@ pub fn setup_physics(mut commands: Commands) {
 
             let collider = ColliderBundle {
                 shape: ColliderShape::cuboid(rad, rad, rad),
-                material: ColliderMaterial {
-                    active_hooks: PhysicsHooksFlags::FILTER_CONTACT_PAIR,
-                    ..Default::default()
-                },
+                flags: ActiveHooks::FILTER_CONTACT_PAIRS.into(),
                 ..Default::default()
             };
             commands

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -101,6 +101,7 @@ pub fn setup_physics(mut commands: Commands) {
 
     let collider = ColliderBundle {
         shape: ColliderShape::cuboid(0.5, 0.5, 0.5),
+        flags: (ActiveEvents::INTERSECTION_EVENTS | ActiveEvents::CONTACT_EVENTS).into(),
         ..ColliderBundle::default()
     };
 

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -4,7 +4,6 @@ use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
 use bevy::render::pass::ClearColor;
-use nalgebra::{Isometry3, Vector3};
 use rapier::dynamics::RigidBodyMassPropsFlags;
 use rapier::geometry::ColliderShape;
 use rapier3d::pipeline::PhysicsPipeline;

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -6,7 +6,6 @@ use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
 use bevy::render::pass::ClearColor;
-use nalgebra::Isometry3;
 use rapier::geometry::{ColliderMaterial, ColliderShape};
 use rapier3d::dynamics::IntegrationParameters;
 use rapier3d::pipeline::PhysicsPipeline;

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+tmp=$(mktemp -d)
+
+echo "$tmp"
+
+cp -r src "$tmp"/.
+cp -r LICENSE README.md "$tmp"/.
+
+### Publish the 2D version.
+sed 's#\.\./src#src#g' bevy_rapier2d/Cargo.toml > "$tmp"/Cargo.toml
+currdir=$(pwd)
+cd "$tmp" && cargo publish
+cd "$currdir" || exit
+
+
+### Publish the 3D version.
+sed 's#\.\./src#src#g' bevy_rapier3d/Cargo.toml > "$tmp"/Cargo.toml
+cp -r LICENSE README.md "$tmp"/.
+cd "$tmp" && cargo publish
+
+rm -rf "$tmp"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,16 +30,7 @@ pub mod prelude {
         RapierConfiguration, RapierPhysicsPlugin, RigidBodyBundle, RigidBodyComponentsSet,
         RigidBodyPositionSync,
     };
-    pub use rapier::dynamics::{
-        RigidBodyActivation, RigidBodyCcd, RigidBodyChanges, RigidBodyColliders, RigidBodyForces,
-        RigidBodyIds, RigidBodyMassProps, RigidBodyMassPropsFlags, RigidBodyPosition,
-        RigidBodyType, RigidBodyVelocity,
-    };
-    pub use rapier::geometry::{
-        ColliderBroadPhaseData, ColliderChanges, ColliderGroups, ColliderMaterial, ColliderParent,
-        ColliderPosition, ColliderShape, ColliderType, ContactEvent, IntersectionEvent,
-    };
-
     #[cfg(feature = "render")]
     pub use super::render::{ColliderDebugRender, RapierRenderPlugin};
+    pub use rapier::prelude::*;
 }

--- a/src/physics/collider_component_set.rs
+++ b/src/physics/collider_component_set.rs
@@ -1,19 +1,17 @@
 use super::{IntoEntity, IntoHandle};
 use bevy::prelude::*;
 use rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
-use rapier::geometry::{
-    ColliderBroadPhaseData, ColliderChanges, ColliderGroups, ColliderHandle,
-    ColliderMassProperties, ColliderMaterial, ColliderParent, ColliderPosition, ColliderShape,
-    ColliderType,
-};
+use rapier::prelude::*;
 
 impl IntoHandle<ColliderHandle> for Entity {
+    #[inline]
     fn handle(self) -> ColliderHandle {
         ColliderHandle::from_raw_parts(self.id(), self.generation())
     }
 }
 
 impl IntoEntity for ColliderHandle {
+    #[inline]
     fn entity(self) -> Entity {
         self.0.entity()
     }
@@ -25,7 +23,7 @@ pub type QueryPipelineColliderComponentsQuery<'a, 'b> = Query<
         Entity,
         &'b ColliderPosition,
         &'b ColliderShape,
-        &'b ColliderGroups,
+        &'b ColliderFlags,
     ),
 >;
 
@@ -41,7 +39,7 @@ impl_component_set_wo_query_set!(
 impl_component_set_wo_query_set!(QueryPipelineColliderComponentsSet, ColliderShape, |data| {
     data.2
 });
-impl_component_set_wo_query_set!(QueryPipelineColliderComponentsSet, ColliderGroups, |data| {
+impl_component_set_wo_query_set!(QueryPipelineColliderComponentsSet, ColliderFlags, |data| {
     data.3
 });
 
@@ -57,8 +55,8 @@ pub type ColliderComponentsQuery<'a, 'b, 'c> = QuerySet<(
             &'b ColliderBroadPhaseData,
             &'b ColliderShape,
             &'b ColliderType,
-            &'b ColliderGroups,
             &'b ColliderMaterial,
+            &'b ColliderFlags,
             Option<&'b ColliderParent>,
         ),
     >,
@@ -77,7 +75,7 @@ pub type ColliderComponentsQuery<'a, 'b, 'c> = QuerySet<(
             Entity,
             &'c mut ColliderChanges,
             Or<(Changed<ColliderPosition>, Added<ColliderPosition>)>,
-            Or<(Changed<ColliderGroups>, Added<ColliderGroups>)>,
+            Or<(Changed<ColliderFlags>, Added<ColliderFlags>)>,
             Or<(Changed<ColliderShape>, Added<ColliderShape>)>,
             Or<(Changed<ColliderType>, Added<ColliderType>)>,
             Option<Or<(Changed<ColliderParent>, Added<ColliderParent>)>>,
@@ -85,8 +83,8 @@ pub type ColliderComponentsQuery<'a, 'b, 'c> = QuerySet<(
         Or<(
             Changed<ColliderPosition>,
             Added<ColliderPosition>,
-            Changed<ColliderGroups>,
-            Added<ColliderGroups>,
+            Changed<ColliderFlags>,
+            Added<ColliderFlags>,
             Changed<ColliderShape>,
             Added<ColliderShape>,
             Changed<ColliderType>,
@@ -103,8 +101,8 @@ impl_component_set_mut!(ColliderComponentsSet, ColliderBroadPhaseData, |d| d.3);
 
 impl_component_set!(ColliderComponentsSet, ColliderShape, |data| data.4);
 impl_component_set!(ColliderComponentsSet, ColliderType, |data| data.5);
-impl_component_set!(ColliderComponentsSet, ColliderGroups, |data| data.6);
-impl_component_set!(ColliderComponentsSet, ColliderMaterial, |data| data.7);
+impl_component_set!(ColliderComponentsSet, ColliderMaterial, |data| data.6);
+impl_component_set!(ColliderComponentsSet, ColliderFlags, |data| data.7);
 
 impl_component_set_option!(ColliderComponentsSet, ColliderParent);
 
@@ -114,8 +112,8 @@ pub struct ColliderBundle {
     pub shape: ColliderShape,
     pub position: ColliderPosition,
     pub material: ColliderMaterial,
-    pub groups: ColliderGroups,
-    pub mass_properties: ColliderMassProperties,
+    pub flags: ColliderFlags,
+    pub mass_properties: ColliderMassProps,
     pub changes: ColliderChanges,
     pub bf_data: ColliderBroadPhaseData,
 }
@@ -127,8 +125,8 @@ impl Default for ColliderBundle {
             shape: ColliderShape::ball(0.5),
             position: ColliderPosition::default(),
             material: ColliderMaterial::default(),
-            groups: ColliderGroups::default(),
-            mass_properties: ColliderMassProperties::default(),
+            flags: ColliderFlags::default(),
+            mass_properties: ColliderMassProps::default(),
             changes: ColliderChanges::default(),
             bf_data: ColliderBroadPhaseData::default(),
         }

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -1,11 +1,7 @@
 use bevy::prelude::*;
 use rapier::dynamics::{JointHandle, JointParams, RigidBodyHandle};
 use rapier::geometry::ColliderHandle;
-use rapier::math::{Isometry, Translation, Vector};
-#[cfg(feature = "dim2")]
-use rapier::na::UnitComplex;
-#[cfg(feature = "dim3")]
-use rapier::na::{Quaternion, UnitQuaternion};
+use rapier::math::Isometry;
 
 /// A component representing a rigid-body that is being handled by
 /// a Rapier physics World.

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -104,38 +104,6 @@ impl JointBuilderComponent {
     }
 }
 
-/// A component to store the previous position of a body to use for
-/// interpolation between steps
-pub struct PhysicsInterpolationComponent(pub Option<Isometry<f32>>);
-
-impl Default for PhysicsInterpolationComponent {
-    fn default() -> Self {
-        PhysicsInterpolationComponent(None)
-    }
-}
-
-impl PhysicsInterpolationComponent {
-    /// Create a new PhysicsInterpolationComponent from a translation and rotation
-    #[cfg(feature = "dim2")]
-    pub fn new(translation: Vec2, rotation_angle: f32) -> Self {
-        Self(Some(Isometry::from_parts(
-            Translation::from(Vector::new(translation.x, translation.y)),
-            UnitComplex::new(rotation_angle),
-        )))
-    }
-
-    /// Create a new PhysicsInterpolationComponent from a translation and rotation
-    #[cfg(feature = "dim3")]
-    pub fn new(translation: Vec3, rotation: Quat) -> Self {
-        Self(Some(Isometry::from_parts(
-            Translation::from(Vector::new(translation.x, translation.y, translation.z)),
-            UnitQuaternion::from_quaternion(Quaternion::new(
-                rotation.x, rotation.y, rotation.z, rotation.w,
-            )),
-        )))
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 pub enum RigidBodyPositionSync {
     Discrete,

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -5,10 +5,9 @@ pub use self::resources::*;
 pub use self::rigid_body_component_set::*;
 pub use self::systems::*;
 
-use crate::rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption};
-use crate::rapier::dynamics::JointHandle;
+use crate::rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
+use crate::rapier::prelude::*;
 use bevy::prelude::{Entity, Query, QuerySet};
-use rapier::data::Index;
 
 pub trait IntoHandle<H> {
     fn handle(self) -> H;
@@ -19,12 +18,14 @@ pub trait IntoEntity {
 }
 
 impl IntoHandle<Index> for Entity {
+    #[inline]
     fn handle(self) -> Index {
         Index::from_raw_parts(self.id(), self.generation())
     }
 }
 
 impl IntoEntity for Index {
+    #[inline]
     fn entity(self) -> Entity {
         let (id, gen) = self.into_raw_parts();
         let bits = u64::from(gen) << 32 | u64::from(id);
@@ -33,6 +34,7 @@ impl IntoEntity for Index {
 }
 
 impl IntoHandle<JointHandle> for Entity {
+    #[inline]
     fn handle(self) -> JointHandle {
         JointHandle::from_raw_parts(self.id(), self.generation())
     }
@@ -73,7 +75,7 @@ macro_rules! impl_component_set_mut(
         impl<'a, 'b, 'c> ComponentSetMut<$T> for $ComponentsSet<'a, 'b, 'c> {
             #[inline(always)]
             fn set_internal(&mut self, handle: Index, val: $T) {
-                let _ = self.0.q1_mut().get_mut(handle.entity()).map(|mut $data| *$data_expr = val);
+                let _ = self.0.q1_mut().get_component_mut(handle.entity()).map(|mut data| *data = val);
             }
 
             #[inline(always)]

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -5,7 +5,7 @@ use crate::physics::{
 use crate::rapier::prelude::*;
 use bevy::ecs::query::WorldQuery;
 use bevy::prelude::*;
-use rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
+use rapier::data::{ComponentSet, ComponentSetMut};
 use std::collections::HashMap;
 use std::sync::RwLock;
 

--- a/src/physics/rigid_body_component_set.rs
+++ b/src/physics/rigid_body_component_set.rs
@@ -8,12 +8,14 @@ use bevy::prelude::*;
 use rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
 
 impl IntoHandle<RigidBodyHandle> for Entity {
+    #[inline]
     fn handle(self) -> RigidBodyHandle {
         RigidBodyHandle::from_raw_parts(self.id(), self.generation())
     }
 }
 
 impl IntoEntity for RigidBodyHandle {
+    #[inline]
     fn entity(self) -> Entity {
         self.0.entity()
     }

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -3,8 +3,8 @@ use crate::physics::{
     EventQueue, IntoEntity, IntoHandle, JointBuilderComponent, JointHandleComponent,
     JointsEntityMap, ModificationTracker, PhysicsHooksWithQueryInstance,
     PhysicsHooksWithQueryObject, QueryComponentSetMut, RapierConfiguration,
-    RigidBodyComponentsQuery, RigidBodyComponentsSet, RigidBodyHandleComponent,
-    RigidBodyPositionSync, SimulationToRenderTime, TimestepMode,
+    RigidBodyComponentsQuery, RigidBodyComponentsSet, RigidBodyPositionSync,
+    SimulationToRenderTime, TimestepMode,
 };
 
 use crate::prelude::{ContactEvent, IntersectionEvent};


### PR DESCRIPTION
## 0.10.0
A new, exhaustive, user-guide for bevy_rapier will be uploaded to rapier.rs today.

This version is a complete rewrite of the plugin. Rigid-bodies and colliders are now split into components that can be queried like any other components. They are created by inserting a `RigidBodyBundle` and/or a `ColliderBundle`.

In addition, the `Entity` type and `ColliderHandle/RigidBodyHandle` type can now be converted directly using `entity.handle()` or `handle.entity()`.

Finally, there is now a prelude: `use bevy_rapier2d::prelude::*`.