### PR TITLE
Add a fmt::Debug impl for Collider component

### DIFF
--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[cfg(feature = "dim3")]
 use crate::geometry::VHACDParameters;
 use bevy::prelude::*;
@@ -76,6 +78,11 @@ impl From<SharedShape> for Collider {
             unscaled: shared_shape,
             scale: Vect::ONE,
         }
+    }
+}
+impl fmt::Debug for Collider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_typed_shape().fmt(f)
     }
 }
 

--- a/src/geometry/shape_views/collider_view.rs
+++ b/src/geometry/shape_views/collider_view.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::*;
 use crate::math::Vect;
 use rapier::geometry::{RoundShape, SharedShape};
@@ -58,6 +60,40 @@ pub enum ColliderView<'a> {
     /// A convex polygon with rounded corners.
     #[cfg(feature = "dim2")]
     RoundConvexPolygon(RoundConvexPolygonView<'a>),
+}
+impl<'a> fmt::Debug for ColliderView<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ColliderView::Ball(view) => write!(f, "{:?}", view.raw),
+            ColliderView::Cuboid(view) => write!(f, "{:?}", view.raw),
+            ColliderView::Capsule(view) => write!(f, "{:?}", view.raw),
+            ColliderView::Segment(view) => write!(f, "{:?}", view.raw),
+            ColliderView::Triangle(view) => write!(f, "{:?}", view.raw),
+            ColliderView::TriMesh(_) => write!(f, "Trimesh (not representable)"),
+            ColliderView::Polyline(_) => write!(f, "Polyline (not representable)"),
+            ColliderView::HalfSpace(view) => write!(f, "{:?}", view.raw),
+            ColliderView::HeightField(view) => write!(f, "{:?}", view.raw),
+            ColliderView::Compound(_) => write!(f, "Compound (not representable)"),
+            #[cfg(feature = "dim2")]
+            ColliderView::ConvexPolygon(view) => write!(f, "{:?}", view.raw),
+            #[cfg(feature = "dim3")]
+            ColliderView::ConvexPolyhedron(view) => write!(f, "{:?}", view.raw),
+            #[cfg(feature = "dim3")]
+            ColliderView::Cylinder(view) => write!(f, "{:?}", view.raw),
+            #[cfg(feature = "dim3")]
+            ColliderView::Cone(view) => write!(f, "{:?}", view.raw),
+            ColliderView::RoundCuboid(view) => write!(f, "{:?}", view.raw),
+            ColliderView::RoundTriangle(view) => write!(f, "{:?}", view.raw),
+            #[cfg(feature = "dim3")]
+            ColliderView::RoundCylinder(view) => write!(f, "{:?}", view.raw),
+            #[cfg(feature = "dim3")]
+            ColliderView::RoundCone(view) => write!(f, "{:?}", view.raw),
+            #[cfg(feature = "dim3")]
+            ColliderView::RoundConvexPolyhedron(view) => write!(f, "{:?}", view.raw),
+            #[cfg(feature = "dim2")]
+            ColliderView::RoundConvexPolygon(view) => write!(f, "{:?}", view.raw),
+        }
+    }
 }
 
 impl<'a> From<TypedShape<'a>> for ColliderView<'a> {


### PR DESCRIPTION
This is a bit repetitive due to the nature of `ColliderView`,
but it's the most streightforward way,
I'm not sure I see a more elegant way and
it's just for the **Debug** representation.