### PR TITLE
Derive Copy, Clone, and Debug for RapierConfiguration

### DIFF
--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -38,6 +38,7 @@ pub enum TimestepMode {
 }
 
 /// A resource for specifying configuration information for the physics simulation
+#[derive(Copy, Clone, Debug)]
 pub struct RapierConfiguration {
     /// Specifying the gravity of the physics simulation.
     pub gravity: Vector<f32>,


### PR DESCRIPTION
Implement some common traits for interoperability [as per official recommendations](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits).

I tried to print out the current `RapierConfiguration`, but since it didn't implement `Debug` I could not. `Copy` and `Clone` make sense for this struct as well.