### PR TITLE
Add missing dependencies

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -19,7 +19,7 @@ required-features = [ "dim2" ]
 
 [features]
 default = [ "dim2", "debug-render" ]
-dim2 = []
+dim2 = ["bevy/bevy_render"]
 debug-render = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "bevy/bevy_sprite", "rapier2d/debug-render" ]
 parallel = [ "rapier2d/parallel" ]
 simd-stable = [ "rapier2d/simd-stable" ]

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -19,7 +19,7 @@ required-features = [ "dim3" ]
 
 [features]
 default = [ "dim3", "debug-render" ]
-dim3 = []
+dim3 = ["bevy/bevy_render"]
 debug-render = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "rapier3d/debug-render" ]
 parallel = [ "rapier3d/parallel" ]
 simd-stable = [ "rapier3d/simd-stable" ]


### PR DESCRIPTION
The features `dim3` and `dim2` require `bevy_render`. Otherwise you will have compile errors with this two commands:

```bash
cargo build -p bevy_rapier2d --no-default-features --features=dim2
cargo build -p bevy_rapier3d --no-default-features --features=dim3
```

I think we should have dependency on rendering under a separate feature, but as a short-term solution it's ok.