### PR TITLE
Fix transform_to_iso to keep identical rotation

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -51,14 +51,15 @@ pub(crate) fn transform_to_iso(transform: &Transform, physics_scale: Real) -> Is
 #[cfg(test)]
 #[cfg(feature = "dim3")]
 mod tests {
-    use bevy::prelude::Transform;
     use super::*;
+    use bevy::prelude::Transform;
 
     #[test]
     fn convert_back_to_equal_transform() {
         let transform = Transform {
             translation: bevy::prelude::Vec3::new(-2.1855694e-8, 0.0, 0.0),
-            rotation: bevy::prelude::Quat::from_xyzw(0.99999994, 0.0, 1.6292068e-7, 0.0).normalize(),
+            rotation: bevy::prelude::Quat::from_xyzw(0.99999994, 0.0, 1.6292068e-7, 0.0)
+                .normalize(),
             ..Default::default()
         };
         let converted_transform = iso_to_transform(&transform_to_iso(&transform, 1.0), 1.0);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -42,8 +42,26 @@ pub(crate) fn transform_to_iso(transform: &Transform, physics_scale: Real) -> Is
 /// The translation is divided by the `physics_scale`.
 #[cfg(feature = "dim3")]
 pub(crate) fn transform_to_iso(transform: &Transform, physics_scale: Real) -> Isometry<Real> {
-    Isometry::new(
+    Isometry::from_parts(
         (transform.translation / physics_scale).into(),
-        transform.rotation.to_scaled_axis().into(),
+        transform.rotation.into(),
     )
+}
+
+#[cfg(test)]
+#[cfg(feature = "dim3")]
+mod tests {
+    use bevy::prelude::Transform;
+    use super::*;
+
+    #[test]
+    fn convert_back_to_equal_transform() {
+        let transform = Transform {
+            translation: bevy::prelude::Vec3::new(-2.1855694e-8, 0.0, 0.0),
+            rotation: bevy::prelude::Quat::from_xyzw(0.99999994, 0.0, 1.6292068e-7, 0.0).normalize(),
+            ..Default::default()
+        };
+        let converted_transform = iso_to_transform(&transform_to_iso(&transform, 1.0), 1.0);
+        assert_eq!(converted_transform, transform);
+    }
 }


### PR DESCRIPTION
As the title, fix the `transform_to_iso` to have an equal quaternion value.

Currently, the result isometry has slightly different values so it's hard to make the app deterministic when setting rotation manually.

I think we need to fix the 2d version of the function too, but I'm not sure how to fix it.