### PR TITLE
Add debug render mesh for capsule and cylinder collider shapes.

### DIFF
--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -371,10 +371,8 @@ pub(crate) fn sync_transform(pos: &Isometry<f32>, scale: f32, transform: &mut Tr
 #[cfg(feature = "dim3")]
 pub(crate) fn sync_transform(pos: &Isometry<f32>, scale: f32, transform: &mut Transform) {
     let (tra, rot) = (*pos).into();
-    transform.translation.x = tra.x * scale;
-    transform.translation.y = tra.y * scale;
-    transform.translation.z = tra.z * scale;
-    transform.rotation = Quat::from_xyzw(rot.x, rot.y, rot.z, rot.w);
+    transform.translation = tra * scale;
+    transform.rotation = rot;
 }
 
 /// System responsible for writing the rigid-bodies positions into the Bevy translation and rotation components.

--- a/src/render/plugins.rs
+++ b/src/render/plugins.rs
@@ -9,13 +9,11 @@ impl Plugin for RapierRenderPlugin {
         app.add_system_to_stage(
             CoreStage::PreUpdate,
             systems::create_collider_renders_system
-                .system()
                 .label(systems::RenderSystems::CreateColliderRenders),
         );
         app.add_system_to_stage(
             CoreStage::PreUpdate,
             systems::update_collider_render_mesh
-                .system()
                 .label(systems::RenderSystems::UpdateColliderRenderMesh),
         );
     }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -90,7 +90,6 @@ fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Ve
             size: Vec2::new(2.0, 2.0),
             flip: false,
         }),
-        #[cfg(feature = "dim3")]
         ShapeType::Ball => Mesh::from(shape::Icosphere {
             subdivisions: 2,
             radius: 1.0,

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -182,31 +182,18 @@ fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Ve
     };
 
     let scale = match co_shape.shape_type() {
-        #[cfg(feature = "dim2")]
-        ShapeType::Cuboid => {
-            let c = co_shape.as_cuboid().unwrap();
-            Vec3::new(c.half_extents.x, c.half_extents.y, 1.0)
-        }
-        #[cfg(feature = "dim3")]
-        ShapeType::Cuboid => {
-            let c = co_shape.as_cuboid().unwrap();
-            Vec3::new(c.half_extents.x, c.half_extents.y, c.half_extents.z)
-        }
         ShapeType::Ball => {
             let b = co_shape.as_ball().unwrap();
             Vec3::new(b.radius, b.radius, b.radius)
         }
         #[cfg(feature = "dim2")]
-        ShapeType::Capsule => {
+        ShapeType::Cuboid | ShapeType::Capsule => {
             let bb = co_shape.compute_local_aabb().half_extents();
-            let (x, y) = (bb[0], bb[1]);
-            Vec3::new(x, y, 1.0)
+            Vec3::new(bb[0], bb[1], 1.0)
         }
         #[cfg(feature = "dim3")]
-        ShapeType::Capsule | ShapeType::Cylinder => {
-            let bb = co_shape.compute_local_aabb().half_extents();
-            let (x, y, z) = (bb[0], bb[1], bb[2]);
-            Vec3::new(x, y, z)
+        ShapeType::Cuboid | ShapeType::Capsule | ShapeType::Cylinder => {
+            co_shape.compute_local_aabb().half_extents().into()
         }
 
         ShapeType::TriMesh => Vec3::ONE,

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -82,23 +82,18 @@ pub fn update_collider_render_mesh(
 fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Vec3)> {
     let mesh = match co_shape.shape_type() {
         #[cfg(feature = "dim3")]
-        ShapeType::Cuboid => Mesh::from(shape::Cube { size: 2.0 }),
+        ShapeType::Cuboid | ShapeType::Capsule | ShapeType::Cylinder => {
+            Mesh::from(shape::Cube { size: 2.0 })
+        }
         #[cfg(feature = "dim2")]
-        ShapeType::Cuboid => Mesh::from(shape::Quad {
+        ShapeType::Cuboid | ShapeType::Capsule => Mesh::from(shape::Quad {
             size: Vec2::new(2.0, 2.0),
             flip: false,
         }),
+        #[cfg(feature = "dim3")]
         ShapeType::Ball => Mesh::from(shape::Icosphere {
             subdivisions: 2,
             radius: 1.0,
-        }),
-        // For capsules, use cuboids and then scale with the bounding box to better show the true shape of the collider.
-        #[cfg(feature = "dim3")]
-        ShapeType::Capsule => Mesh::from(shape::Cube { size: 2.0 }),
-        #[cfg(feature = "dim2")]
-        ShapeType::Capsule => Mesh::from(shape::Quad {
-            size: Vec2::new(2.0, 2.0),
-            flip: false,
         }),
         #[cfg(feature = "dim2")]
         ShapeType::TriMesh => {
@@ -209,7 +204,7 @@ fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Ve
             Vec3::new(x, y, 1.0)
         }
         #[cfg(feature = "dim3")]
-        ShapeType::Capsule => {
+        ShapeType::Capsule | ShapeType::Cylinder => {
             let bb = co_shape.compute_local_aabb().half_extents();
             let (x, y, z) = (bb[0], bb[1], bb[2]);
             Vec3::new(x, y, z)

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -92,6 +92,14 @@ fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Ve
             subdivisions: 2,
             radius: 1.0,
         }),
+        // For capsules, use cuboids and then scale with the bounding box to better show the true shape of the collider.
+        #[cfg(feature = "dim3")]
+        ShapeType::Capsule => Mesh::from(shape::Cube { size: 2.0 }),
+        #[cfg(feature = "dim2")]
+        ShapeType::Capsule => Mesh::from(shape::Quad {
+            size: Vec2::new(2.0, 2.0),
+            flip: false,
+        }),
         #[cfg(feature = "dim2")]
         ShapeType::TriMesh => {
             let mut mesh =
@@ -194,6 +202,19 @@ fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Ve
             let b = co_shape.as_ball().unwrap();
             Vec3::new(b.radius, b.radius, b.radius)
         }
+        #[cfg(feature = "dim2")]
+        ShapeType::Capsule => {
+            let bb = co_shape.compute_local_aabb().half_extents();
+            let (x, y) = (bb[0], bb[1]);
+            Vec3::new(x, y, 1.0)
+        }
+        #[cfg(feature = "dim3")]
+        ShapeType::Capsule => {
+            let bb = co_shape.compute_local_aabb().half_extents();
+            let (x, y, z) = (bb[0], bb[1], bb[2]);
+            Vec3::new(x, y, z)
+        }
+
         ShapeType::TriMesh => Vec3::ONE,
         _ => unimplemented!(),
     };


### PR DESCRIPTION
Without changing the way that the debug mesh's transform is calculated (just from scale), it's not
possible to accurately show a capsule's orientation in the debug view. So, just use a cuboid and
scale it along the capsule's AABB to get a reasonably accurate approximation.

I also did a minor tidy of the transform sync code.