### PR TITLE
Update to bevy 0.7

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -29,11 +29,11 @@ serde-serialize = [ "rapier2d/serde-serialize" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.6", default-features = false }
+bevy = { version = "0.7", default-features = false }
 nalgebra = { version = "0.30.1", features = [ "convert-glam020" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = { version = "0.12.0-alpha.0", default-features = false, features = [ "dim2", "f32" ] }
 
 [dev-dependencies]
-bevy = "0.6"
+bevy = "0.7"
 oorandom = "11"

--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -21,9 +21,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -59,9 +59,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<&CustomFilterTag>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -12,8 +12,8 @@ fn main() {
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_game.system())
-        .add_system(cube_sleep_detection.system())
+        .add_startup_system(setup_game)
+        .add_system(cube_sleep_detection)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .run();
 }

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -34,11 +34,11 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
-        .add_system(despawn.system())
-        .add_system(resize.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
+        .add_system(despawn)
+        .add_system(resize)
         .run();
 }
 

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -21,10 +21,10 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
-        .add_system_to_stage(CoreStage::PostUpdate, display_events.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
+        .add_system_to_stage(CoreStage::PostUpdate, display_events)
         .run();
 }
 

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -23,9 +23,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier2d/examples/joints_despawn2.rs
+++ b/bevy_rapier2d/examples/joints_despawn2.rs
@@ -29,10 +29,10 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
-        .add_system(despawn.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
+        .add_system(despawn)
         .run();
 }
 

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -22,9 +22,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -20,8 +20,8 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
         .run();
 }
 

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -11,8 +11,8 @@ fn main() {
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(spawn_player.system())
-        .add_system(player_movement.system())
+        .add_startup_system(spawn_player)
+        .add_system(player_movement)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .run();
 }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -29,7 +29,7 @@ serde-serialize = [ "rapier3d/serde-serialize" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.6", default-features = false }
+bevy = { version = "0.7", default-features = false }
 nalgebra = { version = "0.30.1", features = [ "convert-glam020" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = { version = "^0.12.0-alpha.0", default-features = false, features = [ "dim3", "f32" ] }

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -22,9 +22,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -59,9 +59,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<&CustomFilterTag>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -27,10 +27,10 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
-        .add_system(despawn.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
+        .add_system(despawn)
         .run();
 }
 

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -21,10 +21,10 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
-        .add_system_to_stage(CoreStage::PostUpdate, display_events.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
+        .add_system_to_stage(CoreStage::PostUpdate, display_events)
         .run();
 }
 

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -24,9 +24,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -30,10 +30,10 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
-        .add_system(despawn.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
+        .add_system(despawn)
         .run();
 }
 

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -23,9 +23,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier3d/examples/multiple_colliders3.rs
+++ b/bevy_rapier3d/examples/multiple_colliders3.rs
@@ -22,9 +22,9 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .run();
 }
 

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -23,10 +23,10 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
-        .add_system(cast_ray.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
+        .add_system(cast_ray)
         .run();
 }
 

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -25,11 +25,11 @@ fn main() {
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierRenderPlugin)
         .add_plugin(DebugUiPlugin)
-        .add_startup_system(setup_graphics.system())
-        .add_startup_system(setup_physics.system())
-        .add_startup_system(enable_physics_profiling.system())
+        .add_startup_system(setup_graphics)
+        .add_startup_system(setup_physics)
+        .add_startup_system(enable_physics_profiling)
         .insert_resource(BallState::default())
-        .add_system(ball_spawner.system())
+        .add_system(ball_spawner)
         .run();
 }
 

--- a/src/physics/collider_component_set.rs
+++ b/src/physics/collider_component_set.rs
@@ -110,14 +110,14 @@ pub type ColliderChangesQueryFilter = (
     )>,
 );
 
-pub type ColliderComponentsQuerySet<'world, 'state, 'a> = QuerySet<
+pub type ColliderComponentsQuerySet<'world, 'state, 'a> = ParamSet<
     'world,
     'state,
     (
         // Components query
-        QueryState<ColliderComponentsQueryPayload<'a>>,
+        Query<'world, 'state, ColliderComponentsQueryPayload<'a>>,
         // Changes query
-        QueryState<ColliderChangesQueryPayload<'a>, ColliderChangesQueryFilter>,
+        Query<'world, 'state, ColliderChangesQueryPayload<'a>, ColliderChangesQueryFilter>,
     ),
 >;
 

--- a/src/physics/plugins.rs
+++ b/src/physics/plugins.rs
@@ -6,7 +6,7 @@ use crate::physics::{
 use crate::prelude::IntersectionEvent;
 use crate::rapier::geometry::ContactEvent;
 use crate::rapier::pipeline::QueryPipeline;
-use bevy::app::Events;
+use bevy::ecs::event::Events;
 use bevy::ecs::query::WorldQuery;
 use bevy::prelude::*;
 use rapier::dynamics::{

--- a/src/physics/rigid_body_component_set.rs
+++ b/src/physics/rigid_body_component_set.rs
@@ -73,14 +73,14 @@ pub type RigidBodyChangesQueryFilter = (
     )>,
 );
 
-pub type RigidBodyComponentsQuerySet<'world, 'state, 'a> = QuerySet<
+pub type RigidBodyComponentsQuerySet<'world, 'state, 'a> = ParamSet<
     'world,
     'state,
     (
         // Components query
-        QueryState<RigidBodyComponentsQueryPayload<'a>>,
+        Query<'world, 'state, RigidBodyComponentsQueryPayload<'a>>,
         // Changes query
-        QueryState<RigidBodyChangesQueryPayload<'a>, RigidBodyChangesQueryFilter>,
+        Query<'world, 'state, RigidBodyChangesQueryPayload<'a>, RigidBodyChangesQueryFilter>,
     ),
 >;
 

--- a/src/render/plugins.rs
+++ b/src/render/plugins.rs
@@ -9,13 +9,11 @@ impl Plugin for RapierRenderPlugin {
         app.add_system_to_stage(
             CoreStage::PreUpdate,
             systems::create_collider_renders_system
-                .system()
                 .label(systems::RenderSystems::CreateColliderRenders),
         );
         app.add_system_to_stage(
             CoreStage::PreUpdate,
             systems::update_collider_render_mesh
-                .system()
                 .label(systems::RenderSystems::UpdateColliderRenderMesh),
         );
     }

--- a/src/render/systems.rs
+++ b/src/render/systems.rs
@@ -97,7 +97,7 @@ fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Ve
             let mut mesh =
                 Mesh::new(bevy::render::render_resource::PrimitiveTopology::TriangleList);
             let trimesh = co_shape.as_trimesh().unwrap();
-            mesh.set_attribute(
+            mesh.insert_attribute(
                 Mesh::ATTRIBUTE_POSITION,
                 VertexAttributeValues::from(
                     trimesh
@@ -122,7 +122,7 @@ fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Ve
             let mut mesh =
                 Mesh::new(bevy::render::render_resource::PrimitiveTopology::TriangleList);
             let trimesh = co_shape.as_trimesh().unwrap();
-            mesh.set_attribute(
+            mesh.insert_attribute(
                 Mesh::ATTRIBUTE_POSITION,
                 VertexAttributeValues::from(
                     trimesh
@@ -153,10 +153,10 @@ fn generate_collider_mesh(co_shape: &ColliderShapeComponent) -> Option<(Mesh, Ve
                     [normal.x, normal.y, normal.z]
                 })
                 .collect();
-            mesh.set_attribute(Mesh::ATTRIBUTE_NORMAL, VertexAttributeValues::from(normals));
+            mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, VertexAttributeValues::from(normals));
             // There's nothing particularly meaningful we can do
             // for this one without knowing anything about the overall topology.
-            mesh.set_attribute(
+            mesh.insert_attribute(
                 Mesh::ATTRIBUTE_UV_0,
                 VertexAttributeValues::from(
                     trimesh

--- a/src_debug_ui/plugins.rs
+++ b/src_debug_ui/plugins.rs
@@ -5,7 +5,7 @@ pub struct DebugUiPlugin;
 
 impl Plugin for DebugUiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(systems::setup_ui.system())
-            .add_system_to_stage(CoreStage::Update, systems::text_update_system.system());
+        app.add_startup_system(systems::setup_ui)
+            .add_system_to_stage(CoreStage::Update, systems::text_update_system);
     }
 }


### PR DESCRIPTION
I've read #134 so no need to merge this, but in the mean time, if someone wants to use bevy_rapier in Bevy 0.7 they can check out this PR.

Fairly trivial changes. Mostly just noise from removing `.system()` calls. 