### PR TITLE
Reflect components and register types in plugin

### DIFF
--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -6,7 +6,7 @@ pub use self::fixed_joint::*;
 pub use self::prismatic_joint::*;
 pub use self::revolute_joint::*;
 
-use bevy::reflect::Reflect;
+use bevy::reflect::{FromReflect, Reflect};
 use rapier::dynamics::CoefficientCombineRule as RapierCoefficientCombineRule;
 
 #[cfg(feature = "dim3")]
@@ -30,7 +30,7 @@ mod spherical_joint;
 /// Each collider has its combination rule of type
 /// `CoefficientCombineRule`. And the rule
 /// actually used is given by `max(first_combine_rule as usize, second_combine_rule as usize)`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Reflect)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Reflect, FromReflect)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub enum CoefficientCombineRule {
     /// The two coefficients are averaged.

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -1,5 +1,5 @@
 use crate::math::Vect;
-use bevy::prelude::*;
+use bevy::{prelude::*, reflect::FromReflect};
 use rapier::prelude::{
     Isometry, LockedAxes as RapierLockedAxes, RigidBodyActivation, RigidBodyHandle, RigidBodyType,
 };
@@ -9,8 +9,8 @@ use rapier::prelude::{
 pub struct RapierRigidBodyHandle(pub RigidBodyHandle);
 
 /// A rigid-body.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub enum RigidBody {
     /// A `RigidBody::Dynamic` body can be affected by all external forces.
     Dynamic,
@@ -54,8 +54,8 @@ impl From<RigidBody> for RigidBodyType {
 /// Use this component to control and/or read the velocity of a dynamic or kinematic rigid-body.
 /// If this component isn’t present, a dynamic rigid-body will still be able to move (you will just
 /// not be able to read/modify its velocity).
-#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct Velocity {
     /// The linear velocity of the rigid-body.
     pub linvel: Vect,
@@ -101,8 +101,8 @@ impl Velocity {
 }
 
 /// Mass-properties of a rigid-body, added to the contributions of its attached colliders.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct AdditionalMassProperties(pub MassProperties);
 
 /// Center-of-mass, mass, and angular inertia.
@@ -111,8 +111,8 @@ pub struct AdditionalMassProperties(pub MassProperties);
 /// a rigid-body (including the colliders contribution). Modifying this component won’t
 /// affect the mass-properties of the rigid-body (the attached colliders’ `ColliderMassProperties`
 /// and the `AdditionalMassProperties` should be modified instead).
-#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct MassProperties {
     /// The center of mass of a rigid-body expressed in its local-space.
     pub local_center_of_mass: Vect,
@@ -167,8 +167,8 @@ impl MassProperties {
 }
 
 bitflags::bitflags! {
-    #[derive(Default, Component, Reflect)]
-    #[reflect(Component)]
+    #[derive(Default, Component, Reflect, FromReflect)]
+    #[reflect(Component, PartialEq)]
     /// Flags affecting the behavior of the constraints solver for a given contact manifold.
     pub struct LockedAxes: u8 {
         /// Flag indicating that the rigid-body cannot translate along the `X` axis.
@@ -199,8 +199,8 @@ impl From<LockedAxes> for RapierLockedAxes {
 /// Constant external forces applied continuously to a rigid-body.
 ///
 /// This force is applied at each timestep.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct ExternalForce {
     /// The linear force applied to the rigid-body.
     pub force: Vect,
@@ -216,8 +216,8 @@ pub struct ExternalForce {
 ///
 /// The impulse is only applied once, and whenever it it modified (based
 /// on Bevy’s change detection).
-#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct ExternalImpulse {
     /// The linear impulse applied to the rigid-body.
     pub impulse: Vect,
@@ -231,8 +231,8 @@ pub struct ExternalImpulse {
 
 /// Gravity is multiplied by this scaling factor before it's
 /// applied to this rigid-body.
-#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct GravityScale(pub f32);
 
 impl Default for GravityScale {
@@ -242,8 +242,8 @@ impl Default for GravityScale {
 }
 
 /// Information used for Continuous-Collision-Detection.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct Ccd {
     /// Is CCD enabled for this rigid-body?
     pub enabled: bool,
@@ -265,8 +265,8 @@ impl Ccd {
 }
 
 /// The dominance groups of a rigid-body.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct Dominance {
     // FIXME: rename this to `group` (no `s`).
     /// The dominance groups of a rigid-body.
@@ -284,8 +284,8 @@ impl Dominance {
 ///
 /// This controls whether a body is sleeping or not.
 /// If the threshold is negative, the body never sleeps.
-#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct Sleeping {
     /// The threshold linear velocity bellow which the body can fall asleep.
     pub linear_threshold: f32,
@@ -317,8 +317,8 @@ impl Default for Sleeping {
 }
 
 /// Damping factors to gradually slow down a rigid-body.
-#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct Damping {
     // TODO: rename these to "linear" and "angular"?
     /// Damping factor for gradually slowing down the translational motion of the rigid-body.

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -10,6 +10,7 @@ pub struct RapierRigidBodyHandle(pub RigidBodyHandle);
 
 /// A rigid-body.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Component, Reflect)]
+#[reflect(Component)]
 pub enum RigidBody {
     /// A `RigidBody::Dynamic` body can be affected by all external forces.
     Dynamic,
@@ -54,6 +55,7 @@ impl From<RigidBody> for RigidBodyType {
 /// If this component isn’t present, a dynamic rigid-body will still be able to move (you will just
 /// not be able to read/modify its velocity).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct Velocity {
     /// The linear velocity of the rigid-body.
     pub linvel: Vect,
@@ -100,6 +102,7 @@ impl Velocity {
 
 /// Mass-properties of a rigid-body, added to the contributions of its attached colliders.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct AdditionalMassProperties(pub MassProperties);
 
 /// Center-of-mass, mass, and angular inertia.
@@ -109,6 +112,7 @@ pub struct AdditionalMassProperties(pub MassProperties);
 /// affect the mass-properties of the rigid-body (the attached colliders’ `ColliderMassProperties`
 /// and the `AdditionalMassProperties` should be modified instead).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct MassProperties {
     /// The center of mass of a rigid-body expressed in its local-space.
     pub local_center_of_mass: Vect,
@@ -164,6 +168,7 @@ impl MassProperties {
 
 bitflags::bitflags! {
     #[derive(Default, Component, Reflect)]
+    #[reflect(Component)]
     /// Flags affecting the behavior of the constraints solver for a given contact manifold.
     pub struct LockedAxes: u8 {
         /// Flag indicating that the rigid-body cannot translate along the `X` axis.
@@ -195,6 +200,7 @@ impl From<LockedAxes> for RapierLockedAxes {
 ///
 /// This force is applied at each timestep.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct ExternalForce {
     /// The linear force applied to the rigid-body.
     pub force: Vect,
@@ -211,6 +217,7 @@ pub struct ExternalForce {
 /// The impulse is only applied once, and whenever it it modified (based
 /// on Bevy’s change detection).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct ExternalImpulse {
     /// The linear impulse applied to the rigid-body.
     pub impulse: Vect,
@@ -225,6 +232,7 @@ pub struct ExternalImpulse {
 /// Gravity is multiplied by this scaling factor before it's
 /// applied to this rigid-body.
 #[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct GravityScale(pub f32);
 
 impl Default for GravityScale {
@@ -235,6 +243,7 @@ impl Default for GravityScale {
 
 /// Information used for Continuous-Collision-Detection.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct Ccd {
     /// Is CCD enabled for this rigid-body?
     pub enabled: bool,
@@ -257,6 +266,7 @@ impl Ccd {
 
 /// The dominance groups of a rigid-body.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct Dominance {
     // FIXME: rename this to `group` (no `s`).
     /// The dominance groups of a rigid-body.
@@ -275,6 +285,7 @@ impl Dominance {
 /// This controls whether a body is sleeping or not.
 /// If the threshold is negative, the body never sleeps.
 #[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct Sleeping {
     /// The threshold linear velocity bellow which the body can fall asleep.
     pub linear_threshold: f32,
@@ -307,6 +318,7 @@ impl Default for Sleeping {
 
 /// Damping factors to gradually slow down a rigid-body.
 #[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct Damping {
     // TODO: rename these to "linear" and "angular"?
     /// Damping factor for gradually slowing down the translational motion of the rigid-body.

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "dim3")]
 use crate::geometry::VHACDParameters;
 use bevy::prelude::*;
+use bevy::reflect::FromReflect;
 #[cfg(feature = "dim3")]
 use bevy::utils::HashMap;
 use bevy::utils::HashSet;
@@ -68,7 +69,7 @@ impl From<SharedShape> for Collider {
 }
 
 /// Overwrites the default application of `Transform::scale` to collider shapes.
-#[derive(Copy, Clone, Debug, PartialEq, Component)] // TODO: Reflect
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
 pub enum ColliderScale {
     /// This scale will be multiplied with the scale in the `Transform` component
     /// before being applied to the collider.
@@ -78,13 +79,13 @@ pub enum ColliderScale {
 }
 
 /// Indicates whether or not the collider is a sensor.
-#[derive(Copy, Clone, Debug, PartialEq, Default, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Default, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct Sensor(pub bool);
 
 /// Custom mass-properties of a collider.
-#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub enum ColliderMassProperties {
     /// The mass-properties are computed automatically from the collider’s shape and this density.
     Density(f32),
@@ -99,8 +100,8 @@ impl Default for ColliderMassProperties {
 }
 
 /// The friction affecting a collider.
-#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct Friction {
     /// The friction coefficient of a collider.
     ///
@@ -141,8 +142,8 @@ impl Friction {
 }
 
 /// The restitution affecting a collider.
-#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
 pub struct Restitution {
     /// The restitution coefficient of a collider.
     ///
@@ -183,7 +184,8 @@ impl Default for Restitution {
 }
 
 bitflags::bitflags! {
-    #[derive(Component, Reflect)]
+    #[derive(Component, Reflect, FromReflect)]
+    #[reflect(Component, Hash, PartialEq)]
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     /// Flags affecting whether or not collision-detection happens between two colliders
     /// depending on the type of rigid-bodies they are attached to.
@@ -240,8 +242,8 @@ impl From<ActiveCollisionTypes> for rapier::geometry::ActiveCollisionTypes {
 /// ```ignore
 /// (self.memberships & rhs.filter) != 0 && (rhs.memberships & self.filter) != 0
 /// ```
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Component, Reflect, FromReflect)]
+#[reflect(Component, Hash, PartialEq)]
 pub struct CollisionGroups {
     /// Groups memberships.
     pub memberships: u32,
@@ -280,8 +282,8 @@ impl From<CollisionGroups> for InteractionGroups {
 /// Pairwise constraints resolution filtering using bit masks.
 ///
 /// This follows the same rules as the `CollisionGroups`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Component, Reflect)]
-#[reflect(Component)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Component, Reflect, FromReflect)]
+#[reflect(Component, Hash, PartialEq)]
 pub struct SolverGroups {
     /// Groups memberships.
     pub memberships: u32,
@@ -318,7 +320,7 @@ impl From<SolverGroups> for InteractionGroups {
 }
 
 bitflags::bitflags! {
-    #[derive(Default, Component, Reflect)]
+    #[derive(Default, Component, Reflect, FromReflect)]
     #[reflect(Component)]
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     /// Flags affecting the behavior of the constraints solver for a given contact manifold.
@@ -340,7 +342,7 @@ impl From<ActiveHooks> for rapier::pipeline::ActiveHooks {
 }
 
 bitflags::bitflags! {
-    #[derive(Default, Component, Reflect)]
+    #[derive(Default, Component, Reflect, FromReflect)]
     #[reflect(Component)]
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     /// Flags affecting the events generated for this collider.
@@ -359,7 +361,7 @@ impl From<ActiveEvents> for rapier::pipeline::ActiveEvents {
 }
 
 /// Component which will be filled (if present) with a list of entities with which the current entity is currently in contact.
-#[derive(Component, Default, Reflect)]
+#[derive(Component, Default, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct CollidingEntities(pub(crate) HashSet<Entity>);
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -79,10 +79,12 @@ pub enum ColliderScale {
 
 /// Indicates whether or not the collider is a sensor.
 #[derive(Copy, Clone, Debug, PartialEq, Default, Component, Reflect)]
+#[reflect(Component)]
 pub struct Sensor(pub bool);
 
 /// Custom mass-properties of a collider.
 #[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub enum ColliderMassProperties {
     /// The mass-properties are computed automatically from the collider’s shape and this density.
     Density(f32),
@@ -98,6 +100,7 @@ impl Default for ColliderMassProperties {
 
 /// The friction affecting a collider.
 #[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct Friction {
     /// The friction coefficient of a collider.
     ///
@@ -139,6 +142,7 @@ impl Friction {
 
 /// The restitution affecting a collider.
 #[derive(Copy, Clone, Debug, PartialEq, Component, Reflect)]
+#[reflect(Component)]
 pub struct Restitution {
     /// The restitution coefficient of a collider.
     ///
@@ -237,6 +241,7 @@ impl From<ActiveCollisionTypes> for rapier::geometry::ActiveCollisionTypes {
 /// (self.memberships & rhs.filter) != 0 && (rhs.memberships & self.filter) != 0
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Component, Reflect)]
+#[reflect(Component)]
 pub struct CollisionGroups {
     /// Groups memberships.
     pub memberships: u32,
@@ -276,6 +281,7 @@ impl From<CollisionGroups> for InteractionGroups {
 ///
 /// This follows the same rules as the `CollisionGroups`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Component, Reflect)]
+#[reflect(Component)]
 pub struct SolverGroups {
     /// Groups memberships.
     pub memberships: u32,
@@ -312,7 +318,8 @@ impl From<SolverGroups> for InteractionGroups {
 }
 
 bitflags::bitflags! {
-    #[derive(Component, Reflect)]
+    #[derive(Default, Component, Reflect)]
+    #[reflect(Component)]
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     /// Flags affecting the behavior of the constraints solver for a given contact manifold.
     pub struct ActiveHooks: u32 {
@@ -333,7 +340,8 @@ impl From<ActiveHooks> for rapier::pipeline::ActiveHooks {
 }
 
 bitflags::bitflags! {
-    #[derive(Component, Reflect)]
+    #[derive(Default, Component, Reflect)]
+    #[reflect(Component)]
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     /// Flags affecting the events generated for this collider.
     pub struct ActiveEvents: u32 {
@@ -352,6 +360,7 @@ impl From<ActiveEvents> for rapier::pipeline::ActiveEvents {
 
 /// Component which will be filled (if present) with a list of entities with which the current entity is currently in contact.
 #[derive(Component, Default, Reflect)]
+#[reflect(Component)]
 pub struct CollidingEntities(pub(crate) HashSet<Entity>);
 
 impl CollidingEntities {

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -1,6 +1,7 @@
 use crate::pipeline::{CollisionEvent, PhysicsHooksWithQueryResource};
 use crate::plugin::configuration::SimulationToRenderTime;
 use crate::plugin::{systems, RapierConfiguration, RapierContext};
+use crate::prelude::*;
 use bevy::ecs::{event::Events, query::WorldQuery};
 use bevy::prelude::*;
 use std::marker::PhantomData;
@@ -124,6 +125,26 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> Plugin
     for RapierPhysicsPlugin<PhysicsHooksData>
 {
     fn build(&self, app: &mut App) {
+        // Register components as reflectable.
+        app.register_type::<RigidBody>()
+            .register_type::<Velocity>()
+            .register_type::<AdditionalMassProperties>()
+            .register_type::<MassProperties>()
+            .register_type::<LockedAxes>()
+            .register_type::<ExternalForce>()
+            .register_type::<ExternalImpulse>()
+            .register_type::<Sleeping>()
+            .register_type::<Damping>()
+            .register_type::<Dominance>()
+            .register_type::<Ccd>()
+            .register_type::<GravityScale>()
+            .register_type::<CollidingEntities>()
+            .register_type::<Sensor>()
+            .register_type::<Friction>()
+            .register_type::<Restitution>()
+            .register_type::<CollisionGroups>()
+            .register_type::<SolverGroups>();
+
         // Insert all of our required resources
         app.insert_resource(RapierConfiguration::default())
             .insert_resource(SimulationToRenderTime::default())


### PR DESCRIPTION
Adds #[reflect(Component)] to components and registers them in the plugin.
 
Makes it so we can do fun stuff like this:

https://user-images.githubusercontent.com/5142292/168717424-3a1d56a6-9d18-438a-a359-4d1638770445.mp4


