### PR TITLE
Reduce bevy dependencies

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -20,7 +20,7 @@ required-features = [ "dim2" ]
 [features]
 default = [ "dim2", "debug-render" ]
 dim2 = []
-debug-render = [ "bevy/render", "rapier2d/debug-render" ]
+debug-render = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "bevy/bevy_sprite", "rapier2d/debug-render" ]
 parallel = [ "rapier2d/parallel" ]
 simd-stable = [ "rapier2d/simd-stable" ]
 simd-nightly = [ "rapier2d/simd-nightly" ]
@@ -39,5 +39,5 @@ log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
-bevy = "0.7"
+bevy = { version = "0.7", default-features = false, features = ["x11"]}
 oorandom = "11"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -20,7 +20,7 @@ required-features = [ "dim3" ]
 [features]
 default = [ "dim3", "debug-render" ]
 dim3 = []
-debug-render = [ "bevy/render", "rapier3d/debug-render" ]
+debug-render = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "bevy/bevy_sprite", "rapier3d/debug-render" ]
 parallel = [ "rapier3d/parallel" ]
 simd-stable = [ "rapier3d/simd-stable" ]
 simd-nightly = [ "rapier3d/simd-nightly" ]
@@ -39,6 +39,4 @@ log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
-bevy = "0.7"
-#bevy_wgpu = "0.5"
-#bevy_winit = { version = "0.5", features = [ "x11" ] }
+bevy = { version = "0.7", default-features = false, features = ["x11"]}


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202