### PR TITLE
Update to Bevy 0.6 main branch.

### DIFF
--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -12,7 +12,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -40,9 +40,9 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(0.0, 200.0, 0.0));
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000_000_.0,
             range: 6000.0,
             ..Default::default()

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -49,7 +49,7 @@ impl<'a> PhysicsHooksWithQuery<&'a CustomFilterTag> for SameUserDataFilter {
 }
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -77,9 +77,9 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(0.0, 200.0, 0.0));
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000_000_.0,
             range: 6000.0,
             ..Default::default()

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -5,9 +5,10 @@
 use bevy::prelude::*;
 use bevy::render::pass::ClearColor;
 use bevy_rapier2d::prelude::*;
+use nalgebra::Point2;
 
 fn main() {
-    App::build()
+    App::new()
         .init_resource::<Game>()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
         .insert_resource(Msaa::default())
@@ -187,8 +188,8 @@ fn spawn_cube(commands: &mut Commands, game: &mut Game) {
             let x_dir = coords[*j].0 as f32 - coords[*i].0 as f32;
             let y_dir = coords[*j].1 as f32 - coords[*i].1 as f32;
 
-            let anchor_1 = Vec2::new(x_dir * 0.5, y_dir * 0.5).into();
-            let anchor_2 = Vec2::new(x_dir * -0.5, y_dir * -0.5).into();
+            let anchor_1 = Point2::new(x_dir * 0.5, y_dir * 0.5);
+            let anchor_2 = Point2::new(x_dir * -0.5, y_dir * -0.5);
 
             commands
                 .spawn()

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -22,7 +22,7 @@ pub struct ResizeResource {
 }
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -54,9 +54,9 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(0.0, 200.0, 0.0));
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000_000_.0,
             range: 6000.0,
             ..Default::default()

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -11,7 +11,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -38,9 +38,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfiguration>) {
     configuration.scale = 15.0;
 
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000_000_.0,
             range: 6000.0,
             ..Default::default()

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -13,7 +13,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -41,9 +41,9 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(200.0, -200.0, 0.0));
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000_000_.0,
             range: 6000.0,
             ..Default::default()

--- a/bevy_rapier2d/examples/joints_despawn2.rs
+++ b/bevy_rapier2d/examples/joints_despawn2.rs
@@ -18,7 +18,7 @@ pub struct DespawnResource {
 }
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -48,9 +48,9 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(200.0, -200.0, 0.0));
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000_000_.0,
             range: 6000.0,
             ..Default::default()

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -12,7 +12,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -40,9 +40,9 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(0.0, 30.0, 0.0));
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000_000_.0,
             range: 6000.0,
             ..Default::default()

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -10,7 +10,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -33,9 +33,9 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
 
     let mut camera = OrthographicCameraBundle::new_2d();
     camera.transform = Transform::from_translation(Vec3::new(0.0, 200.0, 0.0));
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(1000.0, 10.0, 2000.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000_000_.0,
             range: 6000.0,
             ..Default::default()

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 use bevy_rapier2d::rapier::na::Vector2;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(WindowDescriptor {
             title: "Player Movement Example".to_string(),
             width: 1000.0,

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -12,7 +12,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -36,9 +36,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -49,7 +49,7 @@ impl<'a> PhysicsHooksWithQuery<&'a CustomFilterTag> for SameUserDataFilter {
 }
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -73,9 +73,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -16,7 +16,7 @@ pub struct DespawnResource {
 }
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -42,9 +42,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -11,7 +11,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -36,9 +36,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -14,7 +14,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -38,9 +38,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -19,7 +19,7 @@ pub struct DespawnResource {
 }
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -45,9 +45,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -13,7 +13,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -37,9 +37,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/multiple_colliders3.rs
+++ b/bevy_rapier3d/examples/multiple_colliders3.rs
@@ -12,7 +12,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -36,9 +36,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -13,7 +13,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -38,9 +38,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -15,7 +15,7 @@ use ui::DebugUiPlugin;
 mod ui;
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(ClearColor(Color::rgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
@@ -41,9 +41,9 @@ fn enable_physics_profiling(mut pipeline: ResMut<PhysicsPipeline>) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(100.0, 10.0, 200.0)),
-        light: Light {
+        point_light: PointLight {
             intensity: 100_000.0,
             range: 3000.0,
             ..Default::default()

--- a/src/physics/collider_component_set.rs
+++ b/src/physics/collider_component_set.rs
@@ -17,93 +17,92 @@ impl IntoEntity for ColliderHandle {
     }
 }
 
-pub type QueryPipelineColliderComponentsQuery<'a, 'b> = Query<
-    'a,
+pub type QueryPipelineColliderComponentsQuery<'world, 'state, 'a> = Query<
+    'world,
+    'state,
     (
         Entity,
-        &'b ColliderPosition,
-        &'b ColliderShape,
-        &'b ColliderFlags,
+        &'a ColliderPosition,
+        &'a ColliderShape,
+        &'a ColliderFlags,
     ),
 >;
 
-pub struct QueryPipelineColliderComponentsSet<'a, 'b, 'c>(
-    pub &'c QueryPipelineColliderComponentsQuery<'a, 'b>,
+pub struct QueryPipelineColliderComponentsSet<'world, 'state, 'a, 'c>(
+    pub &'c QueryPipelineColliderComponentsQuery<'world, 'state, 'a>,
 );
 
-impl_component_set_wo_query_set!(
+impl_component_set!(
     QueryPipelineColliderComponentsSet,
     ColliderPosition,
     |data| data.1
 );
-impl_component_set_wo_query_set!(QueryPipelineColliderComponentsSet, ColliderShape, |data| {
+impl_component_set!(QueryPipelineColliderComponentsSet, ColliderShape, |data| {
     data.2
 });
-impl_component_set_wo_query_set!(QueryPipelineColliderComponentsSet, ColliderFlags, |data| {
+impl_component_set!(QueryPipelineColliderComponentsSet, ColliderFlags, |data| {
     data.3
 });
 
-pub struct ColliderComponentsSet<'a, 'b, 'c>(pub ColliderComponentsQuery<'a, 'b, 'c>);
+pub struct ColliderComponentsSet<'world, 'state, 'a>(
+    pub Query<'world, 'state, ColliderComponentsQueryPayload<'a>>,
+);
 
-pub type ColliderComponentsQuery<'a, 'b, 'c> = QuerySet<(
-    Query<
-        'a,
-        (
-            Entity,
-            &'b ColliderChanges,
-            &'b ColliderPosition,
-            &'b ColliderBroadPhaseData,
-            &'b ColliderShape,
-            &'b ColliderType,
-            &'b ColliderMaterial,
-            &'b ColliderFlags,
-            Option<&'b ColliderParent>,
-        ),
-    >,
-    Query<
-        'a,
-        (
-            Entity,
-            &'c mut ColliderChanges,
-            &'c mut ColliderPosition,
-            &'c mut ColliderBroadPhaseData,
-        ),
-    >,
-    Query<
-        'a,
-        (
-            Entity,
-            &'c mut ColliderChanges,
-            Or<(Changed<ColliderPosition>, Added<ColliderPosition>)>,
-            Or<(Changed<ColliderFlags>, Added<ColliderFlags>)>,
-            Or<(Changed<ColliderShape>, Added<ColliderShape>)>,
-            Or<(Changed<ColliderType>, Added<ColliderType>)>,
-            Option<Or<(Changed<ColliderParent>, Added<ColliderParent>)>>,
-        ),
-        Or<(
-            Changed<ColliderPosition>,
-            Added<ColliderPosition>,
-            Changed<ColliderFlags>,
-            Added<ColliderFlags>,
-            Changed<ColliderShape>,
-            Added<ColliderShape>,
-            Changed<ColliderType>,
-            Added<ColliderType>,
-            Changed<ColliderParent>,
-            Added<ColliderParent>,
-        )>,
-    >,
-)>;
+pub type ColliderComponentsQueryPayload<'a> = (
+    Entity,
+    &'a mut ColliderChanges,
+    &'a mut ColliderPosition,
+    &'a mut ColliderBroadPhaseData,
+    &'a mut ColliderShape,
+    &'a mut ColliderType,
+    &'a mut ColliderMaterial,
+    &'a mut ColliderFlags,
+    Option<&'a ColliderParent>,
+);
 
-impl_component_set_mut!(ColliderComponentsSet, ColliderChanges, |data| data.1);
-impl_component_set_mut!(ColliderComponentsSet, ColliderPosition, |data| data.2);
-impl_component_set_mut!(ColliderComponentsSet, ColliderBroadPhaseData, |d| d.3);
+pub type ColliderChangesQueryPayload<'a> = (
+    Entity,
+    &'a mut ColliderChanges,
+    Or<(Changed<ColliderPosition>, Added<ColliderPosition>)>,
+    Or<(Changed<ColliderFlags>, Added<ColliderFlags>)>,
+    Or<(Changed<ColliderShape>, Added<ColliderShape>)>,
+    Or<(Changed<ColliderType>, Added<ColliderType>)>,
+    Option<Or<(Changed<ColliderParent>, Added<ColliderParent>)>>,
+);
 
-impl_component_set!(ColliderComponentsSet, ColliderShape, |data| data.4);
-impl_component_set!(ColliderComponentsSet, ColliderType, |data| data.5);
-impl_component_set!(ColliderComponentsSet, ColliderMaterial, |data| data.6);
-impl_component_set!(ColliderComponentsSet, ColliderFlags, |data| data.7);
+pub type ColliderChangesQueryFilter = (
+    Or<(
+        Changed<ColliderPosition>,
+        Added<ColliderPosition>,
+        Changed<ColliderFlags>,
+        Added<ColliderFlags>,
+        Changed<ColliderShape>,
+        Added<ColliderShape>,
+        Changed<ColliderType>,
+        Added<ColliderType>,
+        Changed<ColliderParent>,
+        Added<ColliderParent>,
+    )>,
+);
 
+pub type ColliderComponentsQuerySet<'world, 'state, 'a> = QuerySet<
+    'world,
+    'state,
+    (
+        // Components query
+        QueryState<ColliderComponentsQueryPayload<'a>>,
+        // Changes query
+        QueryState<ColliderChangesQueryPayload<'a>, ColliderChangesQueryFilter>,
+    ),
+>;
+
+impl_component_set_mut!(ColliderComponentsSet, ColliderChanges, |data| &*data.1);
+impl_component_set_mut!(ColliderComponentsSet, ColliderPosition, |data| &*data.2);
+impl_component_set_mut!(ColliderComponentsSet, ColliderBroadPhaseData, |d| &*d.3);
+impl_component_set_mut!(ColliderComponentsSet, ColliderShape, |data| &*data.4);
+impl_component_set_mut!(ColliderComponentsSet, ColliderType, |data| &*data.5);
+impl_component_set_mut!(ColliderComponentsSet, ColliderMaterial, |data| &*data.6);
+impl_component_set_mut!(ColliderComponentsSet, ColliderFlags, |data| &*data.7);
 impl_component_set_option!(ColliderComponentsSet, ColliderParent);
 
 #[derive(Bundle)]

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -7,7 +7,7 @@ pub use self::systems::*;
 
 use crate::rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
 use crate::rapier::prelude::*;
-use bevy::prelude::{Entity, Query, QuerySet};
+use bevy::prelude::{Entity, Query};
 
 pub trait IntoHandle<H> {
     fn handle(self) -> H;
@@ -53,14 +53,14 @@ pub trait BundleBuilder {
 
 macro_rules! impl_component_set_mut(
     ($ComponentsSet: ident, $T: ty, |$data: ident| $data_expr: expr) => {
-        impl<'a, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'b, 'c> {
+        impl<'world, 'state, 'a> ComponentSetOption<$T> for $ComponentsSet<'world, 'state, 'a> {
             #[inline(always)]
             fn get(&self, handle: Index) -> Option<&$T> {
-                self.0.q0().get_component(handle.entity()).ok()
+                self.0.get_component(handle.entity()).ok()
             }
         }
 
-        impl<'a, 'b, 'c> ComponentSet<$T> for $ComponentsSet<'a, 'b, 'c> {
+        impl<'world, 'state, 'a> ComponentSet<$T> for $ComponentsSet<'world, 'state, 'a> {
             #[inline(always)]
             fn size_hint(&self) -> usize {
                 0
@@ -68,14 +68,14 @@ macro_rules! impl_component_set_mut(
 
             #[inline(always)]
             fn for_each(&self, mut f: impl FnMut(Index, &$T)) {
-                self.0.q0().for_each(|$data| f($data.0.handle(), $data_expr))
+                self.0.iter().for_each(|$data| f($data.0.handle(), $data_expr))
             }
         }
 
-        impl<'a, 'b, 'c> ComponentSetMut<$T> for $ComponentsSet<'a, 'b, 'c> {
+        impl<'world, 'state, 'a> ComponentSetMut<$T> for $ComponentsSet<'world, 'state, 'a> {
             #[inline(always)]
             fn set_internal(&mut self, handle: Index, val: $T) {
-                let _ = self.0.q1_mut().get_component_mut(handle.entity()).map(|mut data| *data = val);
+                let _ = self.0.get_component_mut(handle.entity()).map(|mut data| *data = val);
             }
 
             #[inline(always)]
@@ -84,7 +84,7 @@ macro_rules! impl_component_set_mut(
                 handle: Index,
                 f: impl FnOnce(&mut $T) -> Result,
             ) -> Option<Result> {
-                self.0.q1_mut()
+                self.0
                     .get_component_mut(handle.entity())
                     .map(|mut data| f(&mut data))
                     .ok()
@@ -93,16 +93,16 @@ macro_rules! impl_component_set_mut(
     }
 );
 
-macro_rules! impl_component_set_wo_query_set(
+macro_rules! impl_component_set(
     ($ComponentsSet: ident, $T: ty, |$data: ident| $data_expr: expr) => {
-        impl<'a, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'b, 'c> {
+        impl<'a, 'w, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'w, 'b, 'c> {
             #[inline(always)]
             fn get(&self, handle: Index) -> Option<&$T> {
                 self.0.get_component(handle.entity()).ok()
             }
         }
 
-        impl<'a, 'b, 'c> ComponentSet<$T> for $ComponentsSet<'a, 'b, 'c> {
+        impl<'a, 'w, 'b, 'c> ComponentSet<$T> for $ComponentsSet<'a, 'w, 'b, 'c> {
             #[inline(always)]
             fn size_hint(&self) -> usize {
                 0
@@ -116,57 +116,36 @@ macro_rules! impl_component_set_wo_query_set(
     }
 );
 
-macro_rules! impl_component_set(
-    ($ComponentsSet: ident, $T: ty, |$data: ident| $data_expr: expr) => {
-        impl<'a, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'b, 'c> {
-            #[inline(always)]
-            fn get(&self, handle: Index) -> Option<&$T> {
-                self.0.q0().get_component(handle.entity()).ok()
-            }
-        }
-
-        impl<'a, 'b, 'c> ComponentSet<$T> for $ComponentsSet<'a, 'b, 'c> {
-            #[inline(always)]
-            fn size_hint(&self) -> usize {
-                0
-            }
-
-            #[inline(always)]
-            fn for_each(&self, mut f: impl FnMut(Index, &$T)) {
-                self.0.q0().for_each(|$data| f($data.0.handle(), $data_expr))
-            }
-        }
-    }
-);
-
 macro_rules! impl_component_set_option(
     ($ComponentsSet: ident, $T: ty) => {
-        impl<'a, 'b, 'c> ComponentSetOption<$T> for $ComponentsSet<'a, 'b, 'c> {
+        impl<'world, 'state, 'a> ComponentSetOption<$T> for $ComponentsSet<'world, 'state, 'a> {
             #[inline(always)]
             fn get(&self, handle: Index) -> Option<&$T> {
-                self.0.q0().get_component(handle.entity()).ok()
+                self.0.get_component(handle.entity()).ok()
             }
         }
     }
 );
 
-pub type ComponentSetQueryMut<'a, 'b, 'c, T> =
-    QuerySet<(Query<'a, (Entity, &'b T)>, Query<'a, (Entity, &'c mut T)>)>;
+pub type ComponentSetQueryMut<'world, 'state, 'a, T> =
+    Query<'world, 'state, (Entity, &'a mut T)>;
 
-pub struct QueryComponentSetMut<'a, 'b, 'c, T: 'static + Send + Sync>(
-    ComponentSetQueryMut<'a, 'b, 'c, T>,
+pub struct QueryComponentSetMut<'world, 'state, 'a, T: 'static + Send + Sync>(
+    ComponentSetQueryMut<'world, 'state, 'a, T>
 );
 
-impl<'a, 'b, 'c, T: 'static + Send + Sync> ComponentSetOption<T>
-    for QueryComponentSetMut<'a, 'b, 'c, T>
+impl<'world, 'state, 'a, T: 'static + Send + Sync> ComponentSetOption<T>
+    for QueryComponentSetMut<'world, 'state, 'a, T>
 {
     #[inline(always)]
     fn get(&self, handle: Index) -> Option<&T> {
-        self.0.q0().get_component(handle.entity()).ok()
+        self.0.get_component(handle.entity()).ok()
     }
 }
 
-impl<'a, 'b, 'c, T: 'static + Send + Sync> ComponentSet<T> for QueryComponentSetMut<'a, 'b, 'c, T> {
+impl<'world, 'state, 'a, T: 'static + Send + Sync> ComponentSet<T>
+    for QueryComponentSetMut<'world, 'state, 'a, T>
+{
     #[inline(always)]
     fn size_hint(&self) -> usize {
         0
@@ -174,18 +153,17 @@ impl<'a, 'b, 'c, T: 'static + Send + Sync> ComponentSet<T> for QueryComponentSet
 
     #[inline(always)]
     fn for_each(&self, mut f: impl FnMut(Index, &T)) {
-        self.0.q0().for_each(|data| f(data.0.handle(), &data.1))
+        self.0.iter().for_each(|data| f(data.0.handle(), &data.1))
     }
 }
 
-impl<'a, 'b, 'c, T: 'static + Send + Sync> ComponentSetMut<T>
-    for QueryComponentSetMut<'a, 'b, 'c, T>
+impl<'world, 'state, 'a, T: 'static + Send + Sync> ComponentSetMut<T>
+    for QueryComponentSetMut<'world, 'state, 'a, T>
 {
     #[inline(always)]
     fn set_internal(&mut self, handle: Index, val: T) {
         let _ = self
             .0
-            .q1_mut()
             .get_mut(handle.entity())
             .map(|mut data| *data.1 = val);
     }
@@ -197,7 +175,6 @@ impl<'a, 'b, 'c, T: 'static + Send + Sync> ComponentSetMut<T>
         f: impl FnOnce(&mut T) -> Result,
     ) -> Option<Result> {
         self.0
-            .q1_mut()
             .get_component_mut(handle.entity())
             .map(|mut data| f(&mut data))
             .ok()

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -47,7 +47,7 @@ pub enum PhysicsStages {
 }
 
 impl<UserData: 'static + WorldQuery + Send + Sync> Plugin for RapierPhysicsPlugin<UserData> {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         app.add_stage_before(
             CoreStage::PreUpdate,
             PhysicsStages::FinalizeCreations,
@@ -75,41 +75,35 @@ impl<UserData: 'static + WorldQuery + Send + Sync> Plugin for RapierPhysicsPlugi
         .add_system_to_stage(
             PhysicsStages::FinalizeCreations,
             physics::attach_bodies_and_colliders_system
-                .system()
                 .label(physics::PhysicsSystems::AttachBodiesAndColliders),
         )
         .add_system_to_stage(
             PhysicsStages::FinalizeCreations,
             physics::create_joints_system
-                .system()
                 .label(physics::PhysicsSystems::CreateJoints),
         )
         .add_system_to_stage(
             CoreStage::PreUpdate,
             physics::finalize_collider_attach_to_bodies
-                .system()
                 .label(physics::PhysicsSystems::FinalizeColliderAttachToBodies),
         )
         .add_system_to_stage(
             CoreStage::Update,
             physics::step_world_system::<UserData>
-                .system()
                 .label(physics::PhysicsSystems::StepWorld),
         )
         .add_system_to_stage(
             PhysicsStages::SyncTransforms,
             physics::sync_transforms
-                .system()
                 .label(physics::PhysicsSystems::SyncTransforms),
         )
         .add_system_to_stage(
             CoreStage::PostUpdate,
             physics::collect_removals
-                .system()
                 .label(physics::PhysicsSystems::CollectRemovals),
         );
         if app
-            .world()
+            .world
             .get_resource::<PhysicsHooksWithQueryObject<UserData>>()
             .is_none()
         {

--- a/src/physics/rigid_body_component_set.rs
+++ b/src/physics/rigid_body_component_set.rs
@@ -21,90 +21,76 @@ impl IntoEntity for RigidBodyHandle {
     }
 }
 
-pub type RigidBodyComponentsQuery<'a, 'b, 'c> = QuerySet<(
-    Query<
-        'a,
-        (
-            Entity,
-            &'b RigidBodyPosition,
-            &'b RigidBodyVelocity,
-            &'b RigidBodyMassProps,
-            &'b RigidBodyIds,
-            &'b RigidBodyForces,
-            &'b RigidBodyActivation,
-            &'b RigidBodyChanges,
-            &'b RigidBodyCcd,
-            &'b RigidBodyColliders,
-            &'b RigidBodyDamping,
-            &'b RigidBodyDominance,
-            &'b RigidBodyType,
-        ),
-    >,
-    Query<
-        'a,
-        (
-            Entity,
-            &'c mut RigidBodyPosition,
-            &'c mut RigidBodyVelocity,
-            &'c mut RigidBodyMassProps,
-            &'c mut RigidBodyIds,
-            &'c mut RigidBodyForces,
-            &'c mut RigidBodyActivation,
-            &'c mut RigidBodyChanges,
-            &'c mut RigidBodyCcd,
-            // Need for handling collider removals.
-            &'c mut RigidBodyColliders,
-        ),
-    >,
-    Query<
-        'a,
-        (
-            Entity,
-            &'c mut RigidBodyChanges,
-            &'c mut RigidBodyActivation,
-            Or<(Changed<RigidBodyPosition>, Added<RigidBodyPosition>)>,
-            Or<(Changed<RigidBodyVelocity>, Added<RigidBodyVelocity>)>,
-            Or<(Changed<RigidBodyForces>, Added<RigidBodyForces>)>,
-            Or<(Changed<RigidBodyType>, Added<RigidBodyType>)>,
-            Or<(Changed<RigidBodyColliders>, Added<RigidBodyColliders>)>,
-        ),
-        Or<(
-            Changed<RigidBodyPosition>,
-            Added<RigidBodyPosition>,
-            Changed<RigidBodyVelocity>,
-            Added<RigidBodyVelocity>,
-            Changed<RigidBodyForces>,
-            Added<RigidBodyForces>,
-            Changed<RigidBodyActivation>,
-            Added<RigidBodyActivation>,
-            Changed<RigidBodyType>,
-            Added<RigidBodyType>,
-            Changed<RigidBodyColliders>,
-            Added<RigidBodyColliders>,
-        )>,
-    >,
-    Query<
-        'a,
-        &'c mut RigidBodyChanges,
-        Or<(Changed<RigidBodyActivation>, Added<RigidBodyActivation>)>,
-    >,
-)>;
+pub type RigidBodyComponentsQueryPayload<'a> = (
+    Entity,
+    &'a mut RigidBodyPosition,
+    &'a mut RigidBodyVelocity,
+    &'a mut RigidBodyMassProps,
+    &'a mut RigidBodyIds,
+    &'a mut RigidBodyForces,
+    &'a mut RigidBodyCcd,
+    &'a mut RigidBodyColliders,
+    &'a mut RigidBodyDamping,
+    &'a mut RigidBodyDominance,
+    &'a mut RigidBodyType,
+    &'a mut RigidBodyChanges,
+    &'a mut RigidBodyActivation,
+);
 
-pub struct RigidBodyComponentsSet<'a, 'b, 'c>(pub RigidBodyComponentsQuery<'a, 'b, 'c>);
+pub type RigidBodyChangesQueryPayload<'a> = (
+    Entity,
+    &'a mut RigidBodyActivation,
+    &'a mut RigidBodyChanges,
+    Or<(Changed<RigidBodyPosition>, Added<RigidBodyPosition>)>,
+    Or<(Changed<RigidBodyType>, Added<RigidBodyType>)>,
+    Or<(Changed<RigidBodyColliders>, Added<RigidBodyColliders>)>,
+);
 
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyPosition, |data| data.1);
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyVelocity, |data| data.2);
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyMassProps, |data| data.3);
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyIds, |data| data.4);
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyForces, |data| data.5);
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyActivation, |data| data.6);
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyChanges, |data| data.7);
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyCcd, |data| data.8);
-impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyColliders, |data| data.9);
+pub type RigidBodyChangesQueryFilter = (
+    Or<(
+        Changed<RigidBodyPosition>,
+        Added<RigidBodyPosition>,
+        Changed<RigidBodyVelocity>,
+        Added<RigidBodyVelocity>,
+        Changed<RigidBodyForces>,
+        Added<RigidBodyForces>,
+        Changed<RigidBodyActivation>,
+        Added<RigidBodyActivation>,
+        Changed<RigidBodyType>,
+        Added<RigidBodyType>,
+        Changed<RigidBodyColliders>,
+        Added<RigidBodyColliders>,
+    )>,
+);
 
-impl_component_set!(RigidBodyComponentsSet, RigidBodyDamping, |data| data.10);
-impl_component_set!(RigidBodyComponentsSet, RigidBodyDominance, |data| data.11);
-impl_component_set!(RigidBodyComponentsSet, RigidBodyType, |data| data.12);
+pub type RigidBodyComponentsQuerySet<'world, 'state, 'a> = QuerySet<
+    'world,
+    'state,
+    (
+        // Components query
+        QueryState<RigidBodyComponentsQueryPayload<'a>>,
+        // Changes query
+        QueryState<RigidBodyChangesQueryPayload<'a>, RigidBodyChangesQueryFilter>,
+    ),
+>;
+
+pub struct RigidBodyComponentsSet<'world, 'state, 'a>(
+    pub Query<'world, 'state, RigidBodyComponentsQueryPayload<'a>>,
+);
+
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyPosition, |data| &*data.1);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyVelocity, |data| &*data.2);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyMassProps, |data| &*data.3);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyIds, |data| &*data.4);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyForces, |data| &*data.5);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyCcd, |data| &*data.6);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyColliders, |data| &*data.7);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyDamping, |data| &*data.8);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyDominance, |data| &*data.9);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyType, |data| &*data.10);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyChanges, |data| &*data.11);
+impl_component_set_mut!(RigidBodyComponentsSet, RigidBodyActivation, |data| &*data
+    .12);
 
 #[derive(Bundle)]
 pub struct RigidBodyBundle {

--- a/src/render/plugins.rs
+++ b/src/render/plugins.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 pub struct RapierRenderPlugin;
 
 impl Plugin for RapierRenderPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         app.add_system_to_stage(
             CoreStage::PreUpdate,
             systems::create_collider_renders_system

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -172,7 +172,7 @@ fn generate_collider_mesh(co_shape: &ColliderShape) -> Option<(Mesh, Vec3)> {
         #[cfg(feature = "dim3")]
         ShapeType::Cuboid => {
             let c = co_shape.as_cuboid().unwrap();
-            Vec3::from_slice_unaligned(c.half_extents.as_slice())
+            Vec3::new(c.half_extents.x, c.half_extents.y, c.half_extents.z)
         }
         ShapeType::Ball => {
             let b = co_shape.as_ball().unwrap();

--- a/src_debug_ui/plugins.rs
+++ b/src_debug_ui/plugins.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 pub struct DebugUiPlugin;
 
 impl Plugin for DebugUiPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         app.add_startup_system(systems::setup_ui.system())
             .add_system_to_stage(CoreStage::Update, systems::text_update_system.system());
     }


### PR DESCRIPTION
The biggest change here is that doing the same query twice, one mutably and one
immutably, is no longer needed, once bevyengine/bevy#2305 lands. Before that
lands, however, this upgrade is actually impossible to do safely, since the
`q0`/`q0_mut` distinction is gone and therefore it's impossible to implement
the Rapier component traits on Bevy queries. (This is filed upstream as
bevyengine/bevy#2744.) Therefore, this upgrade has to wait until that Bevy PR
lands.

Other minor changes:

* `Light` has been renamed to `PointLight`.

* `App::build()` is now `App::new()`, and `AppBuilder` is now `App`.

* `glam` has been upgraded upstream.