### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.13.0 (30 Apr. 2022)
+This is a **complete rewrite of the plugin** (mostly likely the last large redesign this plugin
+will be subject to). It switches to `rapier` 0.12 and `bevy` 0.7. The focus of this rewrite was
+to significantly improve ergonomics while simplifying the codebase and adding new features.
+
+Refer to [#138](https://github.com/dimforge/bevy_rapier/pull/138) for extensive details
+on this change. See the folders `bevy_rapier2d/examples` and `bevy_rapier3d/examples`
+for some examples.
+
 ## 0.12.0
 ### Modified
 - Switch to `rapier` 0.12.0-alpha.0 and `nalgebra` 0.30.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ codegen-units = 1
 #rapier2d = { path = "../rapier/crates/rapier2d" }
 #rapier3d = { path = "../rapier/crates/rapier3d" }
 
-nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
-parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
-rapier2d = { git = "https://github.com/dimforge/rapier", branch = "master" }
-rapier3d = { git = "https://github.com/dimforge/rapier", branch = "master" }
+#nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
+#parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
+#rapier2d = { git = "https://github.com/dimforge/rapier", branch = "master" }
+#rapier3d = { git = "https://github.com/dimforge/rapier", branch = "master" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
@@ -30,9 +30,9 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.7", default-features = false }
-nalgebra = { version = "0.30.1", features = [ "convert-glam020" ] }
+nalgebra = { version = "0.31", features = [ "convert-glam020" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = "0.12.0-alpha.0"
+rapier2d = "0.12.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", optional = true }
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
@@ -30,9 +30,9 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.7", default-features = false }
-nalgebra = { version = "0.30.1", features = [ "convert-glam020" ] }
+nalgebra = { version = "0.31", features = [ "convert-glam020" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = "0.12.0-alpha.0"
+rapier3d = "0.12.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", features = ["3d"], optional = true }
 log = "0.4"


### PR DESCRIPTION
## 0.13.0 (30 Apr. 2022)
This is a **complete rewrite of the plugin** (mostly likely the last large redesign this plugin
will be subject to). It switches to `rapier` 0.12 and `bevy` 0.7. The focus of this rewrite was
to significantly improve ergonomics while simplifying the codebase and adding new features.

Refer to [#138](https://github.com/dimforge/bevy_rapier/pull/138) for extensive details
on this change. See the folders `bevy_rapier2d/examples` and `bevy_rapier3d/examples`
for some examples.