### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
+## 0.11.0
+### Modified
+- Switch to `Rapier` 0.11 and `nalgebra` 0.29.
+- Add labels to each system from `bevy-rapier`.
+
+### Fixed
+- Fix panics when despawning joints or colliders.
+- Fix a panic where adding a collider.
+- Don’t let the plugin overwrite the user’s `PhysicsHooksWithQueryObject` if it was already 
+  present before inserting the plugin.
+
 ## 0.10.2
 ### Fixed
-- Fix build when targetting WASM.
+- Fix build when targeting WASM.
 
 ## 0.10.1
 ### Fixed

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -30,9 +30,9 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.5", default-features = false }
-nalgebra = { version = "0.27", features = [ "convert-glam013" ] }
+nalgebra = { version = "0.29", features = [ "convert-glam013" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = { version = "^0.9.2", default-features = false, features = [ "dim2", "f32" ] }
+rapier2d = { version = "0.11", default-features = false, features = [ "dim2", "f32" ] }
 
 [dev-dependencies]
 bevy_wgpu = "0.5"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -30,9 +30,9 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.5", default-features = false }
-nalgebra = { version = "0.27", features = [ "convert-glam013" ] }
+nalgebra = { version = "0.29", features = [ "convert-glam013" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = { version = "^0.9.2", default-features = false, features = [ "dim3", "f32" ] }
+rapier3d = { version = "^0.11", default-features = false, features = [ "dim3", "f32" ] }
 
 [dev-dependencies]
 bevy_wgpu = "0.5"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -158,7 +158,7 @@ pub fn create_joints_system(
     query: Query<(Entity, &JointBuilderComponent)>,
     bodies: ComponentSetQueryMut<RigidBodyIds>,
 ) {
-    let mut bodies = QueryComponentSetMut(bodies);
+    let bodies = QueryComponentSetMut(bodies);
 
     for (entity, joint) in &mut query.iter() {
         // Make sure the rigid-bodies the joint it attached to exist.
@@ -176,12 +176,7 @@ pub fn create_joints_system(
             continue;
         }
 
-        let handle = joints.insert(
-            &mut bodies,
-            joint.entity1.handle(),
-            joint.entity2.handle(),
-            joint.params,
-        );
+        let handle = joints.insert(joint.entity1.handle(), joint.entity2.handle(), joint.params);
         commands
             .entity(entity)
             .insert(JointHandleComponent::new(


### PR DESCRIPTION
## 0.11.0
### Modified
- Switch to `Rapier` 0.11 and `nalgebra` 0.29.
- Add labels to each system from `bevy-rapier`.

### Fixed
- Fix panics when despawning joints or colliders.
- Fix a panic where adding a collider.
- Don’t let the plugin overwrite the user’s `PhysicsHooksWithQueryObject` if it was already 
  present before inserting the plugin.
