### PR TITLE
Clear collision events

### DIFF
--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -103,13 +103,12 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                     systems
                 }
             }
-            PhysicsStages::StepSimulation => {
-                SystemSet::new()
-                    .with_system(systems::step_simulation::<PhysicsHooksData>)
-                    .with_system(Events::<CollisionEvent>::update_system
-                        .before(systems::step_simulation::<PhysicsHooksData>)
-                    )
-            }
+            PhysicsStages::StepSimulation => SystemSet::new()
+                .with_system(systems::step_simulation::<PhysicsHooksData>)
+                .with_system(
+                    Events::<CollisionEvent>::update_system
+                        .before(systems::step_simulation::<PhysicsHooksData>),
+                ),
             PhysicsStages::Writeback => SystemSet::new()
                 .with_system(systems::update_colliding_entities)
                 .with_system(systems::writeback_rigid_bodies),

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -108,6 +108,10 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                 .with_system(
                     Events::<CollisionEvent>::update_system
                         .before(systems::step_simulation::<PhysicsHooksData>),
+                )
+                .with_system(
+                    Events::<ContactForceEvent>::update_system
+                        .before(systems::step_simulation::<PhysicsHooksData>),
                 ),
             PhysicsStages::Writeback => SystemSet::new()
                 .with_system(systems::update_colliding_entities)

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -104,7 +104,11 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                 }
             }
             PhysicsStages::StepSimulation => {
-                SystemSet::new().with_system(systems::step_simulation::<PhysicsHooksData>)
+                SystemSet::new()
+                    .with_system(systems::step_simulation::<PhysicsHooksData>)
+                    .with_system(Events::<CollisionEvent>::update_system
+                        .before(systems::step_simulation::<PhysicsHooksData>)
+                    )
             }
             PhysicsStages::Writeback => SystemSet::new()
                 .with_system(systems::update_colliding_entities)


### PR DESCRIPTION
Adding it to the `StepSimulation` stage mainly because that is when events get sent, so it should line up well with any custom usecase (fixed timesteps, etc.).

Fixes #216 