### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.15.0 (10 July 2022)
 ### Fixed
 - Fix unpredictable broad-phase panic when using small colliders in the simulation.
 - Fix collision events being incorrectly generated for any shape that produces multiple

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ codegen-units = 1
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
 #parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
-rapier2d = { git = "https://github.com/dimforge/rapier", branch = "master" }
-rapier3d = { git = "https://github.com/dimforge/rapier", branch = "master" }
+#rapier2d = { git = "https://github.com/dimforge/rapier", branch = "master" }
+#rapier3d = { git = "https://github.com/dimforge/rapier", branch = "master" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 bevy = { version = "0.7", default-features = false }
 nalgebra = { version = "0.31", features = [ "convert-glam020" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = "0.13.0"
+rapier2d = "0.14.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", optional = true }
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 bevy = { version = "0.7", default-features = false }
 nalgebra = { version = "0.31", features = [ "convert-glam020" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = "0.13.0"
+rapier3d = "0.14.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", features = ["3d"], optional = true }
 log = "0.4"


### PR DESCRIPTION
### Fixed
- Fix unpredictable broad-phase panic when using small colliders in the simulation.
- Fix collision events being incorrectly generated for any shape that produces multiple
  contact manifolds (like triangle meshes).
- Fix transform hierarchies not being properly taken into account for colliders with a 
  parent rigid-body.
- Fix force and impulse application when the `ExternalImpulse` or `ExternalForce` components were added
  at the same time as the rigid-body creation.
- Fix sleeping threshold application when these thresholds are set at the same time as the rigid-body
  creation.

### Added
- Add the `ColliderMassProperties::Mass` variant to let the user specify a collider’s mass directly (instead of its density).
  As a result the collider’s angular inertia tensor will be automatically be computed based on this mass and its shape.
- Add the `ContactForceEvent` event. It can be read by a bevy system with the `EventReader<ContactForceEvent>`. This
  event is useful to read contact forces. A `ContactForceEvent` is generated whenever the sum of the magnitudes of the
  forces applied by contacts between two colliders exceeds the value specified by the `ContactForceEventThreshold`
  component.
- Add the `QueryFilter` struct that is now used by all the scene queries instead of the `CollisionGroups` and
 `Fn(Entity) -> bool` closure. This `QueryFilter` provides easy access to most common filtering strategies
 (e.g. dynamic bodies only, excluding one particular entity, etc.) for scene queries.
- Added some missing serialization of joints.
- Implement `Default` for `Collider`. It defaults to a `Ball` with radius 0.5.
- Added a `contacts_enabled` flag to all the joints. If this flag is set to `false` for a joint, no contact will be 
  computed between two colliders attached to rigid-bodies liked by that joint.

### Modified
- The `MassProperties` struct is no longer a `Component`. A common mistake was to assume that `MassProperties` could
  be used to initialize the mass/angular inertia tensor of a rigid-body. It is not the case. Instead, the user should
  use the `AdditionalMassProperties` component. The `ReadMassProperties` component has been added to read the mass
  properties of a rigid-body.
- The `Sensor` component is now a marker component: if it exists the related collider is a sensor, otherwise it is
  a solid collider.