### PR TITLE
Don’t apply physics_scale to joints’ angular limits and angular motors

### DIFF
--- a/src/dynamics/generic_joint.rs
+++ b/src/dynamics/generic_joint.rs
@@ -4,6 +4,7 @@ use rapier::dynamics::{
     GenericJoint as RapierGenericJoint, JointAxesMask, JointAxis, JointLimits, JointMotor,
     MotorModel,
 };
+use rapier::math::DIM;
 
 #[cfg(feature = "dim3")]
 use crate::dynamics::SphericalJoint;
@@ -23,12 +24,14 @@ impl GenericJoint {
         self.raw.local_frame1.translation.vector /= physics_scale;
         self.raw.local_frame2.translation.vector /= physics_scale;
 
-        for limit in &mut self.raw.limits {
+        // NOTE: we don’t apply the physics scale to angular limits.
+        for limit in &mut self.raw.limits[0..DIM] {
             limit.min /= physics_scale;
             limit.max /= physics_scale;
         }
 
-        for motor in &mut self.raw.motors {
+        // NOTE: we don’t apply the physics scale to angular motors.
+        for motor in &mut self.raw.motors[0..DIM] {
             motor.target_vel /= physics_scale;
             motor.target_pos /= physics_scale;
         }


### PR DESCRIPTION
Fix #232 