### PR TITLE
Update to the latest version of Rapier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ codegen-units = 1
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
 #parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
-#rapier2d = { git = "https://github.com/dimforge/rapier", branch = "master" }
-#rapier3d = { git = "https://github.com/dimforge/rapier", branch = "master" }
+rapier2d = { git = "https://github.com/dimforge/rapier", branch = "master" }
+rapier3d = { git = "https://github.com/dimforge/rapier", branch = "master" }

--- a/deny.toml
+++ b/deny.toml
@@ -19,3 +19,4 @@ wildcards = "deny"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = ["https://github.com/dimforge/rapier"]

--- a/src/dynamics/fixed_joint.rs
+++ b/src/dynamics/fixed_joint.rs
@@ -23,6 +23,17 @@ impl FixedJoint {
         Self { data }
     }
 
+    /// Are contacts between the attached rigid-bodies enabled?
+    pub fn contacts_enabled(&self) -> bool {
+        self.data.contacts_enabled()
+    }
+
+    /// Sets whether contacts between the attached rigid-bodies are enabled.
+    pub fn set_contacts_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.data.set_contacts_enabled(enabled);
+        self
+    }
+
     /// The joint’s basis, expressed in the first rigid-body’s local-space.
     #[must_use]
     pub fn local_basis1(&self) -> Rot {

--- a/src/dynamics/generic_joint.rs
+++ b/src/dynamics/generic_joint.rs
@@ -154,6 +154,17 @@ impl GenericJoint {
         self
     }
 
+    /// Are contacts between the attached rigid-bodies enabled?
+    pub fn contacts_enabled(&self) -> bool {
+        self.raw.contacts_enabled
+    }
+
+    /// Sets whether contacts between the attached rigid-bodies are enabled.
+    pub fn set_contacts_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.raw.set_contacts_enabled(enabled);
+        self
+    }
+
     /// The joint limits along the specified axis.
     #[must_use]
     pub fn limits(&self, axis: JointAxis) -> Option<&JointLimits<Real>> {

--- a/src/dynamics/prismatic_joint.rs
+++ b/src/dynamics/prismatic_joint.rs
@@ -27,6 +27,17 @@ impl PrismaticJoint {
         &self.data
     }
 
+    /// Are contacts between the attached rigid-bodies enabled?
+    pub fn contacts_enabled(&self) -> bool {
+        self.data.contacts_enabled()
+    }
+
+    /// Sets whether contacts between the attached rigid-bodies are enabled.
+    pub fn set_contacts_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.data.set_contacts_enabled(enabled);
+        self
+    }
+
     /// The joint’s anchor, expressed in the local-space of the first rigid-body.
     #[must_use]
     pub fn local_anchor1(&self) -> Vect {

--- a/src/dynamics/revolute_joint.rs
+++ b/src/dynamics/revolute_joint.rs
@@ -42,6 +42,17 @@ impl RevoluteJoint {
         &self.data
     }
 
+    /// Are contacts between the attached rigid-bodies enabled?
+    pub fn contacts_enabled(&self) -> bool {
+        self.data.contacts_enabled()
+    }
+
+    /// Sets whether contacts between the attached rigid-bodies are enabled.
+    pub fn set_contacts_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.data.set_contacts_enabled(enabled);
+        self
+    }
+
     /// The joint’s anchor, expressed in the local-space of the first rigid-body.
     #[must_use]
     pub fn local_anchor1(&self) -> Vect {

--- a/src/dynamics/spherical_joint.rs
+++ b/src/dynamics/spherical_joint.rs
@@ -28,6 +28,17 @@ impl SphericalJoint {
         &self.data
     }
 
+    /// Are contacts between the attached rigid-bodies enabled?
+    pub fn contacts_enabled(&self) -> bool {
+        self.data.contacts_enabled()
+    }
+
+    /// Sets whether contacts between the attached rigid-bodies are enabled.
+    pub fn set_contacts_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.data.set_contacts_enabled(enabled);
+        self
+    }
+
     /// The joint’s anchor, expressed in the local-space of the first rigid-body.
     #[must_use]
     pub fn local_anchor1(&self) -> Vect {

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -347,8 +347,8 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     /// Flags affecting the events generated for this collider.
     pub struct ActiveEvents: u32 {
-        /// If set, Rapier will call `EventHandler::handle_intersection_event` and
-        /// `EventHandler::handle_contact_event` whenever relevant for this collider.
+        /// If set, Rapier will call `EventHandler::handle_collision_event`
+        /// whenever relevant for this collider.
         const COLLISION_EVENTS = 0b0001;
     }
 }
@@ -360,7 +360,19 @@ impl From<ActiveEvents> for rapier::pipeline::ActiveEvents {
     }
 }
 
-/// Component which will be filled (if present) with a list of entities with which the current entity is currently in contact.
+/// The total force magnitude beyond which a contact force event can be emitted.
+#[derive(Copy, Clone, PartialEq, Component, Reflect, FromReflect)]
+#[reflect(Component)]
+pub struct ContactForceEventThreshold(pub f32);
+
+impl Default for ContactForceEventThreshold {
+    fn default() -> Self {
+        Self(f32::MAX)
+    }
+}
+
+/// Component which will be filled (if present) with a list of entities with which the current
+/// entity is currently in contact.
 #[derive(Component, Default, Reflect, FromReflect)]
 #[reflect(Component)]
 pub struct CollidingEntities(pub(crate) HashSet<Entity>);

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -1,8 +1,9 @@
+use crate::math::{Real, Vect};
 use bevy::prelude::{Entity, EventWriter};
 use rapier::dynamics::RigidBodySet;
 use rapier::geometry::{
     ColliderHandle, ColliderSet, CollisionEvent as RapierCollisionEvent, CollisionEventFlags,
-    ContactPair,
+    ContactForceEvent as RapierContactForceEvent, ContactPair,
 };
 use rapier::pipeline::EventHandler;
 use std::collections::HashMap;
@@ -17,6 +18,28 @@ pub enum CollisionEvent {
     Stopped(Entity, Entity, CollisionEventFlags),
 }
 
+/// Event occurring when the sum of the magnitudes of the contact forces
+/// between two colliders exceed a threshold.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct ContactForceEvent {
+    /// The first collider involved in the contact.
+    pub collider1: Entity,
+    /// The second collider involved in the contact.
+    pub collider2: Entity,
+    /// The sum of all the forces between the two colliders.
+    pub total_force: Vect,
+    /// The sum of the magnitudes of each force between the two colliders.
+    ///
+    /// Note that this is **not** the same as the magnitude of `self.total_force`.
+    /// Here we are summing the magnitude of all the forces, instead of taking
+    /// the magnitude of their sum.
+    pub total_force_magnitude: Real,
+    /// The world-space (unit) direction of the force with strongest magnitude.
+    pub max_force_direction: Vect,
+    /// The magnitude of the largest force at a contact point of this contact pair.
+    pub max_force_magnitude: Real,
+}
+
 // TODO: it may be more efficient to use crossbeam channel.
 // However crossbeam channels cause a Segfault (I have not
 // investigated how to reproduce this exactly to open an
@@ -26,7 +49,18 @@ pub(crate) struct EventQueue<'a> {
     // Used ot retrieve the entity of colliders that have been removed from the simulation
     // since the last physics step.
     pub deleted_colliders: &'a HashMap<ColliderHandle, Entity>,
-    pub events: RwLock<EventWriter<'a, 'a, CollisionEvent>>,
+    pub collision_events: RwLock<EventWriter<'a, 'a, CollisionEvent>>,
+    pub contact_force_events: RwLock<EventWriter<'a, 'a, ContactForceEvent>>,
+}
+
+impl<'a> EventQueue<'a> {
+    fn collider2entity(&self, colliders: &ColliderSet, handle: ColliderHandle) -> Entity {
+        colliders
+            .get(handle)
+            .map(|co| Entity::from_bits(co.user_data as u64))
+            .or_else(|| self.deleted_colliders.get(&handle).copied())
+            .expect("Internal error: entity not found for collision event.")
+    }
 }
 
 impl<'a> EventHandler for EventQueue<'a> {
@@ -37,28 +71,45 @@ impl<'a> EventHandler for EventQueue<'a> {
         event: RapierCollisionEvent,
         _: Option<&ContactPair>,
     ) {
-        let collider2entity = |handle| {
-            colliders
-                .get(handle)
-                .map(|co| Entity::from_bits(co.user_data as u64))
-                .or_else(|| self.deleted_colliders.get(&handle).copied())
-                .expect("Internal error: entity not found for collision event.")
+        let event = match event {
+            RapierCollisionEvent::Started(h1, h2, flags) => {
+                let e1 = self.collider2entity(colliders, h1);
+                let e2 = self.collider2entity(colliders, h2);
+                CollisionEvent::Started(e1, e2, flags)
+            }
+            RapierCollisionEvent::Stopped(h1, h2, flags) => {
+                let e1 = self.collider2entity(colliders, h1);
+                let e2 = self.collider2entity(colliders, h2);
+                CollisionEvent::Stopped(e1, e2, flags)
+            }
         };
 
-        if let Ok(mut events) = self.events.write() {
-            let event = match event {
-                RapierCollisionEvent::Started(h1, h2, flags) => {
-                    let e1 = collider2entity(h1);
-                    let e2 = collider2entity(h2);
-                    CollisionEvent::Started(e1, e2, flags)
-                }
-                RapierCollisionEvent::Stopped(h1, h2, flags) => {
-                    let e1 = collider2entity(h1);
-                    let e2 = collider2entity(h2);
-                    CollisionEvent::Stopped(e1, e2, flags)
-                }
-            };
+        if let Ok(mut events) = self.collision_events.write() {
             events.send(event)
+        }
+    }
+
+    fn handle_contact_force_event(
+        &self,
+        dt: Real,
+        _bodies: &RigidBodySet,
+        colliders: &ColliderSet,
+        contact_pair: &ContactPair,
+        total_force_magnitude: Real,
+    ) {
+        let rapier_event =
+            RapierContactForceEvent::from_contact_pair(dt, contact_pair, total_force_magnitude);
+        let event = ContactForceEvent {
+            collider1: self.collider2entity(colliders, rapier_event.collider1),
+            collider2: self.collider2entity(colliders, rapier_event.collider2),
+            total_force: rapier_event.total_force.into(),
+            total_force_magnitude: rapier_event.total_force_magnitude,
+            max_force_direction: rapier_event.max_force_direction.into(),
+            max_force_magnitude: rapier_event.max_force_magnitude,
+        };
+
+        if let Ok(mut events) = self.contact_force_events.write() {
+            events.send(event);
         }
     }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,10 +1,12 @@
-pub use self::events::CollisionEvent;
 pub(crate) use self::events::EventQueue;
+pub use self::events::{CollisionEvent, ContactForceEvent};
 pub(crate) use self::physics_hooks::PhysicsHooksWithQueryInstance;
 pub use self::physics_hooks::{
     ContactModificationContextView, PairFilterContextView, PhysicsHooksWithQuery,
     PhysicsHooksWithQueryResource,
 };
+pub use query_filter::QueryFilter;
 
 mod events;
 mod physics_hooks;
+mod query_filter;

--- a/src/pipeline/query_filter.rs
+++ b/src/pipeline/query_filter.rs
@@ -1,0 +1,113 @@
+use bevy::prelude::Entity;
+use rapier::geometry::InteractionGroups;
+use rapier::pipeline::QueryFilterFlags;
+
+/// A filter tha describes what collider should be included or excluded from a scene query.
+#[derive(Copy, Clone, Default)]
+pub struct QueryFilter<'a> {
+    /// Flags indicating what particular type of colliders should be exclude.
+    pub flags: QueryFilterFlags,
+    /// If set, only colliders with collision groups compatible with this one will
+    /// be included in the scene query.
+    pub groups: Option<InteractionGroups>,
+    /// If set, the collider attached to that entity will be excluded by the query.
+    pub exclude_collider: Option<Entity>,
+    /// If set, any collider attached to the rigid-body attached to that entity
+    /// will be exclude by the query.
+    pub exclude_rigid_body: Option<Entity>,
+    /// If set, any collider for which this closure returns false.
+    pub predicate: Option<&'a dyn Fn(Entity) -> bool>,
+}
+
+impl<'a> From<QueryFilterFlags> for QueryFilter<'a> {
+    fn from(flags: QueryFilterFlags) -> Self {
+        Self {
+            flags,
+            ..QueryFilter::default()
+        }
+    }
+}
+
+impl<'a> From<InteractionGroups> for QueryFilter<'a> {
+    fn from(groups: InteractionGroups) -> Self {
+        Self {
+            groups: Some(groups),
+            ..QueryFilter::default()
+        }
+    }
+}
+
+impl<'a> QueryFilter<'a> {
+    /// A query filter that doesn’t exclude any collider.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Exclude from the query any collider attached to a fixed rigid-body and colliders with no rigid-body attached.
+    pub fn exclude_fixed() -> Self {
+        QueryFilterFlags::EXCLUDE_FIXED.into()
+    }
+
+    /// Exclude from the query any collider attached to a dynamic rigid-body.
+    pub fn exclude_kinematic() -> Self {
+        QueryFilterFlags::EXCLUDE_KINEMATIC.into()
+    }
+
+    /// Exclude from the query any collider attached to a kinematic rigid-body.
+    pub fn exclude_dynamic(self) -> Self {
+        QueryFilterFlags::EXCLUDE_DYNAMIC.into()
+    }
+
+    /// Excludes all colliders not attached to a dynamic rigid-body.
+    pub fn only_dynamic() -> Self {
+        QueryFilterFlags::ONLY_DYNAMIC.into()
+    }
+
+    /// Excludes all colliders not attached to a kinematic rigid-body.
+    pub fn only_kinematic() -> Self {
+        QueryFilterFlags::ONLY_KINEMATIC.into()
+    }
+
+    /// Exclude all colliders attached to a non-fixed rigid-body
+    /// (this will not exclude colliders not attached to any rigid-body).
+    pub fn only_fixed() -> Self {
+        QueryFilterFlags::ONLY_FIXED.into()
+    }
+
+    /// Exclude from the query any collider that is a sensor.
+    pub fn exclude_sensors(mut self) -> Self {
+        self.flags |= QueryFilterFlags::EXCLUDE_SENSORS;
+        self
+    }
+
+    /// Exclude from the query any collider that is not a sensor.
+    pub fn exclude_solids(mut self) -> Self {
+        self.flags |= QueryFilterFlags::EXCLUDE_SOLIDS;
+        self
+    }
+
+    /// Only colliders with collision groups compatible with this one will
+    /// be included in the scene query.
+    pub fn groups(mut self, groups: InteractionGroups) -> Self {
+        self.groups = Some(groups);
+        self
+    }
+
+    /// Set the collider that will be excluded from the scene query.
+    pub fn exclude_collider(mut self, collider: Entity) -> Self {
+        self.exclude_collider = Some(collider);
+        self
+    }
+
+    /// Set the rigid-body that will be excluded from the scene query.
+    pub fn exclude_rigid_body(mut self, rigid_body: Entity) -> Self {
+        self.exclude_rigid_body = Some(rigid_body);
+        self
+    }
+
+    /// Set the predicate to apply a custom collider filtering during the scene query.
+    pub fn predicate(mut self, predicate: &'a impl Fn(Entity) -> bool) -> Self {
+        self.predicate = Some(predicate);
+        self
+    }
+}

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -1,4 +1,4 @@
-use crate::pipeline::{CollisionEvent, PhysicsHooksWithQueryResource};
+use crate::pipeline::{CollisionEvent, ContactForceEvent, PhysicsHooksWithQueryResource};
 use crate::plugin::configuration::SimulationToRenderTime;
 use crate::plugin::{systems, RapierConfiguration, RapierContext};
 use crate::prelude::*;
@@ -176,7 +176,8 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> Plugin
                 physics_scale: self.physics_scale,
                 ..Default::default()
             })
-            .insert_resource(Events::<CollisionEvent>::default());
+            .insert_resource(Events::<CollisionEvent>::default())
+            .insert_resource(Events::<ContactForceEvent>::default());
 
         // Add each stage as necessary
         if self.default_system_setup {

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -163,7 +163,8 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> Plugin
             .register_type::<Friction>()
             .register_type::<Restitution>()
             .register_type::<CollisionGroups>()
-            .register_type::<SolverGroups>();
+            .register_type::<SolverGroups>()
+            .register_type::<ContactForceEventThreshold>();
 
         // Insert all of our required resources. Don’t overwrite
         // the `RapierConfiguration` if it already exists.

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -12,7 +12,7 @@ use crate::geometry::{
     SolverGroups,
 };
 use crate::pipeline::{
-    CollisionEvent, PhysicsHooksWithQueryInstance, PhysicsHooksWithQueryResource,
+    CollisionEvent, ContactForceEvent, PhysicsHooksWithQueryInstance, PhysicsHooksWithQueryResource,
 };
 use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
 use crate::plugin::{RapierConfiguration, RapierContext};
@@ -533,7 +533,8 @@ pub fn step_simulation<PhysicsHooksData: 'static + WorldQuery + Send + Sync>(
     config: Res<RapierConfiguration>,
     hooks: Res<PhysicsHooksWithQueryResource<PhysicsHooksData>>,
     (time, mut sim_to_render_time): (Res<Time>, ResMut<SimulationToRenderTime>),
-    events: EventWriter<CollisionEvent>,
+    collision_events: EventWriter<CollisionEvent>,
+    contact_force_events: EventWriter<ContactForceEvent>,
     hooks_data: Query<PhysicsHooksData>,
     interpolation_query: Query<(&RapierRigidBodyHandle, &mut TransformInterpolation)>,
 ) {
@@ -548,7 +549,7 @@ pub fn step_simulation<PhysicsHooksData: 'static + WorldQuery + Send + Sync>(
         context.step_simulation(
             config.gravity,
             config.timestep_mode,
-            Some(events),
+            Some((collision_events, contact_force_events)),
             &hooks_instance,
             &*time,
             &mut *sim_to_render_time,


### PR DESCRIPTION
This updates `bevy_rapier` to make it work with the latest version of Rapier on the `master` branch.
This includes a few nice new features:
- Contact force events: these are new type of events emitted when the contact force applied to a rigid-body exceeds a threshold (specified on the `Collider`).
- Query filter: it is now simpler to filter-out whole families of colliders when performing a scene queries. For example, you can easily say that all the colliders attached to dynamic bodies must be ignored by a ray-cast, and that one particular entity (e.g. the player) has to be ignored as well.
- The `contacts_enabled` flags on all the joint types has been added (defaults to `true`) to disable contacts between the colliders attached to rigid-bodies linked by a joint.