### PR TITLE
Fix 2D debug render depth + fix 3D debug render colors

### DIFF
--- a/src/render/lines/debuglines.wgsl
+++ b/src/render/lines/debuglines.wgsl
@@ -25,9 +25,13 @@ struct FragmentOutput {
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     out.clip_position = view.view_proj * vec4<f32>(vertex.pos, 1.0);
-    //out.color = vertex.color;
     // https://github.com/bevyengine/bevy/blob/328c26d02c50de0bc77f0d24a376f43ba89517b1/examples/2d/mesh2d_manual.rs#L234
-    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(8u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
+    // ... except the above doesn't seem to work in 3d.  Not sure what's going on there.
+    var r = f32(vertex.color & 255u) / 255.0;
+    var g = f32(vertex.color >> 8u & 255u) / 255.0;
+    var b = f32(vertex.color >> 16u & 255u) / 255.0;
+    var a = f32(vertex.color >> 24u & 255u) / 255.0;
+    out.color = vec4<f32>(r, g, b, a);
 
     return out;
 }

--- a/src/render/lines/debuglines2d.wgsl
+++ b/src/render/lines/debuglines2d.wgsl
@@ -17,10 +17,11 @@ struct VertexOutput {
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     out.clip_position = view.view_proj * vec4<f32>(vertex.place, 1.0);
-    // What is this craziness?
-    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
-    //out.color = vertex.color;
-    //out.color = vec4<f32>(1.0, 0.0, 0.0, 1.0);
+    var r = f32(vertex.color & 255u) / 255.0;
+    var g = f32(vertex.color >> 8u & 255u) / 255.0;
+    var b = f32(vertex.color >> 16u & 255u) / 255.0;
+    var a = f32(vertex.color >> 24u & 255u) / 255.0;
+    out.color = vec4<f32>(r, g, b, a);
 
     return out;
 }

--- a/src/render/lines/mod.rs
+++ b/src/render/lines/mod.rs
@@ -33,9 +33,7 @@ mod render_dim;
 // gates-specific code.
 #[cfg(feature = "dim3")]
 mod dim {
-    pub(crate) use crate::render::lines::render_dim::r3d::{
-        queue, DebugLinePipeline, DrawDebugLines,
-    };
+    pub(crate) use super::render_dim::r3d::{queue, DebugLinePipeline, DrawDebugLines};
     pub(crate) use bevy::core_pipeline::Opaque3d as Phase;
     use bevy::{asset::Handle, render::mesh::Mesh};
 
@@ -51,9 +49,7 @@ mod dim {
 }
 #[cfg(feature = "dim2")]
 mod dim {
-    pub(crate) use crate::render::lines::render_dim::r2d::{
-        queue, DebugLinePipeline, DrawDebugLines,
-    };
+    pub(crate) use super::render_dim::r2d::{queue, DebugLinePipeline, DrawDebugLines};
     pub(crate) use bevy::core_pipeline::Transparent2d as Phase;
     use bevy::{asset::Handle, render::mesh::Mesh, sprite::Mesh2dHandle};
 
@@ -81,7 +77,7 @@ pub(crate) struct DebugLinesConfig {
 ///
 /// # Usage
 ///
-/// ```.ignore
+/// ```
 /// use bevy::prelude::*;
 /// use bevy_prototype_debug_lines::*;
 ///
@@ -93,7 +89,7 @@ pub(crate) struct DebugLinesConfig {
 ///
 /// Alternatively, you can initialize the plugin with depth testing, so that
 /// debug lines cut through geometry. To do this, use [`DebugLinesPlugin::with_depth_test(true)`].
-/// ```.ignore
+/// ```
 /// use bevy::prelude::*;
 /// use bevy_prototype_debug_lines::*;
 ///
@@ -194,7 +190,7 @@ fn update(
     // For each debug line mesh, fill its buffers with the relevant positions/colors chunks.
     for (mesh_handle, debug_lines_idx) in debug_line_meshes.iter() {
         let mesh = meshes.get_mut(dim::from_handle(mesh_handle)).unwrap();
-        use VertexAttributeValues::{Float32x3, Float32x4, Uint32};
+        use VertexAttributeValues::{Float32x3, Uint32};
         if let Some(Float32x3(vbuffer)) = mesh.attribute_mut(Mesh::ATTRIBUTE_POSITION) {
             vbuffer.clear();
             if let Some(new_content) = lines
@@ -242,7 +238,7 @@ fn extract(mut commands: Commands, query: Query<Entity, With<DebugLinesMesh>>) {
 }
 
 #[derive(Component)]
-struct DebugLinesMesh(usize);
+pub(crate) struct DebugLinesMesh(usize);
 
 #[derive(Component)]
 pub(crate) struct RenderDebugLinesMesh;
@@ -250,7 +246,7 @@ pub(crate) struct RenderDebugLinesMesh;
 /// Bevy resource providing facilities to draw lines.
 ///
 /// # Usage
-/// ```.ignore
+/// ```
 /// use bevy::prelude::*;
 /// use bevy_prototype_debug_lines::*;
 ///

--- a/src/render/lines/mod.rs
+++ b/src/render/lines/mod.rs
@@ -77,7 +77,7 @@ pub(crate) struct DebugLinesConfig {
 ///
 /// # Usage
 ///
-/// ```
+/// ```.ignore
 /// use bevy::prelude::*;
 /// use bevy_prototype_debug_lines::*;
 ///
@@ -89,7 +89,7 @@ pub(crate) struct DebugLinesConfig {
 ///
 /// Alternatively, you can initialize the plugin with depth testing, so that
 /// debug lines cut through geometry. To do this, use [`DebugLinesPlugin::with_depth_test(true)`].
-/// ```
+/// ```.ignore
 /// use bevy::prelude::*;
 /// use bevy_prototype_debug_lines::*;
 ///
@@ -246,7 +246,7 @@ pub(crate) struct RenderDebugLinesMesh;
 /// Bevy resource providing facilities to draw lines.
 ///
 /// # Usage
-/// ```
+/// ```.ignore
 /// use bevy::prelude::*;
 /// use bevy_prototype_debug_lines::*;
 ///


### PR DESCRIPTION
Updates the debug-renderer based on the last (unpublished) commit on [bevy_debug_lines](https://github.com/Toqozz/bevy_debug_lines). This fixes colors for the 3D debug lines.
This also addresses the problem when 2D lines would not always be on top, based on the suggestion given in #157.

Fix #157