### PR TITLE
Add a pointer from `docs.rs` docs to rapier docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! The `bevy_rapier` projects implements two other crates `bevy_rapier2d` and `bevy_rapier3d` which
 //! defines physics plugins for the Bevy game engine.
 //!
+//! User documentation for `bevy_rapier` is on [the official Rapier site](https://rapier.rs/docs/).
+//!
 
 // #![deny(missing_docs)] // FIXME: deny this
 


### PR DESCRIPTION
Added a pointer from the module-level cargo docs to the actual docs on `rapier.rs` so other people won't be lost like I was.

(Searches for bevy-rapier3d documentation often end up on `docs.rs`, where the module appears to be almost completely undocumented. The Bevy docs also make little or no mention of it. The README has a pointer to the docs, but it never even occurred to me that that might go anywhere other than docs.rs.)