### PR TITLE
Update to the latest HEAD of rapier/master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,7 @@ codegen-units = 1
 #nalgebra = { path = "../nalgebra" }
 #parry2d = { path = "../parry/build/parry2d" }
 #parry3d = { path = "../parry/build/parry3d" }
-#rapier2d = { path = "../rapier/build/rapier2d" }
-#rapier3d = { path = "../rapier/build/rapier3d" }
+# rapier2d = { path = "../rapier/crates/rapier2d" }
+# rapier3d = { path = "../rapier/crates/rapier3d" }
+rapier2d = { git = "https://github.com/dimforge/rapier", rev = "7efcff615e821d97957fe813d066567117c8e999" }
+rapier3d = { git = "https://github.com/dimforge/rapier", rev = "7efcff615e821d97957fe813d066567117c8e999" }

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -158,7 +158,7 @@ fn setup_board(commands: &mut Commands, game: &Game) {
             ..Default::default()
         })
         .insert_bundle(RigidBodyBundle {
-            body_type: RigidBodyType::Static.into(),
+            body_type: RigidBodyType::Fixed.into(),
             position: [0.0, floor_y - (FLOOR_BLOCK_HEIGHT * 0.5)].into(),
             ..RigidBodyBundle::default()
         })
@@ -195,7 +195,7 @@ fn spawn_cube(commands: &mut Commands, game: &mut Game) {
             commands
                 .spawn()
                 .insert_bundle((JointBuilderComponent::new(
-                    RevoluteJoint::new()
+                    RevoluteJointBuilder::new()
                         .local_anchor1(anchor_1)
                         .local_anchor2(anchor_2),
                     block_entities[*i],

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -49,16 +49,9 @@ fn setup_graphics(mut commands: Commands, mut configuration: ResMut<RapierConfig
         .insert_bundle(OrthographicCameraBundle::new_2d());
 }
 
-fn display_events(
-    mut intersection_events: EventReader<IntersectionEvent>,
-    mut contact_events: EventReader<ContactEvent>,
-) {
-    for intersection_event in intersection_events.iter() {
-        println!("Received intersection event: {:?}", intersection_event);
-    }
-
-    for contact_event in contact_events.iter() {
-        println!("Received contact event: {:?}", contact_event);
+fn display_events(mut collision_events: EventReader<CollisionEvent>) {
+    for collision_event in collision_events.iter() {
+        println!("Received collision event: {:?}", collision_event);
     }
 }
 
@@ -92,7 +85,7 @@ pub fn setup_physics(mut commands: Commands) {
     };
     let collider = ColliderBundle {
         shape: ColliderShape::cuboid(0.5, 0.5).into(),
-        flags: (ActiveEvents::INTERSECTION_EVENTS | ActiveEvents::CONTACT_EVENTS).into(),
+        flags: (ActiveEvents::COLLISION_EVENTS).into(),
         ..Default::default()
     };
     commands

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
 use nalgebra::Point2;
-use rapier2d::dynamics::{RevoluteJoint, RigidBodyType};
+use rapier2d::dynamics::RigidBodyType;
 use rapier2d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
 
@@ -73,7 +73,7 @@ pub fn setup_physics(mut commands: Commands) {
             color += 1;
 
             let body_type = if i == 0 && (k % 4 == 0 || k == numk - 1) {
-                RigidBodyType::Static
+                RigidBodyType::Fixed
             } else {
                 RigidBodyType::Dynamic
             };
@@ -98,7 +98,7 @@ pub fn setup_physics(mut commands: Commands) {
             // Vertical joint.
             if i > 0 {
                 let parent_entity = *body_entities.last().unwrap();
-                let joint = RevoluteJoint::new().local_anchor2(Point2::new(0.0, shift));
+                let joint = RevoluteJointBuilder::new().local_anchor2(Point2::new(0.0, shift));
                 commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,
@@ -110,7 +110,7 @@ pub fn setup_physics(mut commands: Commands) {
             if k > 0 {
                 let parent_index = body_entities.len() - numi;
                 let parent_entity = body_entities[parent_index];
-                let joint = RevoluteJoint::new().local_anchor2(Point2::new(-shift, 0.0));
+                let joint = RevoluteJointBuilder::new().local_anchor2(Point2::new(-shift, 0.0));
                 commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,

--- a/bevy_rapier2d/examples/joints_despawn2.rs
+++ b/bevy_rapier2d/examples/joints_despawn2.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
 use nalgebra::Point2;
-use rapier2d::dynamics::{RevoluteJoint, RigidBodyType};
+use rapier2d::dynamics::RigidBodyType;
 use rapier2d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
 
@@ -80,7 +80,7 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
             color += 1;
 
             let body_type = if i == 0 && (k % 4 == 0 || k == numk - 1) {
-                RigidBodyType::Static
+                RigidBodyType::Fixed
             } else {
                 RigidBodyType::Dynamic
             };
@@ -104,7 +104,7 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
             // Vertical joint.
             if i > 0 {
                 let parent_entity = *body_entities.last().unwrap();
-                let joint = RevoluteJoint::new().local_anchor2(Point2::new(0.0, shift));
+                let joint = RevoluteJointBuilder::new().local_anchor2(Point2::new(0.0, shift));
                 let entity = commands
                     .spawn()
                     .insert_bundle((JointBuilderComponent::new(
@@ -122,7 +122,7 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
             if k > 0 {
                 let parent_index = body_entities.len() - numi;
                 let parent_entity = body_entities[parent_index];
-                let joint = RevoluteJoint::new().local_anchor2(Point2::new(-shift, 0.0));
+                let joint = RevoluteJointBuilder::new().local_anchor2(Point2::new(-shift, 0.0));
                 let entity = commands
                     .spawn()
                     .insert_bundle((JointBuilderComponent::new(

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -71,7 +71,7 @@ pub fn setup_physics(mut commands: Commands) {
      */
     let rigid_body = RigidBodyBundle {
         position: [0.0, 3.0].into(),
-        mass_properties: RigidBodyMassPropsFlags::TRANSLATION_LOCKED.into(),
+        mass_properties: LockedAxes::TRANSLATION_LOCKED.into(),
         ..Default::default()
     };
     let collider = ColliderBundle {
@@ -89,7 +89,7 @@ pub fn setup_physics(mut commands: Commands) {
      */
     let rigid_body = RigidBodyBundle {
         position: Isometry2::new([0.3, 5.0].into(), 1.0).into(),
-        mass_properties: RigidBodyMassPropsFlags::ROTATION_LOCKED.into(),
+        mass_properties: LockedAxes::ROTATION_LOCKED.into(),
         ..Default::default()
     };
     let collider = ColliderBundle {

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -68,16 +68,9 @@ fn setup_graphics(mut commands: Commands) {
     });
 }
 
-fn display_events(
-    mut intersection_events: EventReader<IntersectionEvent>,
-    mut contact_events: EventReader<ContactEvent>,
-) {
-    for intersection_event in intersection_events.iter() {
-        println!("Received intersection event: {:?}", intersection_event);
-    }
-
-    for contact_event in contact_events.iter() {
-        println!("Received contact event: {:?}", contact_event);
+fn display_events(mut collision_events: EventReader<CollisionEvent>) {
+    for collision_event in collision_events.iter() {
+        println!("Received collision event: {:?}", collision_event);
     }
 }
 
@@ -119,7 +112,7 @@ pub fn setup_physics(mut commands: Commands) {
 
     let collider = ColliderBundle {
         shape: ColliderShape::cuboid(0.5, 0.5, 0.5).into(),
-        flags: (ActiveEvents::INTERSECTION_EVENTS | ActiveEvents::CONTACT_EVENTS).into(),
+        flags: (ActiveEvents::COLLISION_EVENTS).into(),
         ..ColliderBundle::default()
     };
 

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
 use na::{Isometry3, Point3, Unit, Vector3};
-use rapier::dynamics::{FixedJoint, PrismaticJoint, RevoluteJoint, RigidBodyType, SphericalJoint};
+use rapier::dynamics::RigidBodyType;
 use rapier3d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
 
@@ -75,7 +75,7 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Point3<f32>, num: us
     let shift = 1.0;
 
     let body = RigidBodyBundle {
-        body_type: RigidBodyType::Static.into(),
+        body_type: RigidBodyType::Fixed.into(),
         position: origin.into(),
         ..Default::default()
     };
@@ -117,9 +117,9 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Point3<f32>, num: us
             Unit::new_normalize(Vector3::new(-1.0, 1.0, 0.0))
         };
 
-        let prism = PrismaticJoint::new(axis)
+        let prism = PrismaticJointBuilder::new(axis)
             .local_anchor2(Point3::new(0.0, 0.0, -shift))
-            .limit_axis([-2.0, 2.0]);
+            .limits([-2.0, 2.0]);
 
         commands.spawn_bundle((JointBuilderComponent::new(prism, curr_parent, curr_child),));
 
@@ -132,7 +132,7 @@ fn create_revolute_joints(commands: &mut Commands, origin: Point3<f32>, num: usi
     let shift = 2.0;
 
     let ground = RigidBodyBundle {
-        body_type: RigidBodyType::Static.into(),
+        body_type: RigidBodyType::Fixed.into(),
         position: [origin.x, origin.y, 0.0].into(),
         ..RigidBodyBundle::default()
     };
@@ -184,10 +184,10 @@ fn create_revolute_joints(commands: &mut Commands, origin: Point3<f32>, num: usi
         let z = Vector3::z_axis();
 
         let revs = [
-            RevoluteJoint::new(z).local_anchor2(Point3::new(0.0, 0.0, -shift)),
-            RevoluteJoint::new(x).local_anchor2(Point3::new(-shift, 0.0, 0.0)),
-            RevoluteJoint::new(z).local_anchor2(Point3::new(0.0, 0.0, -shift)),
-            RevoluteJoint::new(x).local_anchor2(Point3::new(shift, 0.0, 0.0)),
+            RevoluteJointBuilder::new(z).local_anchor2(Point3::new(0.0, 0.0, -shift)),
+            RevoluteJointBuilder::new(x).local_anchor2(Point3::new(-shift, 0.0, 0.0)),
+            RevoluteJointBuilder::new(z).local_anchor2(Point3::new(0.0, 0.0, -shift)),
+            RevoluteJointBuilder::new(x).local_anchor2(Point3::new(shift, 0.0, 0.0)),
         ];
 
         commands.spawn_bundle((JointBuilderComponent::new(revs[0], curr_parent, handles[0]),));
@@ -216,7 +216,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Point3<f32>, num: usize)
             // fixed bodies. Because physx will crash if we add
             // a joint between these.
             let body_type = if i == 0 && (k % 4 == 0 && k != num - 2 || k == num - 1) {
-                RigidBodyType::Static
+                RigidBodyType::Fixed
             } else {
                 RigidBodyType::Dynamic
             };
@@ -242,7 +242,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Point3<f32>, num: usize)
             // Vertical joint.
             if i > 0 {
                 let parent_entity = *body_entities.last().unwrap();
-                let joint = FixedJoint::new().local_anchor2(point![0.0, 0.0, -shift]);
+                let joint = FixedJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift]);
                 commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,
@@ -254,7 +254,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Point3<f32>, num: usize)
             if k > 0 {
                 let parent_index = body_entities.len() - num;
                 let parent_entity = body_entities[parent_index];
-                let joint = FixedJoint::new().local_anchor2(point![-shift, 0.0, 0.0]);
+                let joint = FixedJointBuilder::new().local_anchor2(point![-shift, 0.0, 0.0]);
                 commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,
@@ -281,7 +281,7 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
             color += 1;
 
             let body_type = if i == 0 && (k % 4 == 0 || k == num - 1) {
-                RigidBodyType::Static
+                RigidBodyType::Fixed
             } else {
                 RigidBodyType::Dynamic
             };
@@ -307,7 +307,8 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
             // Vertical joint.
             if i > 0 {
                 let parent_entity = *body_entities.last().unwrap();
-                let joint = SphericalJoint::new().local_anchor2(Point3::new(0.0, 0.0, -shift));
+                let joint =
+                    SphericalJointBuilder::new().local_anchor2(Point3::new(0.0, 0.0, -shift));
                 commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,
@@ -319,7 +320,8 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
             if k > 0 {
                 let parent_index = body_entities.len() - num;
                 let parent_entity = body_entities[parent_index];
-                let joint = SphericalJoint::new().local_anchor2(Point3::new(-shift, 0.0, 0.0));
+                let joint =
+                    SphericalJointBuilder::new().local_anchor2(Point3::new(-shift, 0.0, 0.0));
                 commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
 use na::{Isometry3, Point3, Unit, Vector3};
-use rapier::dynamics::{FixedJoint, PrismaticJoint, RevoluteJoint, RigidBodyType, SphericalJoint};
+use rapier::dynamics::RigidBodyType;
 use rapier3d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
 
@@ -87,7 +87,7 @@ fn create_prismatic_joints(
     let shift = 1.0;
 
     let body = RigidBodyBundle {
-        body_type: RigidBodyType::Static.into(),
+        body_type: RigidBodyType::Fixed.into(),
         position: origin.into(),
         ..Default::default()
     };
@@ -129,9 +129,9 @@ fn create_prismatic_joints(
             Unit::new_normalize(Vector3::new(-1.0, 1.0, 0.0))
         };
 
-        let prism = PrismaticJoint::new(axis)
+        let prism = PrismaticJointBuilder::new(axis)
             .local_anchor2(Point3::new(0.0, 0.0, -shift))
-            .limit_axis([-2.0, 2.0]);
+            .limits([-2.0, 2.0]);
 
         let entity = commands
             .spawn_bundle((JointBuilderComponent::new(prism, curr_parent, curr_child),))
@@ -155,7 +155,7 @@ fn create_revolute_joints(
     let shift = 2.0;
 
     let ground = RigidBodyBundle {
-        body_type: RigidBodyType::Static.into(),
+        body_type: RigidBodyType::Fixed.into(),
         position: [origin.x, origin.y, 0.0].into(),
         ..RigidBodyBundle::default()
     };
@@ -207,10 +207,10 @@ fn create_revolute_joints(
         let z = Vector3::z_axis();
 
         let revs = [
-            RevoluteJoint::new(z).local_anchor2(Point3::new(0.0, 0.0, -shift)),
-            RevoluteJoint::new(x).local_anchor2(Point3::new(-shift, 0.0, 0.0)),
-            RevoluteJoint::new(z).local_anchor2(Point3::new(0.0, 0.0, -shift)),
-            RevoluteJoint::new(x).local_anchor2(Point3::new(shift, 0.0, 0.0)),
+            RevoluteJointBuilder::new(z).local_anchor2(Point3::new(0.0, 0.0, -shift)),
+            RevoluteJointBuilder::new(x).local_anchor2(Point3::new(-shift, 0.0, 0.0)),
+            RevoluteJointBuilder::new(z).local_anchor2(Point3::new(0.0, 0.0, -shift)),
+            RevoluteJointBuilder::new(x).local_anchor2(Point3::new(shift, 0.0, 0.0)),
         ];
 
         let entity1 = commands
@@ -259,7 +259,7 @@ fn create_fixed_joints(
             // fixed bodies. Because physx will crash if we add
             // a joint between these.
             let body_type = if i == 0 && (k % 4 == 0 && k != num - 2 || k == num - 1) {
-                RigidBodyType::Static
+                RigidBodyType::Fixed
             } else {
                 RigidBodyType::Dynamic
             };
@@ -285,7 +285,7 @@ fn create_fixed_joints(
             // Vertical joint.
             if i > 0 {
                 let parent_entity = *body_entities.last().unwrap();
-                let joint = FixedJoint::new().local_anchor2(point![0.0, 0.0, -shift]);
+                let joint = FixedJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift]);
 
                 commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
@@ -298,7 +298,7 @@ fn create_fixed_joints(
             if k > 0 {
                 let parent_index = body_entities.len() - num;
                 let parent_entity = body_entities[parent_index];
-                let joint = FixedJoint::new().local_anchor2(point![-shift, 0.0, 0.0]);
+                let joint = FixedJointBuilder::new().local_anchor2(point![-shift, 0.0, 0.0]);
 
                 let entity = commands
                     .spawn()
@@ -332,7 +332,7 @@ fn create_ball_joints(commands: &mut Commands, num: usize, despawn: &mut ResMut<
             color += 1;
 
             let body_type = if i == 0 && (k % 4 == 0 || k == num - 1) {
-                RigidBodyType::Static
+                RigidBodyType::Fixed
             } else {
                 RigidBodyType::Dynamic
             };
@@ -358,7 +358,8 @@ fn create_ball_joints(commands: &mut Commands, num: usize, despawn: &mut ResMut<
             // Vertical joint.
             if i > 0 {
                 let parent_entity = *body_entities.last().unwrap();
-                let joint = SphericalJoint::new().local_anchor2(Point3::new(0.0, 0.0, -shift));
+                let joint =
+                    SphericalJointBuilder::new().local_anchor2(Point3::new(0.0, 0.0, -shift));
                 let entity = commands
                     .spawn()
                     .insert_bundle((JointBuilderComponent::new(
@@ -377,7 +378,8 @@ fn create_ball_joints(commands: &mut Commands, num: usize, despawn: &mut ResMut<
             if k > 0 {
                 let parent_index = body_entities.len() - num;
                 let parent_entity = body_entities[parent_index];
-                let joint = SphericalJoint::new().local_anchor2(Point3::new(-shift, 0.0, 0.0));
+                let joint =
+                    SphericalJointBuilder::new().local_anchor2(Point3::new(-shift, 0.0, 0.0));
                 commands.spawn_bundle((JointBuilderComponent::new(
                     joint,
                     parent_entity,

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -3,7 +3,7 @@ extern crate rapier3d as rapier; // For the debug UI.
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
-use rapier::dynamics::RigidBodyMassPropsFlags;
+use rapier::dynamics::LockedAxes;
 use rapier::geometry::ColliderShape;
 use rapier3d::pipeline::PhysicsPipeline;
 use ui::DebugUiPlugin;
@@ -89,9 +89,9 @@ pub fn setup_physics(mut commands: Commands) {
     /*
      * A rectangle that only rotates along the `x` axis.
      */
-    let locked_dofs = RigidBodyMassPropsFlags::TRANSLATION_LOCKED
-        | RigidBodyMassPropsFlags::ROTATION_LOCKED_Y
-        | RigidBodyMassPropsFlags::ROTATION_LOCKED_Z;
+    let locked_dofs = LockedAxes::TRANSLATION_LOCKED
+        | LockedAxes::ROTATION_LOCKED_Y
+        | LockedAxes::ROTATION_LOCKED_Z;
 
     let rigid_body = RigidBodyBundle {
         position: [0.0, 3.0, 0.0].into(),
@@ -114,7 +114,7 @@ pub fn setup_physics(mut commands: Commands) {
      */
     let rigid_body = RigidBodyBundle {
         position: (Vec3::new(0.0, 5.0, 0.0), Quat::from_rotation_x(1.0)).into(),
-        mass_properties: RigidBodyMassPropsFlags::ROTATION_LOCKED.into(),
+        mass_properties: LockedAxes::ROTATION_LOCKED.into(),
         ..RigidBodyBundle::default()
     };
 

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use rapier::dynamics::{JointData, JointHandle, RigidBodyHandle};
+use rapier::dynamics::{GenericJoint, ImpulseJointHandle, RigidBodyHandle};
 use rapier::geometry::ColliderHandle;
 use rapier::math::Isometry;
 
@@ -49,13 +49,13 @@ impl ColliderHandleComponent {
 /// added to an entity by the `JointBuilderComponent`.
 #[derive(Component)]
 pub struct JointHandleComponent {
-    handle: JointHandle,
+    handle: ImpulseJointHandle,
     entity1: Entity,
     entity2: Entity,
 }
 
 impl JointHandleComponent {
-    pub(crate) fn new(handle: JointHandle, entity1: Entity, entity2: Entity) -> Self {
+    pub(crate) fn new(handle: ImpulseJointHandle, entity1: Entity, entity2: Entity) -> Self {
         Self {
             handle,
             entity1,
@@ -64,7 +64,7 @@ impl JointHandleComponent {
     }
 
     /// The Rapier handle of the joint.
-    pub fn handle(&self) -> JointHandle {
+    pub fn handle(&self) -> ImpulseJointHandle {
         self.handle
     }
 
@@ -85,7 +85,7 @@ impl JointHandleComponent {
 /// once the Rapier joint it describes has been created and added to the `JointSet` resource.
 #[derive(Component)]
 pub struct JointBuilderComponent {
-    pub(crate) params: JointData,
+    pub(crate) params: GenericJoint,
     pub(crate) entity1: Entity,
     pub(crate) entity2: Entity,
 }
@@ -94,7 +94,7 @@ impl JointBuilderComponent {
     /// Initializes a joint builder from the given joint params and the entities attached to this joint.
     pub fn new<J>(joint: J, entity1: Entity, entity2: Entity) -> Self
     where
-        J: Into<JointData>,
+        J: Into<GenericJoint>,
     {
         JointBuilderComponent {
             params: joint.into(),

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -7,7 +7,7 @@ pub use self::systems::*;
 pub mod wrapper;
 use crate::rapier::data::{ComponentSet, ComponentSetMut, ComponentSetOption, Index};
 //use crate::rapier::prelude::*;
-use crate::rapier::prelude::JointHandle;
+use crate::rapier::prelude::ImpulseJointHandle;
 use bevy::prelude::{Entity, Query};
 
 pub trait IntoHandle<H> {
@@ -34,14 +34,14 @@ impl IntoEntity for Index {
     }
 }
 
-impl IntoHandle<JointHandle> for Entity {
+impl IntoHandle<ImpulseJointHandle> for Entity {
     #[inline]
-    fn handle(self) -> JointHandle {
-        JointHandle::from_raw_parts(self.id(), self.generation())
+    fn handle(self) -> ImpulseJointHandle {
+        ImpulseJointHandle::from_raw_parts(self.id(), self.generation())
     }
 }
 
-impl IntoEntity for JointHandle {
+impl IntoEntity for ImpulseJointHandle {
     fn entity(self) -> Entity {
         self.0.entity()
     }

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -3,8 +3,7 @@ use crate::physics::{
     JointsEntityMap, ModificationTracker, PhysicsHooksWithQueryObject, RapierConfiguration,
     SimulationToRenderTime,
 };
-use crate::prelude::IntersectionEvent;
-use crate::rapier::geometry::ContactEvent;
+use crate::rapier::geometry::CollisionEvent;
 use crate::rapier::pipeline::QueryPipeline;
 use bevy::app::Events;
 use bevy::ecs::query::WorldQuery;
@@ -72,8 +71,7 @@ impl<UserData: 'static + WorldQuery + Send + Sync> Plugin for RapierPhysicsPlugi
         .insert_resource(ImpulseJointSet::new())
         .insert_resource(MultibodyJointSet::new())
         .insert_resource(CCDSolver::new())
-        .insert_resource(Events::<IntersectionEvent>::default())
-        .insert_resource(Events::<ContactEvent>::default())
+        .insert_resource(Events::<CollisionEvent>::default())
         .insert_resource(SimulationToRenderTime::default())
         .insert_resource(JointsEntityMap::default())
         .insert_resource(ModificationTracker::default())

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -13,8 +13,8 @@ use bevy::prelude::*;
 use rapier::data::{ComponentSet, ComponentSetMut};
 use rapier::prelude::{
     CollisionEvent, ContactModificationContext, ContactPair, EventHandler, ImpulseJointHandle,
-    ImpulseJointSet, IslandManager, MultibodyJointSet, PairFilterContext,
-    PhysicsHooks, SolverFlags, Vector,
+    ImpulseJointSet, IslandManager, MultibodyJointSet, PairFilterContext, PhysicsHooks,
+    SolverFlags, Vector,
 };
 use rapier::{dynamics, geometry};
 use std::collections::HashMap;

--- a/src/physics/resources.rs
+++ b/src/physics/resources.rs
@@ -342,7 +342,7 @@ pub struct PhysicsHooksWithQueryObject<UserData: WorldQuery>(
     pub Box<dyn PhysicsHooksWithQuery<UserData>>,
 );
 
-pub(crate) struct PhysicsHooksWithQueryInstance<'world, 'state, 'b, UserData: WorldQuery> {
+pub struct PhysicsHooksWithQueryInstance<'world, 'state, 'b, UserData: WorldQuery> {
     pub user_data: Query<'world, 'state, UserData>,
     pub hooks: &'b dyn PhysicsHooksWithQuery<UserData>,
 }

--- a/src/physics/systems.rs
+++ b/src/physics/systems.rs
@@ -13,7 +13,7 @@ use crate::physics::wrapper::{
     RigidBodyCcdComponent, RigidBodyChangesComponent, RigidBodyCollidersComponent,
     RigidBodyIdsComponent, RigidBodyMassPropsComponent, RigidBodyPositionComponent,
 };
-use crate::prelude::{ContactEvent, IntersectionEvent};
+use crate::prelude::CollisionEvent;
 use crate::rapier::data::ComponentSetOption;
 
 use crate::rapier::pipeline::QueryPipeline;
@@ -218,10 +218,7 @@ pub fn step_world_system<UserData: 'static + WorldQuery>(
         ResMut<JointsEntityMap>,
     ),
     hooks: Res<PhysicsHooksWithQueryObject<UserData>>,
-    (intersection_events, contact_events): (
-        EventWriter<IntersectionEvent>,
-        EventWriter<ContactEvent>,
-    ),
+    collision_events: EventWriter<CollisionEvent>,
     user_data: Query<UserData>,
     mut position_sync_query: Query<(Entity, &mut RigidBodyPositionSync)>,
     mut bodies_query: RigidBodyComponentsQuerySet,
@@ -236,8 +233,7 @@ pub fn step_world_system<UserData: 'static + WorldQuery>(
     use std::mem::replace;
 
     let events = EventQueue {
-        intersection_events: RwLock::new(intersection_events),
-        contact_events: RwLock::new(contact_events),
+        collision_events: RwLock::new(collision_events),
     };
     modifs_tracker.detect_removals(removed_bodies, removed_colliders, removed_joints);
     modifs_tracker.detect_modifications(bodies_query.q1(), colliders_query.q1());


### PR DESCRIPTION
This makes `bevy_rapier` compatible with the latest commit (7efcff615e821) on the `master` branch of `rapier`. This fixes an important bug in the broad-phase that could result in crashing after modifying and creating colliders and a particular order.