### PR TITLE
Mitigate rounding errors due to scaling extraction from the global transform

### DIFF
--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -512,27 +512,17 @@ impl Collider {
     /// the shape is approximated by a convex polygon/convex polyhedron using
     /// `num_subdivisions` subdivisions.
     pub fn set_scale(&mut self, mut scale: Vect, num_subdivisions: u32) {
-        /// First, we need to snap the new value to the old one if it’s close
-        /// enough. This protects us from the numerical jitters due to the scale
-        /// extraction from the global transformation matrix.
-        /// We do a special-case for when we are close to 1.0: if the new scaling
-        /// is close to 1.0, we snap it to 1.0 to recover the exact identity.
-        fn snap_value(new: &mut f32, old: f32) {
-            const SCALE_EPS: f32 = 1.0e-4;
-
-            if (*new - 1.0).abs() <= SCALE_EPS {
-                *new = 1.0;
-            } else if (*new - (-1.0)).abs() <= SCALE_EPS {
-                *new = -1.0;
-            } else if (*new - old).abs() <= SCALE_EPS {
-                *new = old;
-            }
+        /// We restrict the scaling increment to 1.0e-4, to avoid numerical jitter
+        /// due to the extraction of scaling factor from the GlobalTransform matrix.
+        fn snap_value(new: &mut f32) {
+            const PRECISION: f32 = 1.0e4;
+            *new = (*new * PRECISION).round() / PRECISION;
         }
 
-        snap_value(&mut scale.x, self.scale.x);
-        snap_value(&mut scale.y, self.scale.y);
+        snap_value(&mut scale.x);
+        snap_value(&mut scale.y);
         #[cfg(feature = "dim3")]
-        snap_value(&mut scale.z, self.scale.z);
+        snap_value(&mut scale.z);
 
         if scale == self.scale {
             // Nothing to do.


### PR DESCRIPTION
The extraction of scaling from the new `GlobalTransform` in bevy 0.8 can introduce rounding error. This PR prevents the scaling from drifting slightly from the identity, reducing risks of switching unnecessarily to a convex polyhedron representation.

Fix #244 