### PR TITLE
Fix #197

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -41,3 +41,5 @@ serde = { version = "1", features = [ "derive" ], optional = true}
 [dev-dependencies]
 bevy = { version = "0.7", default-features = false, features = ["x11"]}
 oorandom = "11"
+approx = "0.5.1"
+glam = { version = "0.20", features = [ "approx" ] }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -40,3 +40,5 @@ serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
 bevy = { version = "0.7", default-features = false, features = ["x11"]}
+approx = "0.5.1"
+glam = { version = "0.20", features = [ "approx" ] }

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -1313,12 +1313,15 @@ mod tests {
         let different = (
             Transform {
                 translation: Vec3::X * 10.0,
-                rotation: Quat::from_rotation_x(PI), // TODO: Why doesn't this work?
+                // NOTE: in 2D the test will fail if the rotation is wrt. an axis
+                //       other than Z because 2D physics objects can’t rotate wrt.
+                //       other axes.
+                rotation: Quat::from_rotation_z(PI),
                 ..Default::default()
             },
             Transform {
                 translation: Vec3::Y * 10.0,
-                rotation: Quat::from_rotation_x(PI),
+                rotation: Quat::from_rotation_z(PI),
                 ..Default::default()
             },
         );
@@ -1351,10 +1354,17 @@ mod tests {
             let child_collider = context.colliders.get(child_collider_handle).unwrap();
             let body_transform =
                 utils::iso_to_transform(child_collider.position(), context.physics_scale);
-            assert_eq!(
-                body_transform, *child_transform,
-                "Collider transform should have have global rotation and translation"
+            approx::assert_relative_eq!(
+                body_transform.translation,
+                child_transform.translation,
+                epsilon = 1.0e-5
             );
+            approx::assert_relative_eq!(
+                body_transform.rotation,
+                child_transform.rotation,
+                epsilon = 1.0e-5
+            );
+            approx::assert_relative_eq!(body_transform.scale, child_transform.scale,);
         }
     }
 

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -59,7 +59,6 @@ pub type RigidBodyComponents<'a> = (
 pub type ColliderComponents<'a> = (
     Entity,
     &'a Collider,
-    Option<&'a GlobalTransform>,
     Option<&'a Sensor>,
     Option<&'a ColliderMassProperties>,
     Option<&'a ActiveEvents>,
@@ -657,7 +656,6 @@ pub fn init_colliders(
     for (
         entity,
         shape,
-        transform,
         sensor,
         mprops,
         active_events,
@@ -735,7 +733,6 @@ pub fn init_colliders(
         }
 
         builder = builder.position(utils::transform_to_iso(&child_transform.into(), scale));
-
         builder = builder.user_data(entity.to_bits() as u128);
 
         let handle = if let Some(body_handle) = body_handle {
@@ -1336,7 +1333,8 @@ mod tests {
                 .insert(Collider::ball(1.0))
                 .id();
 
-            let parent = app.world
+            let parent = app
+                .world
                 .spawn()
                 .insert_bundle(TransformBundle::from(parent_transform))
                 .insert(RigidBody::Fixed)


### PR DESCRIPTION
This fixes #197. Putting rotation back in the child_transform in transform_propagation2 causes the test to fail. This fixes child collider shapes in my project.

TODO: Update collider position_wrt_parent when child transform changes?