### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   If that’s the case, the `RapierPhysicsPlugin::get_systems` method can be called to retrieve the relevant `SystemSet`
   that can be added to your own stages in order to apply your own scheduling.
 
+### Fixed
+- Fixed issues where contact regularization (using compliance) would result in tunnelling despite tunnelling
+  being enabled.
+- Don’t overwrite the user’s `RapierConfiguration` if one already exists before initializing the plugin.
+
 ## 0.13.2 (5 May 2022)
 ### Modified
 - The `TimestepMode` and `SimulationToRenderTime` structures are now public.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # Changelog
 
-## Unreleased
+## 0.14.0 (31 May 2022)
 ### Added
-- `AsyncSceneCollider` component to generate collision for scene meshes similar to `AsyncCollider`.
+- Add the `AsyncSceneCollider` component to generate collision for scene meshes similar to `AsyncCollider`.
+- Add calls to `App::register_type` for the types implementing `Reflect`.
 
 ### Modified
 - `Collider::bevy_mesh`, `Collider::bevy_mesh_convex_decomposition` and `Collider::bevy_mesh_convex_decomposition_with_params` was replaced with single `Collider::from_bevy_mesh` function which accepts `ComputedColliderShape`.
-- `AsyncCollider` now a struct which contains a mesh handle and `ComputedColliderShape`.
-
+- `AsyncCollider` is now a struct which contains a mesh handle and `ComputedColliderShape`.
+- The physics systems are now running after `CoreStage::Update` but before `CoreStage::PostUpdate`.
+- The collider and rigid-body positions are read from the `GlobalTransform` instead of `Transform` (the 
+  transforms modified by Rapier are written back to the `Transform` component). It is therefore important
+  to insert both a `Transform` and `GlobalTransform` component (or the `TransformBundle` bundle).
+- It is now possible to prevent the plugin from registering its system thanks to `RapierPhysicsPlugin::with_default_system_setup(false)`.
+  If that’s the case, the `RapierPhysicsPlugin::get_systems` method can be called to retrieve the relevant `SystemSet`
+  that can be added to your own stages in order to apply your own scheduling.
 
 ## 0.13.2 (5 May 2022)
 ### Modified

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.13.2"
+version = "0.14.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 bevy = { version = "0.7", default-features = false }
 nalgebra = { version = "0.31", features = [ "convert-glam020" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = "0.12.0"
+rapier2d = "0.13.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", optional = true }
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.13.2"
+version = "0.14.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 bevy = { version = "0.7", default-features = false }
 nalgebra = { version = "0.31", features = [ "convert-glam020" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = "0.12.0"
+rapier3d = "0.13.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", features = ["3d"], optional = true }
 log = "0.4"

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -151,11 +151,7 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> Plugin
 
         // Insert all of our required resources. Don’t overwrite
         // the `RapierConfiguration` if it already exists.
-        if app
-            .world
-            .get_resource::<RapierConfiguration>()
-            .is_none()
-        {
+        if app.world.get_resource::<RapierConfiguration>().is_none() {
             app.insert_resource(RapierConfiguration::default());
         }
 

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -149,9 +149,17 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> Plugin
             .register_type::<CollisionGroups>()
             .register_type::<SolverGroups>();
 
-        // Insert all of our required resources
-        app.insert_resource(RapierConfiguration::default())
-            .insert_resource(SimulationToRenderTime::default())
+        // Insert all of our required resources. Don’t overwrite
+        // the `RapierConfiguration` if it already exists.
+        if app
+            .world
+            .get_resource::<RapierConfiguration>()
+            .is_none()
+        {
+            app.insert_resource(RapierConfiguration::default());
+        }
+
+        app.insert_resource(SimulationToRenderTime::default())
             .insert_resource(RapierContext {
                 physics_scale: self.physics_scale,
                 ..Default::default()

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -893,11 +893,12 @@ pub fn init_joints(
         let target = context.entity2body.get(&entity);
 
         if let (Some(target), Some(source)) = (target, context.entity2body.get(&joint.parent)) {
-            if let Some(handle) =
-                context
-                    .multibody_joints
-                    .insert(*source, *target, joint.data.into_rapier(scale), true)
-            {
+            if let Some(handle) = context.multibody_joints.insert(
+                *source,
+                *target,
+                joint.data.into_rapier(scale),
+                true,
+            ) {
                 commands
                     .entity(entity)
                     .insert(RapierMultibodyJointHandle(handle));
@@ -988,17 +989,13 @@ pub fn sync_removals(
      */
     for entity in removed_impulse_joints.iter() {
         if let Some(handle) = context.entity2impulse_joint.remove(&entity) {
-            context
-                .impulse_joints
-                .remove(handle, true);
+            context.impulse_joints.remove(handle, true);
         }
     }
 
     for entity in orphan_impulse_joints.iter() {
         if let Some(handle) = context.entity2impulse_joint.remove(&entity) {
-            context
-                .impulse_joints
-                .remove(handle, true);
+            context.impulse_joints.remove(handle, true);
         }
         commands.entity(entity).remove::<RapierImpulseJointHandle>();
     }
@@ -1008,19 +1005,13 @@ pub fn sync_removals(
      */
     for entity in removed_multibody_joints.iter() {
         if let Some(handle) = context.entity2multibody_joint.remove(&entity) {
-            context.multibody_joints.remove(
-                handle,
-                true,
-            );
+            context.multibody_joints.remove(handle, true);
         }
     }
 
     for entity in orphan_multibody_joints.iter() {
         if let Some(handle) = context.entity2multibody_joint.remove(&entity) {
-            context.multibody_joints.remove(
-                handle,
-                true,
-            );
+            context.multibody_joints.remove(handle, true);
         }
         commands
             .entity(entity)

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -881,7 +881,7 @@ pub fn init_joints(
             let handle =
                 context
                     .impulse_joints
-                    .insert(*source, target, joint.data.into_rapier(scale));
+                    .insert(*source, target, joint.data.into_rapier(scale), true);
             commands
                 .entity(entity)
                 .insert(RapierImpulseJointHandle(handle));
@@ -896,7 +896,7 @@ pub fn init_joints(
             if let Some(handle) =
                 context
                     .multibody_joints
-                    .insert(*source, *target, joint.data.into_rapier(scale))
+                    .insert(*source, *target, joint.data.into_rapier(scale), true)
             {
                 commands
                     .entity(entity)
@@ -990,7 +990,7 @@ pub fn sync_removals(
         if let Some(handle) = context.entity2impulse_joint.remove(&entity) {
             context
                 .impulse_joints
-                .remove(handle, &mut context.islands, &mut context.bodies, true);
+                .remove(handle, true);
         }
     }
 
@@ -998,7 +998,7 @@ pub fn sync_removals(
         if let Some(handle) = context.entity2impulse_joint.remove(&entity) {
             context
                 .impulse_joints
-                .remove(handle, &mut context.islands, &mut context.bodies, true);
+                .remove(handle, true);
         }
         commands.entity(entity).remove::<RapierImpulseJointHandle>();
     }
@@ -1010,8 +1010,6 @@ pub fn sync_removals(
         if let Some(handle) = context.entity2multibody_joint.remove(&entity) {
             context.multibody_joints.remove(
                 handle,
-                &mut context.islands,
-                &mut context.bodies,
                 true,
             );
         }
@@ -1021,8 +1019,6 @@ pub fn sync_removals(
         if let Some(handle) = context.entity2multibody_joint.remove(&entity) {
             context.multibody_joints.remove(
                 handle,
-                &mut context.islands,
-                &mut context.bodies,
                 true,
             );
         }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -170,6 +170,7 @@ fn debug_render_scene(
         &rapier_context.colliders,
         &rapier_context.impulse_joints,
         &rapier_context.multibody_joints,
+        &rapier_context.narrow_phase,
     );
     render_context.pipeline.style = unscaled_style;
 }


### PR DESCRIPTION
### Added
- Add the `AsyncSceneCollider` component to generate collision for scene meshes similar to `AsyncCollider`.
- Add calls to `App::register_type` for the types implementing `Reflect`.

### Modified
- `Collider::bevy_mesh`, `Collider::bevy_mesh_convex_decomposition` and `Collider::bevy_mesh_convex_decomposition_with_params` was replaced with single `Collider::from_bevy_mesh` function which accepts `ComputedColliderShape`.
- `AsyncCollider` is now a struct which contains a mesh handle and `ComputedColliderShape`.
- The physics systems are now running after `CoreStage::Update` but before `CoreStage::PostUpdate`.
- The collider and rigid-body positions are read from the `GlobalTransform` instead of `Transform` (the 
  transforms modified by Rapier are written back to the `Transform` component). It is therefore important
  to insert both a `Transform` and `GlobalTransform` component (or the `TransformBundle` bundle).
- It is now possible to prevent the plugin from registering its system thanks to `RapierPhysicsPlugin::with_default_system_setup(false)`.
  If that’s the case, the `RapierPhysicsPlugin::get_systems` method can be called to retrieve the relevant `SystemSet`
  that can be added to your own stages in order to apply your own scheduling.