### PR TITLE
Attach colliders to their containing bodies only if there are such bodies

### DIFF
--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -69,6 +69,10 @@ fn display_events(
 }
 
 pub fn setup_physics(mut commands: Commands) {
+    let parent = commands
+        .spawn_bundle((Transform::identity(), GlobalTransform::identity()))
+        .id();
+
     /*
      * Ground
      */
@@ -79,6 +83,7 @@ pub fn setup_physics(mut commands: Commands) {
 
     commands
         .spawn_bundle(collider)
+        .insert(Parent(parent))
         .insert(ColliderDebugRender::default())
         .insert(ColliderPositionSync::Discrete);
 


### PR DESCRIPTION
This commit replaces the old implementation of `attach_bodies_and_colliders_system` that wrongly assumed that the parent of a bodyless collider always has an attachable body and caused runtime panics in `rapier3d::pipeline::handle_user_changes_to_ colliders`, where it attempted to look up the non-existent bodies that `ColliderParent` claimed to be attached to given colliders.

The new implementation also widens the possible usage: In the old implementation, bodies can include colliders defined in their children but not non-direct descendants. The new implementation makes all descendants eligible for inclusion. I think this behavior is more in accordance with the users' expectation.

Fixes #76.