### PR TITLE
Remove `AsyncCollider` and `AsyncSceneCollider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Removed
+- `AsyncCollider` and `AsyncSceneCollider`. The approach used is very restrictive. This will be solved on the Bevy side with asset preprocessing: https://github.com/bevyengine/bevy/issues/4933. In the meanwhile there is a dedicated plugin that can do this and even more: https://github.com/nicopap/bevy-scene-hook.
+
 ## 0.15.0 (10 July 2022)
 ### Fixed
 - Fix unpredictable broad-phase panic when using small colliders in the simulation.

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,9 +1,5 @@
-#[cfg(feature = "dim3")]
-use crate::geometry::VHACDParameters;
 use bevy::prelude::*;
 use bevy::reflect::FromReflect;
-#[cfg(feature = "dim3")]
-use bevy::utils::HashMap;
 use bevy::utils::HashSet;
 use rapier::prelude::{ColliderHandle, InteractionGroups, SharedShape};
 
@@ -13,40 +9,6 @@ use crate::math::Vect;
 /// The Rapier handle of a collider that was inserted to the physics scene.
 #[derive(Copy, Clone, Debug, Component)]
 pub struct RapierColliderHandle(pub ColliderHandle);
-
-/// A component which will be replaced by the specified collider type after the referenced mesh become available.
-#[cfg(feature = "dim3")]
-#[derive(Component, Debug, Clone)]
-pub struct AsyncCollider {
-    /// Mesh handle to use for collider generation.
-    pub handle: Handle<Mesh>,
-    /// Collider type that will be generated.
-    pub shape: ComputedColliderShape,
-}
-
-/// A component which will be replaced the specified collider types on children with meshes after the referenced scene become available.
-#[cfg(feature = "dim3")]
-#[derive(Component, Debug, Clone)]
-pub struct AsyncSceneCollider {
-    /// Scene handle to use for colliders generation.
-    pub handle: Handle<Scene>,
-    /// Collider type for each scene mesh not included in [`named_shapes`]. If [`None`], then all
-    /// shapes will be skipped for processing except [`named_shapes`].
-    pub shape: Option<ComputedColliderShape>,
-    /// Shape types for meshes by name. If shape is [`None`], then it will be skipped for
-    /// processing.
-    pub named_shapes: HashMap<String, Option<ComputedColliderShape>>,
-}
-
-/// Shape type based on a Bevy mesh asset.
-#[cfg(feature = "dim3")]
-#[derive(Debug, Clone)]
-pub enum ComputedColliderShape {
-    /// Triangle-mesh.
-    TriMesh,
-    /// Convex decomposition.
-    ConvexDecomposition(VHACDParameters),
-}
 
 /// A geometric entity that can be attached to a body so it can be affected by contacts
 /// and intersection queries.

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -9,8 +9,6 @@ use {
 use rapier::prelude::{FeatureId, Point, Ray, SharedShape, Vector, DIM};
 
 use super::shape_views::*;
-#[cfg(feature = "dim3")]
-use crate::geometry::ComputedColliderShape;
 use crate::geometry::{Collider, PointProjection, RayIntersection, VHACDParameters};
 use crate::math::{Real, Rot, Vect};
 
@@ -160,18 +158,30 @@ impl Collider {
     ///
     /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
     #[cfg(feature = "dim3")]
-    pub fn from_bevy_mesh(mesh: &Mesh, collider_shape: &ComputedColliderShape) -> Option<Self> {
-        let vertices_indices = extract_mesh_vertices_indices(mesh);
-        match collider_shape {
-            ComputedColliderShape::TriMesh => {
-                vertices_indices.map(|(vtx, idx)| SharedShape::trimesh(vtx, idx).into())
-            }
-            ComputedColliderShape::ConvexDecomposition(params) => {
-                vertices_indices.map(|(vtx, idx)| {
-                    SharedShape::convex_decomposition_with_params(&vtx, &idx, params).into()
-                })
-            }
-        }
+    pub fn bevy_mesh(mesh: &Mesh) -> Option<Self> {
+        extract_mesh_vertices_indices(mesh).map(|(vtx, idx)| SharedShape::trimesh(vtx, idx).into())
+    }
+
+    /// Initializes a collider with the convex decomposition of a Bevy Mesh.
+    ///
+    /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
+    #[cfg(feature = "dim3")]
+    pub fn bevy_mesh_convex_decomposition(mesh: &Mesh) -> Option<Self> {
+        extract_mesh_vertices_indices(mesh)
+            .map(|(vtx, idx)| SharedShape::convex_decomposition(&vtx, &idx).into())
+    }
+
+    /// Initializes a collider with the convex decomposition of a Bevy Mesh, using custom convex decomposition parameters.
+    ///
+    /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
+    #[cfg(feature = "dim3")]
+    pub fn bevy_mesh_convex_decomposition_with_params(
+        mesh: &Mesh,
+        params: &VHACDParameters,
+    ) -> Option<Self> {
+        extract_mesh_vertices_indices(mesh).map(|(vtx, idx)| {
+            SharedShape::convex_decomposition_with_params(&vtx, &idx, params).into()
+        })
     }
 
     /// Initializes a collider with a compound shape obtained from the decomposition of

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -58,13 +58,11 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
     pub fn get_systems(stage: PhysicsStages) -> SystemSet {
         match stage {
             PhysicsStages::SyncBackend => {
-                let systems = SystemSet::new()
+                SystemSet::new()
                     .with_system(bevy::transform::transform_propagate_system) // Run Bevy transform propagation additionaly to sync [`GlobalTransform`]
                     .with_system(
-                        systems::init_async_colliders
-                            .after(bevy::transform::transform_propagate_system),
+                        systems::apply_scale.after(bevy::transform::transform_propagate_system),
                     )
-                    .with_system(systems::apply_scale.after(systems::init_async_colliders))
                     .with_system(systems::apply_collider_user_changes.after(systems::apply_scale))
                     .with_system(
                         systems::apply_rigid_body_user_changes
@@ -77,11 +75,7 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                     .with_system(
                         systems::init_rigid_bodies.after(systems::apply_joint_user_changes),
                     )
-                    .with_system(
-                        systems::init_colliders
-                            .after(systems::init_rigid_bodies)
-                            .after(systems::init_async_colliders),
-                    )
+                    .with_system(systems::init_colliders.after(systems::init_rigid_bodies))
                     .with_system(systems::init_joints.after(systems::init_colliders))
                     .with_system(
                         systems::apply_initial_rigid_body_impulses.after(systems::init_colliders),
@@ -90,18 +84,7 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                         systems::sync_removals
                             .after(systems::init_joints)
                             .after(systems::apply_initial_rigid_body_impulses),
-                    );
-
-                #[cfg(feature = "dim3")]
-                {
-                    systems.with_system(
-                        systems::init_async_scene_colliders.before(systems::init_async_colliders),
                     )
-                }
-                #[cfg(not(feature = "dim3"))]
-                {
-                    systems
-                }
             }
             PhysicsStages::StepSimulation => {
                 SystemSet::new().with_system(systems::step_simulation::<PhysicsHooksData>)


### PR DESCRIPTION
In this PR I removed the feature I added in #214.

The approach was too limited anyway. You can't set collision groups, friction and other stuff. This will be solved on the Bevy side with asset preprocessing: https://github.com/bevyengine/bevy/issues/4933. In the meanwhile there is a dedicated plugin that can do this and even more: https://github.com/nicopap/bevy-scene-hook.