### PR TITLE
Rework AsyncCollider and add AsyncSceneCollider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+### Added
+- `AsyncSceneCollider` component to generate collision for scene meshes similar to `AsyncCollider`.
+
+### Modified
+- `Collider::bevy_mesh`, `Collider::bevy_mesh_convex_decomposition` and `Collider::bevy_mesh_convex_decomposition_with_params` was replaced with single `Collider::from_bevy_mesh` function which accepts `ComputedColliderShape`.
+- `AsyncCollider` now a struct which contains a mesh handle and `ComputedColliderShape`.
+
 ## 0.13.1 (1 May 2022)
 ### Added
 - Add the `CollidingEntities` components which tracks the set of entities colliding

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -29,10 +29,12 @@ pub struct AsyncCollider {
 pub struct AsyncSceneCollider {
     /// Scene handle to use for colliders generation.
     pub handle: Handle<Scene>,
-    /// Collider type for each scene mesh not included in [`named_shapes`].
-    pub shape: ComputedColliderShape,
-    /// Shape types for meshes by name
-    pub named_shapes: HashMap<String, ComputedColliderShape>,
+    /// Collider type for each scene mesh not included in [`named_shapes`]. If [`None`], then all
+    /// shapes will be skipped for processing except [`named_shapes`].
+    pub shape: Option<ComputedColliderShape>,
+    /// Shape types for meshes by name. If shape is [`None`], then it will be skipped for
+    /// processing.
+    pub named_shapes: HashMap<String, Option<ComputedColliderShape>>,
 }
 
 /// Shape type based on a Bevy mesh asset.

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "dim3")]
 use crate::geometry::VHACDParameters;
 use bevy::prelude::*;
+#[cfg(feature = "dim3")]
+use bevy::utils::HashMap;
 use bevy::utils::HashSet;
 use rapier::prelude::{ColliderHandle, InteractionGroups, SharedShape};
 
@@ -11,14 +13,36 @@ use crate::math::Vect;
 #[derive(Copy, Clone, Debug, Component)]
 pub struct RapierColliderHandle(pub ColliderHandle);
 
-/// A collider that will be inserted in the future, once the referenced assets become available.
+/// A component which will be replaced by the specified collider type after the referenced mesh become available.
 #[cfg(feature = "dim3")]
 #[derive(Component, Debug, Clone)]
-pub enum AsyncCollider {
-    /// A future triangle-mesh collider based on a Bevy mesh asset.
-    Mesh(Handle<Mesh>),
-    /// A future convex decomposition collider based on a Bevy mesh asset.
-    ConvexDecomposition(Handle<Mesh>, VHACDParameters),
+pub struct AsyncCollider {
+    /// Mesh handle to use for collider generation.
+    pub handle: Handle<Mesh>,
+    /// Collider type that will be generated.
+    pub shape: AsyncColliderShape,
+}
+
+/// A component which will be replaced the specified collider types on children with meshes after the referenced scene become available.
+#[cfg(feature = "dim3")]
+#[derive(Component, Debug, Clone)]
+pub struct AsyncSceneCollider {
+    /// Scene handle to use for colliders generation.
+    pub handle: Handle<Scene>,
+    /// Collider type for each scene mesh not included in [`named_shapes`].
+    pub shape: AsyncColliderShape,
+    /// Shape types for meshes by name
+    pub named_shapes: HashMap<String, AsyncColliderShape>,
+}
+
+/// Shape type based on a Bevy mesh asset.
+#[cfg(feature = "dim3")]
+#[derive(Debug, Clone)]
+pub enum AsyncColliderShape {
+    /// Triangle-mesh.
+    TriMesh,
+    /// Convex decomposition.
+    ConvexDecomposition(VHACDParameters),
 }
 
 /// A geometric entity that can be attached to a body so it can be affected by contacts

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -20,7 +20,7 @@ pub struct AsyncCollider {
     /// Mesh handle to use for collider generation.
     pub handle: Handle<Mesh>,
     /// Collider type that will be generated.
-    pub shape: AsyncColliderShape,
+    pub shape: ComputedColliderShape,
 }
 
 /// A component which will be replaced the specified collider types on children with meshes after the referenced scene become available.
@@ -30,15 +30,15 @@ pub struct AsyncSceneCollider {
     /// Scene handle to use for colliders generation.
     pub handle: Handle<Scene>,
     /// Collider type for each scene mesh not included in [`named_shapes`].
-    pub shape: AsyncColliderShape,
+    pub shape: ComputedColliderShape,
     /// Shape types for meshes by name
-    pub named_shapes: HashMap<String, AsyncColliderShape>,
+    pub named_shapes: HashMap<String, ComputedColliderShape>,
 }
 
 /// Shape type based on a Bevy mesh asset.
 #[cfg(feature = "dim3")]
 #[derive(Debug, Clone)]
-pub enum AsyncColliderShape {
+pub enum ComputedColliderShape {
     /// Triangle-mesh.
     TriMesh,
     /// Convex decomposition.

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -9,6 +9,8 @@ use {
 use rapier::prelude::{FeatureId, Point, Ray, SharedShape, Vector, DIM};
 
 use super::shape_views::*;
+#[cfg(feature = "dim3")]
+use crate::geometry::ComputedColliderShape;
 use crate::geometry::{Collider, PointProjection, RayIntersection, VHACDParameters};
 use crate::math::{Real, Rot, Vect};
 
@@ -158,30 +160,18 @@ impl Collider {
     ///
     /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
     #[cfg(feature = "dim3")]
-    pub fn bevy_mesh(mesh: &Mesh) -> Option<Self> {
-        extract_mesh_vertices_indices(mesh).map(|(vtx, idx)| SharedShape::trimesh(vtx, idx).into())
-    }
-
-    /// Initializes a collider with the convex decomposition of a Bevy Mesh.
-    ///
-    /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
-    #[cfg(feature = "dim3")]
-    pub fn bevy_mesh_convex_decomposition(mesh: &Mesh) -> Option<Self> {
-        extract_mesh_vertices_indices(mesh)
-            .map(|(vtx, idx)| SharedShape::convex_decomposition(&vtx, &idx).into())
-    }
-
-    /// Initializes a collider with the convex decomposition of a Bevy Mesh, using custom convex decomposition parameters.
-    ///
-    /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
-    #[cfg(feature = "dim3")]
-    pub fn bevy_mesh_convex_decomposition_with_params(
-        mesh: &Mesh,
-        params: &VHACDParameters,
-    ) -> Option<Self> {
-        extract_mesh_vertices_indices(mesh).map(|(vtx, idx)| {
-            SharedShape::convex_decomposition_with_params(&vtx, &idx, params).into()
-        })
+    pub fn from_bevy_mesh(mesh: &Mesh, collider_shape: &ComputedColliderShape) -> Option<Self> {
+        let vertices_indices = extract_mesh_vertices_indices(mesh);
+        match collider_shape {
+            ComputedColliderShape::TriMesh => {
+                vertices_indices.map(|(vtx, idx)| SharedShape::trimesh(vtx, idx).into())
+            }
+            ComputedColliderShape::ConvexDecomposition(params) => {
+                vertices_indices.map(|(vtx, idx)| {
+                    SharedShape::convex_decomposition_with_params(&vtx, &idx, params).into()
+                })
+            }
+        }
     }
 
     /// Initializes a collider with a compound shape obtained from the decomposition of

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -83,8 +83,8 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> Plugin
             .add_system_set_to_stage(
                 PhysicsStages::StepSimulation,
                 SystemSet::new()
-                    .with_system(systems::init_async_shapes)
-                    .with_system(systems::apply_scale.after(systems::init_async_shapes))
+                    .with_system(systems::init_async_colliders)
+                    .with_system(systems::apply_scale.after(systems::init_async_colliders))
                     .with_system(systems::apply_collider_user_changes.after(systems::apply_scale))
                     .with_system(
                         systems::apply_rigid_body_user_changes
@@ -100,7 +100,7 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> Plugin
                     .with_system(
                         systems::init_colliders
                             .after(systems::init_rigid_bodies)
-                            .after(systems::init_async_shapes),
+                            .after(systems::init_async_colliders),
                     )
                     .with_system(systems::init_joints.after(systems::init_colliders))
                     .with_system(systems::sync_removals.after(systems::init_joints))

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -587,7 +587,10 @@ pub fn init_async_scene_colliders(
                             Some(collider) => {
                                 commands.entity(child).insert(collider);
                             }
-                            None => error!("Unable to generate collider from mesh {:?} with name {}", mesh, name),
+                            None => error!(
+                                "Unable to generate collider from mesh {:?} with name {}",
+                                mesh, name
+                            ),
                         }
                     }
                 }


### PR DESCRIPTION
Closes #144.

I turned `AsyncCollider` into a struct and moved collision shape into a separate enum to reuse it for `AsyncSceneCollider`. This also allows to check if mesh is loaded without expanding the enum.

Maybe we should replace [bevy_mesh](https://docs.rs/bevy_rapier3d/latest/bevy_rapier3d/geometry/struct.Collider.html#method.bevy_mesh), [bevy_mesh_convex_decomposition](https://docs.rs/bevy_rapier3d/latest/bevy_rapier3d/geometry/struct.Collider.html#method.bevy_mesh_convex_decomposition) and [bevy_mesh_convex_decomposition_with_params](https://docs.rs/bevy_rapier3d/latest/bevy_rapier3d/geometry/struct.Collider.html#method.bevy_mesh_convex_decomposition_with_params) with a single function which accepts `AsyncColliderShape` (if yes, how would you will rename it)?
This will make things more clear and allow to get rid of matches in `init_asyc_*` systems.