### PR TITLE
Change rigid body type earlier to allow velocity updates when changing from Fixed

### DIFF
--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -245,6 +245,12 @@ pub fn apply_rigid_body_user_changes(
         }
     }
 
+    // NOTE: we must change the rigid-body type before updating the
+    //       transform or velocity. Otherwise, if the rigid-body was fixed
+    //       and changed to anything else, the velocity change wouldn’t have any effect.
+    //       Similarly, if the rigid-body was kinematic position-based before and
+    //       changed to anything else, a transform change would modify the next
+    //       position instead of the current one.
     for (handle, rb_type) in changed_rb_types.iter() {
         if let Some(rb) = context.bodies.get_mut(handle.0) {
             rb.set_body_type((*rb_type).into());

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -245,6 +245,12 @@ pub fn apply_rigid_body_user_changes(
         }
     }
 
+    for (handle, rb_type) in changed_rb_types.iter() {
+        if let Some(rb) = context.bodies.get_mut(handle.0) {
+            rb.set_body_type((*rb_type).into());
+        }
+    }
+
     // Manually checks if the transform changed.
     // This is needed for detecting if the user actually changed the rigid-body
     // transform, or if it was just the change we made in our `writeback_rigid_bodies`
@@ -299,12 +305,6 @@ pub fn apply_rigid_body_user_changes(
             rb.set_linvel((velocity.linvel / scale).into(), true);
             #[allow(clippy::useless_conversion)] // Need to convert if dim3 enabled
             rb.set_angvel(velocity.angvel.into(), true);
-        }
-    }
-
-    for (handle, rb_type) in changed_rb_types.iter() {
-        if let Some(rb) = context.bodies.get_mut(handle.0) {
-            rb.set_body_type((*rb_type).into());
         }
     }
 


### PR DESCRIPTION
When updating both `RigidBody` type and velocity at the same time, velocity update is ignored if the body type was `Fixed`.
This change should fix it.