### PR TITLE
Add and export labels for systems

### DIFF
--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -75,24 +75,39 @@ impl<UserData: 'static + WorldQuery + Send + Sync> Plugin for RapierPhysicsPlugi
         .insert_resource(ModificationTracker::default())
         .add_system_to_stage(
             PhysicsStages::FinalizeCreations,
-            physics::attach_bodies_and_colliders_system.system(),
+            physics::attach_bodies_and_colliders_system
+                .system()
+                .label(physics::ATTACH_BODIES_AND_COLLIDERS_SYSTEM),
         )
         .add_system_to_stage(
             PhysicsStages::FinalizeCreations,
-            physics::create_joints_system.system(),
+            physics::create_joints_system
+                .system()
+                .label(physics::CREATE_JOINTS_SYSTEM),
         )
         .add_system_to_stage(
             CoreStage::PreUpdate,
-            physics::finalize_collider_attach_to_bodies.system(),
+            physics::finalize_collider_attach_to_bodies
+                .system()
+                .label(physics::FINALIZE_COLLIDER_ATTACH_TO_BODIES_SYSTEM),
         )
         .add_system_to_stage(
             CoreStage::Update,
-            physics::step_world_system::<UserData>.system(),
+            physics::step_world_system::<UserData>
+                .system()
+                .label(physics::STEP_WORLD_SYSTEM),
         )
         .add_system_to_stage(
             PhysicsStages::SyncTransforms,
-            physics::sync_transforms.system(),
+            physics::sync_transforms
+                .system()
+                .label(physics::SYNC_TRANSFORMS_SYSTEM),
         )
-        .add_system_to_stage(CoreStage::PostUpdate, physics::collect_removals.system());
+        .add_system_to_stage(
+            CoreStage::PostUpdate,
+            physics::collect_removals
+                .system()
+                .label(physics::COLLECT_REMOVALS_SYSTEM),
+        );
     }
 }

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -77,37 +77,37 @@ impl<UserData: 'static + WorldQuery + Send + Sync> Plugin for RapierPhysicsPlugi
             PhysicsStages::FinalizeCreations,
             physics::attach_bodies_and_colliders_system
                 .system()
-                .label(physics::ATTACH_BODIES_AND_COLLIDERS_SYSTEM),
+                .label(physics::PhysicsSystems::AttachBodiesAndColliders),
         )
         .add_system_to_stage(
             PhysicsStages::FinalizeCreations,
             physics::create_joints_system
                 .system()
-                .label(physics::CREATE_JOINTS_SYSTEM),
+                .label(physics::PhysicsSystems::CreateJoints),
         )
         .add_system_to_stage(
             CoreStage::PreUpdate,
             physics::finalize_collider_attach_to_bodies
                 .system()
-                .label(physics::FINALIZE_COLLIDER_ATTACH_TO_BODIES_SYSTEM),
+                .label(physics::PhysicsSystems::FinalizeColliderAttachToBodies),
         )
         .add_system_to_stage(
             CoreStage::Update,
             physics::step_world_system::<UserData>
                 .system()
-                .label(physics::STEP_WORLD_SYSTEM),
+                .label(physics::PhysicsSystems::StepWorld),
         )
         .add_system_to_stage(
             PhysicsStages::SyncTransforms,
             physics::sync_transforms
                 .system()
-                .label(physics::SYNC_TRANSFORMS_SYSTEM),
+                .label(physics::PhysicsSystems::SyncTransforms),
         )
         .add_system_to_stage(
             CoreStage::PostUpdate,
             physics::collect_removals
                 .system()
-                .label(physics::COLLECT_REMOVALS_SYSTEM),
+                .label(physics::PhysicsSystems::CollectRemovals),
         );
     }
 }

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -26,12 +26,15 @@ use rapier::math::Isometry;
 use rapier::pipeline::PhysicsPipeline;
 use std::sync::RwLock;
 
-pub const ATTACH_BODIES_AND_COLLIDERS_SYSTEM: &str = "attach_bodies_and_colliders_system";
-pub const FINALIZE_COLLIDER_ATTACH_TO_BODIES_SYSTEM: &str = "finalize_collider_attach_to_bodies";
-pub const CREATE_JOINTS_SYSTEM: &str = "create_joints_system";
-pub const STEP_WORLD_SYSTEM: &str = "step_world_system";
-pub const SYNC_TRANSFORMS_SYSTEM: &str = "sync_transforms";
-pub const COLLECT_REMOVALS_SYSTEM: &str = "collect_removals";
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
+pub enum PhysicsSystems {
+    AttachBodiesAndColliders,
+    FinalizeColliderAttachToBodies,
+    CreateJoints,
+    StepWorld,
+    SyncTransforms,
+    CollectRemovals,
+}
 
 /// System responsible for creating a Rapier rigid-body and collider from their
 /// builder resources.

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -26,6 +26,13 @@ use rapier::math::Isometry;
 use rapier::pipeline::PhysicsPipeline;
 use std::sync::RwLock;
 
+pub const ATTACH_BODIES_AND_COLLIDERS_SYSTEM: &str = "attach_bodies_and_colliders_system";
+pub const FINALIZE_COLLIDER_ATTACH_TO_BODIES_SYSTEM: &str = "finalize_collider_attach_to_bodies";
+pub const CREATE_JOINTS_SYSTEM: &str = "create_joints_system";
+pub const STEP_WORLD_SYSTEM: &str = "step_world_system";
+pub const SYNC_TRANSFORMS_SYSTEM: &str = "sync_transforms";
+pub const COLLECT_REMOVALS_SYSTEM: &str = "collect_removals";
+
 /// System responsible for creating a Rapier rigid-body and collider from their
 /// builder resources.
 pub fn attach_bodies_and_colliders_system(

--- a/src/render/plugins.rs
+++ b/src/render/plugins.rs
@@ -8,11 +8,15 @@ impl Plugin for RapierRenderPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_system_to_stage(
             CoreStage::PreUpdate,
-            systems::create_collider_renders_system.system(),
+            systems::create_collider_renders_system
+                .system()
+                .label(systems::CREATE_COLLIDER_RENDERS_SYSTEM),
         );
         app.add_system_to_stage(
             CoreStage::PreUpdate,
-            systems::update_collider_render_mesh.system(),
+            systems::update_collider_render_mesh
+                .system()
+                .label(systems::UPDATE_COLLIDER_RENDER_MESH_SYSTEM),
         );
     }
 }

--- a/src/render/plugins.rs
+++ b/src/render/plugins.rs
@@ -10,13 +10,13 @@ impl Plugin for RapierRenderPlugin {
             CoreStage::PreUpdate,
             systems::create_collider_renders_system
                 .system()
-                .label(systems::CREATE_COLLIDER_RENDERS_SYSTEM),
+                .label(systems::RenderSystems::CreateColliderRenders),
         );
         app.add_system_to_stage(
             CoreStage::PreUpdate,
             systems::update_collider_render_mesh
                 .system()
-                .label(systems::UPDATE_COLLIDER_RENDER_MESH_SYSTEM),
+                .label(systems::RenderSystems::UpdateColliderRenderMesh),
         );
     }
 }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -5,6 +5,9 @@ use bevy::prelude::*;
 use bevy::render::mesh::{Indices, VertexAttributeValues};
 use rapier::geometry::ShapeType;
 
+pub const CREATE_COLLIDER_RENDERS_SYSTEM: &str = "create_collider_renders_system";
+pub const UPDATE_COLLIDER_RENDER_MESH_SYSTEM: &str = "update_collider_render_mesh";
+
 /// System responsible for attaching a PbrBundle to each entity having a collider.
 pub fn create_collider_renders_system(
     mut commands: Commands,

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -5,8 +5,11 @@ use bevy::prelude::*;
 use bevy::render::mesh::{Indices, VertexAttributeValues};
 use rapier::geometry::ShapeType;
 
-pub const CREATE_COLLIDER_RENDERS_SYSTEM: &str = "create_collider_renders_system";
-pub const UPDATE_COLLIDER_RENDER_MESH_SYSTEM: &str = "update_collider_render_mesh";
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
+pub enum RenderSystems {
+    CreateColliderRenders,
+    UpdateColliderRenderMesh,
+}
 
 /// System responsible for attaching a PbrBundle to each entity having a collider.
 pub fn create_collider_renders_system(


### PR DESCRIPTION
This allows developers using bevy_rapier to explicitly schedule their systems
relative to bevy_rapier systems, either through use of stages, or the new
before/after system dependency specification within a stage.