### PR TITLE
Fix component removal detection

### DIFF
--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -93,6 +93,6 @@ impl<UserData: 'static + WorldQuery + Send + Sync> Plugin for RapierPhysicsPlugi
             PhysicsStages::SyncTransforms,
             physics::sync_transforms.system(),
         )
-        .add_system_to_stage(CoreStage::Last, physics::collect_removals.system());
+        .add_system_to_stage(CoreStage::PostUpdate, physics::collect_removals.system());
     }
 }


### PR DESCRIPTION
Looks like it doesn't work if it's run of the Last stage. They have been moved to the PostUpdate stage instead.
Fix #71 