### PR TITLE
Make sensor a marker component

### DIFF
--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -39,7 +39,7 @@ pub fn setup_physics(mut commands: Commands) {
     commands
         .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 100.0, 0.0)))
         .insert(Collider::cuboid(80.0, 30.0))
-        .insert(Sensor(true));
+        .insert(Sensor);
 
     commands
         .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 260.0, 0.0)))

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -49,7 +49,7 @@ pub fn setup_physics(mut commands: Commands) {
     commands
         .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)))
         .insert(Collider::cuboid(4.0, 1.5, 1.0))
-        .insert(Sensor(true));
+        .insert(Sensor);
 
     commands
         .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 13.0, 0.0)))

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -79,15 +79,9 @@ pub enum ColliderScale {
 }
 
 /// Indicates whether or not the collider is a sensor.
-#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Component, Reflect, FromReflect)]
 #[reflect(Component, PartialEq)]
-pub struct Sensor(pub bool);
-
-impl Default for Sensor {
-    fn default() -> Self {
-        Self(true)
-    }
-}
+pub struct Sensor;
 
 /// Custom mass-properties of a collider.
 #[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -79,9 +79,15 @@ pub enum ColliderScale {
 }
 
 /// Indicates whether or not the collider is a sensor.
-#[derive(Copy, Clone, Debug, PartialEq, Default, Component, Reflect, FromReflect)]
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
 #[reflect(Component, PartialEq)]
 pub struct Sensor(pub bool);
+
+impl Default for Sensor {
+    fn default() -> Self {
+        Self(true)
+    }
+}
 
 /// Custom mass-properties of a collider.
 #[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -193,9 +193,9 @@ pub fn apply_collider_user_changes(
         }
     }
 
-    for (handle, sensor) in changed_sensors.iter() {
+    for (handle, _) in changed_sensors.iter() {
         if let Some(co) = context.colliders.get_mut(handle.0) {
-            co.set_sensor(sensor.0)
+            co.set_sensor(true);
         }
     }
 }
@@ -664,9 +664,7 @@ pub fn init_colliders(
         scaled_shape.set_scale(shape.scale / scale, config.scaled_shape_subdivision);
         let mut builder = ColliderBuilder::new(scaled_shape.raw.clone());
 
-        if let Some(sensor) = sensor {
-            builder = builder.sensor(sensor.0);
-        }
+        builder = builder.sensor(sensor.is_some());
 
         if let Some(mprops) = mprops {
             builder = match mprops {
@@ -927,6 +925,8 @@ pub fn sync_removals(
         Entity,
         (With<RapierMultibodyJointHandle>, Without<MultibodyJoint>),
     >,
+
+    removed_sensors: RemovedComponents<Sensor>,
 ) {
     /*
      * Rigid-bodies removal detection.
@@ -1016,6 +1016,17 @@ pub fn sync_removals(
         commands
             .entity(entity)
             .remove::<RapierMultibodyJointHandle>();
+    }
+
+    /*
+     * Sensor marker component removal detection.
+     */
+    for entity in removed_sensors.iter() {
+        if let Some(handle) = context.entity2collider.get(&entity) {
+            if let Some(co) = context.colliders.get_mut(*handle) {
+                co.set_sensor(false);
+            }
+        }
     }
 
     // TODO: update mass props after collider removal.


### PR DESCRIPTION
Was a bit confused when I added a `Sensor` component to my entity and it ended up defaulting to `Sensor(false)` which was a bit unintuitive IMO.

e.g. would expect this to be a sensor rigid body:
```rust
commands
    .spawn(entity)
    .insert(Transform::default())
    .insert(GlobalTransform::default())
    .insert(RigidBody::KinematicVelocityBased)
    .insert(Collider::ball(1.0))
    .insert(Sensor::default());
```