### PR TITLE
Add serialization for some joints

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,10 @@ jobs:
       run: cargo clippy --verbose -p bevy_rapier2d
     - name: Clippy for bevy_rapier3d
       run: cargo clippy --verbose -p bevy_rapier3d
+    - name: Clippy for bevy_rapier2d (all features)
+      run: cargo clippy --verbose -p bevy_rapier2d --all-features
+    - name: Clippy for bevy_rapier3d (all features)
+      run: cargo clippy --verbose -p bevy_rapier3d --all-features
     - name: Test for bevy_rapier2d
       run: cargo test --verbose -p bevy_rapier2d
     - name: Test for bevy_rapier3d

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
       run: cargo clippy --verbose -p bevy_rapier2d
     - name: Clippy for bevy_rapier3d
       run: cargo clippy --verbose -p bevy_rapier3d
-    - name: Clippy for bevy_rapier2d (all features)
-      run: cargo clippy --verbose -p bevy_rapier2d --all-features
-    - name: Clippy for bevy_rapier3d (all features)
-      run: cargo clippy --verbose -p bevy_rapier3d --all-features
+    - name: Clippy for bevy_rapier2d (debug-render, simd, serde)
+      run: cargo clippy --verbose -p bevy_rapier2d --features debug-render,simd-stable,serde-serialize
+    - name: Clippy for bevy_rapier3d (debug-render, simd, serde)
+      run: cargo clippy --verbose -p bevy_rapier3d --features debug-render,simd-stable,serde-serialize
     - name: Test for bevy_rapier2d
       run: cargo test --verbose -p bevy_rapier2d
     - name: Test for bevy_rapier3d

--- a/src/dynamics/generic_joint.rs
+++ b/src/dynamics/generic_joint.rs
@@ -9,6 +9,7 @@ use rapier::dynamics::{
 use crate::dynamics::SphericalJoint;
 
 /// The description of any joint.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
 #[repr(transparent)]
 pub struct GenericJoint {
@@ -286,6 +287,7 @@ impl GenericJoint {
 }
 
 /// Create generic joints using the builder pattern.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct GenericJointBuilder(GenericJoint);
 

--- a/src/dynamics/prismatic_joint.rs
+++ b/src/dynamics/prismatic_joint.rs
@@ -2,6 +2,7 @@ use crate::dynamics::{GenericJoint, GenericJointBuilder};
 use crate::math::{Real, Vect};
 use rapier::dynamics::{JointAxesMask, JointAxis, JointLimits, JointMotor, MotorModel};
 
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(transparent)]
 /// A prismatic joint, locks all relative motion between two bodies except for translation along the joint’s principal axis.
@@ -146,6 +147,7 @@ impl From<PrismaticJoint> for GenericJoint {
 /// Create prismatic joints using the builder pattern.
 ///
 /// A prismatic joint locks all relative motion except for translations along the joint’s principal axis.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct PrismaticJointBuilder(PrismaticJoint);
 

--- a/src/dynamics/revolute_joint.rs
+++ b/src/dynamics/revolute_joint.rs
@@ -2,6 +2,7 @@ use crate::dynamics::{GenericJoint, GenericJointBuilder};
 use crate::math::{Real, Vect};
 use rapier::dynamics::{JointAxesMask, JointAxis, JointLimits, JointMotor, MotorModel};
 
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(transparent)]
 /// A revolute joint, locks all relative motion except for rotation along the joint’s principal axis.
@@ -137,6 +138,7 @@ impl From<RevoluteJoint> for GenericJoint {
 /// Create revolute joints using the builder pattern.
 ///
 /// A revolute joint locks all relative motion except for rotations along the joint’s principal axis.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct RevoluteJointBuilder(RevoluteJoint);
 

--- a/src/dynamics/spherical_joint.rs
+++ b/src/dynamics/spherical_joint.rs
@@ -2,6 +2,7 @@ use crate::dynamics::{GenericJoint, GenericJointBuilder};
 use crate::math::{Real, Vect};
 use rapier::dynamics::{JointAxesMask, JointAxis, JointLimits, JointMotor, MotorModel};
 
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(transparent)]
 /// A spherical joint, locks all relative translations between two bodies.


### PR DESCRIPTION
Was having some compiling issues with the `serde-serialization` feature flag, since `SphericalJointBuilder` had 
```rust
#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
```
So just went ahead and added it to the rest, if this was unintentional, I can also just remove that cfg from `SphericalJointBuilder`