### PR TITLE
Run debug_render_scene before lines are drawn

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -78,7 +78,10 @@ impl Plugin for RapierDebugRenderPlugin {
                 enabled: true,
                 pipeline: DebugRenderPipeline::new(self.style, self.mode),
             })
-            .add_system_to_stage(CoreStage::PostUpdate, debug_render_scene);
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                debug_render_scene.before("draw_lines"),
+            );
     }
 }
 


### PR DESCRIPTION
The debug lines are still out of sync with #192. My understanding is that the ordering this PR adds is necessary because `debug_render_scene` updates the `DebugLines` resource which `update` (system that has the `draw_lines` label) uses to render the lines.