### PR TITLE
Rework mass-properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- Fix unpredictable broad-phase panic when using small colliders in the simulation.
+- Fix collision events being incorrectly generated for any shape that produces multiple
+  contact manifolds (like triangle meshes).
+- Fix transform hierarchies not being properly taken into account for colliders with a 
+  parent rigid-body.
+
+### Added
+- Add the `ColliderMassProperties::Mass` variant to let the user specify a collider’s mass directly (instead of its density).
+  As a result the collider’s angular inertia tensor will be automatically be computed based on this mass and its shape.
+- Add the `ContactForceEvent` event. It can be read by a bevy system with the `EventReader<ContactForceEvent>`. This
+  event is useful to read contact forces. A `ContactForceEvent` is generated whenever the sum of the magnitudes of the
+  forces applied by contacts between two colliders exceeds the value specified by the `ContactForceEventThreshold`
+  component.
+- Add the `QueryFilter` struct that is now used by all the scene queries instead of the `CollisionGroups` and
+ `Fn(Entity) -> bool` closure. This `QueryFilter` provides easy access to most common filtering strategies
+ (e.g. dynamic bodies only, excluding one particular entity, etc.) for scene queries.
+- Added some missing serialization of joints.
+- Implement `Default` for `Collider`. It defaults to a `Ball` with radius 0.5.
+- Added a `contacts_enabled` flag to all the joints. If this flag is set to `false` for a joint, no contact will be 
+  computed between two colliders attached to rigid-bodies liked by that joint.
+
+### Modified
+- The `MassProperties` struct is no longer a `Component`. A common mistake was to assume that `MassProperties` could
+  be used to initialize the mass/angular inertia tensor of a rigid-body. It is not the case. Instead, the user should
+  use the `AdditionalMassProperties` component. The `ReadMassProperties` component has been added to read the mass
+  properties of a rigid-body.
+- The `Sensor` component is now a marker component: if it exists the related collider is a sensor, otherwise it is
+  a solid collider.
+
 ## 0.14.1 (01 June 2022)
 ### Fixed
 - Add the missing `init_async_scene_colliders` to the list of the plugin systems.

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -101,9 +101,22 @@ impl Velocity {
 }
 
 /// Mass-properties of a rigid-body, added to the contributions of its attached colliders.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[derive(Copy, Clone, Debug, PartialEq, Component, Reflect, FromReflect)]
 #[reflect(Component, PartialEq)]
-pub struct AdditionalMassProperties(pub MassProperties);
+pub enum AdditionalMassProperties {
+    /// This mass will be added to the rigid-body. The rigid-body’s total
+    /// angular inertia tensor (obtained from its attached colliders) will
+    /// be scaled accordingly.
+    Mass(f32),
+    /// These mass properties will be added to the rigid-body.
+    MassProperties(MassProperties),
+}
+
+impl Default for AdditionalMassProperties {
+    fn default() -> Self {
+        Self::MassProperties(MassProperties::default())
+    }
+}
 
 /// Center-of-mass, mass, and angular inertia.
 ///
@@ -113,6 +126,14 @@ pub struct AdditionalMassProperties(pub MassProperties);
 /// and the `AdditionalMassProperties` should be modified instead).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
 #[reflect(Component, PartialEq)]
+pub struct ReadMassProperties(pub MassProperties);
+
+/// Center-of-mass, mass, and angular inertia.
+///
+/// This cannot be used as a component. Use the components `ReadMassProperties` to read a rigid-body’s
+/// mass-properties or `AdditionalMassProperties` to set its additional mass-properties.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Reflect, FromReflect)]
+#[reflect(PartialEq)]
 pub struct MassProperties {
     /// The center of mass of a rigid-body expressed in its local-space.
     pub local_center_of_mass: Vect,

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -89,6 +89,8 @@ pub struct Sensor;
 pub enum ColliderMassProperties {
     /// The mass-properties are computed automatically from the collider’s shape and this density.
     Density(f32),
+    /// The mass-properties are computed automatically from the collider’s shape and this mass.
+    Mass(f32),
     /// The mass-properties of the collider are replaced by the ones specified here.
     MassProperties(MassProperties),
 }


### PR DESCRIPTION
- Add the `ColliderMassProperties::Mass` variant to let the user specify a collider’s mass directly (instead of its density).
  As a result the collider’s angular inertia tensor will be automatically be computed based on this mass and its shape.
- Add the `ContactForceEvent` event. It can be read by a bevy system with the `EventReader<ContactForceEvent>`. This
  event is useful to read contact forces. A `ContactForceEvent` is generated whenever the sum of the magnitudes of the
  forces applied by contacts between two colliders exceeds the value specified by the `ContactForceEventThreshold`
  component.
- The `MassProperties` struct is no longer a `Component`. A common mistake was to assume that `MassProperties` could
  be used to initialize the mass/angular inertia tensor of a rigid-body. It is not the case. Instead, the user should
  use the `AdditionalMassProperties` component. The `ReadMassProperties` component has been added to read the mass
  properties of a rigid-body.