### PR TITLE
Fix spawn position of colliders without rigid bodies

### DIFF
--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -755,7 +755,7 @@ pub fn init_colliders(
             solver_groups,
             contact_force_event_threshold,
         ),
-        transform,
+        global_transform,
     ) in colliders.iter()
     {
         let mut scaled_shape = shape.clone();
@@ -845,9 +845,9 @@ pub fn init_colliders(
             }
             handle
         } else {
-            let transform = transform.cloned().unwrap_or_default();
+            let global_transform = global_transform.cloned().unwrap_or_default();
             builder = builder.position(utils::transform_to_iso(
-                &transform.compute_transform(),
+                &global_transform.compute_transform(),
                 scale,
             ));
             context.colliders.insert(builder)

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -733,7 +733,7 @@ pub fn init_colliders(
     mut commands: Commands,
     config: Res<RapierConfiguration>,
     mut context: ResMut<RapierContext>,
-    colliders: Query<ColliderComponents, Without<RapierColliderHandle>>,
+    colliders: Query<(ColliderComponents, &Transform), Without<RapierColliderHandle>>,
     mut rigid_body_mprops: Query<&mut ReadMassProperties>,
     parent_query: Query<(&Parent, Option<&Transform>)>,
 ) {
@@ -741,18 +741,21 @@ pub fn init_colliders(
     let physics_scale = context.physics_scale;
 
     for (
-        entity,
-        shape,
-        sensor,
-        mprops,
-        active_events,
-        active_hooks,
-        active_collision_types,
-        friction,
-        restitution,
-        collision_groups,
-        solver_groups,
-        contact_force_event_threshold,
+        (
+            entity,
+            shape,
+            sensor,
+            mprops,
+            active_events,
+            active_hooks,
+            active_collision_types,
+            friction,
+            restitution,
+            collision_groups,
+            solver_groups,
+            contact_force_event_threshold,
+        ),
+        transform,
     ) in colliders.iter()
     {
         let mut scaled_shape = shape.clone();
@@ -809,7 +812,7 @@ pub fn init_colliders(
 
         let mut body_entity = entity;
         let mut body_handle = context.entity2body.get(&body_entity).copied();
-        let mut child_transform = Transform::default();
+        let mut child_transform = *transform;
         while body_handle.is_none() {
             if let Ok((parent_entity, transform)) = parent_query.get(body_entity) {
                 if let Some(transform) = transform {

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -826,11 +826,10 @@ pub fn init_colliders(
             body_handle = context.entity2body.get(&body_entity).copied();
         }
 
-        builder = builder.position(utils::transform_to_iso(&child_transform, physics_scale));
         builder = builder.user_data(entity.to_bits() as u128);
 
         let handle = if let Some(body_handle) = body_handle {
-            builder = builder.position(utils::transform_to_iso(&child_transform, scale));
+            builder = builder.position(utils::transform_to_iso(&child_transform, physics_scale));
             let handle =
                 context
                     .colliders
@@ -848,7 +847,7 @@ pub fn init_colliders(
             let global_transform = global_transform.cloned().unwrap_or_default();
             builder = builder.position(utils::transform_to_iso(
                 &global_transform.compute_transform(),
-                scale,
+                physics_scale,
             ));
             context.colliders.insert(builder)
         };

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -733,7 +733,7 @@ pub fn init_colliders(
     mut commands: Commands,
     config: Res<RapierConfiguration>,
     mut context: ResMut<RapierContext>,
-    colliders: Query<(ColliderComponents, &Transform), Without<RapierColliderHandle>>,
+    colliders: Query<(ColliderComponents, Option<&Transform>), Without<RapierColliderHandle>>,
     mut rigid_body_mprops: Query<&mut ReadMassProperties>,
     parent_query: Query<(&Parent, Option<&Transform>)>,
 ) {
@@ -812,7 +812,7 @@ pub fn init_colliders(
 
         let mut body_entity = entity;
         let mut body_handle = context.entity2body.get(&body_entity).copied();
-        let mut child_transform = *transform;
+        let mut child_transform = *transform.unwrap_or(&Transform::default());
         while body_handle.is_none() {
             if let Ok((parent_entity, transform)) = parent_query.get(body_entity) {
                 if let Some(transform) = transform && body_entity != entity {

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -815,7 +815,7 @@ pub fn init_colliders(
         let mut child_transform = *transform;
         while body_handle.is_none() {
             if let Ok((parent_entity, transform)) = parent_query.get(body_entity) {
-                if let Some(transform) = transform {
+                if let Some(transform) = transform && body_entity != entity {
                     child_transform = *transform * child_transform;
                 }
                 body_entity = parent_entity.get();

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -815,8 +815,10 @@ pub fn init_colliders(
         let mut child_transform = *transform.unwrap_or(&Transform::default());
         while body_handle.is_none() {
             if let Ok((parent_entity, transform)) = parent_query.get(body_entity) {
-                if let Some(transform) = transform && body_entity != entity {
-                    child_transform = *transform * child_transform;
+                if let Some(transform) = transform {
+                    if body_entity != entity {
+                        child_transform = *transform * child_transform;
+                    }
                 }
                 body_entity = parent_entity.get();
             } else {


### PR DESCRIPTION
Attempt to fix #249.

Issue occurs when a collider has no parents and is not being attached to a rigid body. Since the entity has no parent it will not get it's own transform from the parent query. With these changes if a collider is not being attached to a handle we instead use the global transform to position it. Based on the documentation for ColliderBuilder.position and testing this seems correct.

Fixes the bug as it appears in #249 and as I encountered it in my personal project.