### PR TITLE
Add a kinematic character controller implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.17.0 (02 Oct. 2022)
+### Added
+- Add a **kinematic character controller** implementation. This feature is accessible in two different ways:
+  1. The first approach is to insert the `KinematicCharacterController` component to an entity. If the
+  `KinematicCharacterController::custom_shape` field is set, then this shape is used for the character control.
+  If this field is `None` then the `Collider` attached to the same entity as the character controller is used.
+  The character controller will be automatically updated when the `KinematicCharacterController::movement` is set.
+  The result position is written to the `Transform` of the character controller’s entity.
+  2. The second, lower level, approach, is to call `RapierContext::move_shape` to compute the possible movement
+  of a shape, taking obstacle and sliding into account.
+- Add implementations of `Add`, `AddAssign`, `Sub`, `SubAssign` to `ExternalForce` and `ExternalImpulse`.
+- Add `ExternalForce::at_point` and `ExternalImpulse::at_point` to apply a force/impulse at a specific point
+  of a rigid-body.
+
+### Fix
+- Fix shapes quickly switching between scaled and non-scaled versions due to rounding errors in the scaling extraction
+  from bevy’s global affine transform.
+
 ## 0.16.2 (23 August 2022)
 ### Added
 - Implement `Debug` for `Collider` and `ColliderView`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ codegen-units = 1
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
 #parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
-#rapier2d = { git = "https://github.com/dimforge/rapier", branch = "master" }
-#rapier3d = { git = "https://github.com/dimforge/rapier", branch = "master" }
+#rapier2d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
+#rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.17.0"
+version = "0.16.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.16.2"
+version = "0.17.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = "0.14.0"
+rapier2d = "0.15.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", optional = true }
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.16.2"
+version = "0.17.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = "0.14.0"
+rapier3d = "0.15.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", features = ["3d"], optional = true }
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.17.0"
+version = "0.16.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -1,0 +1,212 @@
+use crate::geometry::{Collider, Toi};
+use crate::math::{Real, Rot, Vect};
+use bevy::prelude::*;
+
+use crate::plugin::RapierContext;
+pub use rapier::control::CharacterAutostep;
+pub use rapier::control::CharacterLength;
+use rapier::prelude::{ColliderSet, InteractionGroups, QueryFilterFlags};
+
+/// A collision between the character and its environment during its movement.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct CharacterCollision {
+    /// The entity hit by the character.
+    pub entity: Entity,
+    /// The position of the character when the collider was hit.
+    pub character_translation: Vect,
+    /// The rotation of the character when the collider was hit.
+    pub character_rotation: Rot,
+    /// The translation that was already applied to the character when the hit happens.
+    pub translation_applied: Vect,
+    /// The translations that was still waiting to be applied to the character when the hit happens.
+    pub translation_remaining: Vect,
+    /// Geometric information about the hit.
+    pub toi: Toi,
+}
+
+impl CharacterCollision {
+    pub(crate) fn from_raw(
+        ctxt: &RapierContext,
+        c: &rapier::control::CharacterCollision,
+    ) -> Option<Self> {
+        Self::from_raw_with_set(ctxt.physics_scale, &ctxt.colliders, c)
+    }
+
+    pub(crate) fn from_raw_with_set(
+        physics_scale: Real,
+        colliders: &ColliderSet,
+        c: &rapier::control::CharacterCollision,
+    ) -> Option<Self> {
+        RapierContext::collider_entity_with_set(colliders, c.handle).map(|entity| {
+            CharacterCollision {
+                entity,
+                character_translation: (c.character_pos.translation.vector * physics_scale).into(),
+                #[cfg(feature = "dim2")]
+                character_rotation: c.character_pos.rotation.angle(),
+                #[cfg(feature = "dim3")]
+                character_rotation: c.character_pos.rotation.into(),
+                translation_applied: (c.translation_applied * physics_scale).into(),
+                translation_remaining: (c.translation_remaining * physics_scale).into(),
+                toi: Toi::from_rapier(physics_scale, c.toi),
+            }
+        })
+    }
+}
+
+/// Options for moving a shape using `RapierContext::move_shape`.
+#[derive(Clone, Debug, Copy, PartialEq)]
+pub struct MoveShapeOptions {
+    /// The direction that goes "up". Used to determine where the floor is, and the floor’s angle.
+    pub up: Vect,
+    /// A small gap to preserve between the character and its surroundings.
+    ///
+    /// This value should not be too large to avoid visual artifacts, but shouldn’t be too small
+    /// (must not be zero) to improve numerical stability of the character controller.
+    pub offset: CharacterLength,
+    /// Should the character try to slide against the floor if it hits it?
+    pub slide: bool,
+    /// Should the character automatically step over small obstacles?
+    pub autostep: Option<CharacterAutostep>,
+    /// The maximum angle (radians) between the floor’s normal and the `up` vector that the
+    /// character is able to climb.
+    pub max_slope_climb_angle: Real,
+    /// The minimum angle (radians) between the floor’s normal and the `up` vector before the
+    /// character starts to slide down automatically.
+    pub min_slope_slide_angle: Real,
+    /// Should the character apply forces to dynamic bodies in its path?
+    pub apply_impulse_to_dynamic_bodies: bool,
+    /// Should the character be automatically snapped to the ground if the distance between
+    /// the ground and its feed are smaller than the specified threshold?
+    pub snap_to_ground: Option<CharacterLength>,
+}
+
+impl Default for MoveShapeOptions {
+    fn default() -> Self {
+        let def = rapier::control::KinematicCharacterController::default();
+        Self {
+            up: def.up.into(),
+            offset: def.offset,
+            slide: def.slide,
+            autostep: def.autostep,
+            max_slope_climb_angle: def.max_slope_climb_angle,
+            min_slope_slide_angle: def.min_slope_slide_angle,
+            apply_impulse_to_dynamic_bodies: true,
+            snap_to_ground: def.snap_to_ground,
+        }
+    }
+}
+
+/// A character controller for kinematic bodies and free-standing colliders.
+#[derive(Clone, Debug, Component)] // TODO: Reflect
+pub struct KinematicCharacterController {
+    /// The translations we desire the character to move by if it doesn’t meet any obstacle.
+    pub translation: Option<Vect>,
+    /// The shape, and its position, to be used instead of the shape of the collider attached to
+    /// the same entity is this `KinematicCharacterController`.
+    pub custom_shape: Option<(Collider, Vect, Rot)>,
+    /// The mass to be used for impulse of dynamic bodies. This replaces the mass of the rigid-body
+    /// potentially associated to the collider attached to the same entity as this
+    /// `KinematicCharacterController`.
+    ///
+    /// This field isn’t used if `Self::apply_impulse_to_dynamic_bodies` is set to `false`.
+    pub custom_mass: Option<Real>,
+    /// The direction that goes "up". Used to determine where the floor is, and the floor’s angle.
+    pub up: Vect,
+    /// A small gap to preserve between the character and its surroundings.
+    ///
+    /// This value should not be too large to avoid visual artifacts, but shouldn’t be too small
+    /// (must not be zero) to improve numerical stability of the character controller.
+    pub offset: CharacterLength,
+    /// Should the character try to slide against the floor if it hits it?
+    pub slide: bool,
+    /// Should the character automatically step over small obstacles?
+    pub autostep: Option<CharacterAutostep>,
+    /// The maximum angle (radians) between the floor’s normal and the `up` vector that the
+    /// character is able to climb.
+    pub max_slope_climb_angle: Real,
+    /// The minimum angle (radians) between the floor’s normal and the `up` vector before the
+    /// character starts to slide down automatically.
+    pub min_slope_slide_angle: Real,
+    /// Should the character apply forces to dynamic bodies in its path?
+    pub apply_impulse_to_dynamic_bodies: bool,
+    /// Should the character be automatically snapped to the ground if the distance between
+    /// the ground and its feed are smaller than the specified threshold?
+    pub snap_to_ground: Option<CharacterLength>,
+    /// Flags for filtering-out some categories of entities from the environment seen by the
+    /// character controller.
+    pub filter_flags: QueryFilterFlags,
+    /// Groups for filtering-out some colliders from the environment seen by the character
+    /// controller.
+    pub filter_groups: Option<InteractionGroups>,
+}
+
+impl KinematicCharacterController {
+    pub(crate) fn to_raw(
+        &self,
+        physics_scale: Real,
+    ) -> Option<rapier::control::KinematicCharacterController> {
+        let autostep = self.autostep.map(|autostep| CharacterAutostep {
+            max_height: autostep.max_height.map_absolute(|x| x / physics_scale),
+            min_width: autostep.min_width.map_absolute(|x| x / physics_scale),
+            include_dynamic_bodies: autostep.include_dynamic_bodies,
+        });
+
+        Some(rapier::control::KinematicCharacterController {
+            up: self.up.try_into().ok()?,
+            offset: self.offset.map_absolute(|x| x / physics_scale),
+            slide: self.slide,
+            autostep,
+            max_slope_climb_angle: self.max_slope_climb_angle,
+            min_slope_slide_angle: self.min_slope_slide_angle,
+            snap_to_ground: self
+                .snap_to_ground
+                .map(|x| x.map_absolute(|x| x / physics_scale)),
+        })
+    }
+}
+
+impl Default for KinematicCharacterController {
+    fn default() -> Self {
+        let def = rapier::control::KinematicCharacterController::default();
+        Self {
+            translation: None,
+            custom_shape: None,
+            custom_mass: None,
+            up: def.up.into(),
+            offset: def.offset,
+            slide: def.slide,
+            autostep: def.autostep,
+            max_slope_climb_angle: def.max_slope_climb_angle,
+            min_slope_slide_angle: def.min_slope_slide_angle,
+            apply_impulse_to_dynamic_bodies: true,
+            snap_to_ground: def.snap_to_ground,
+            filter_flags: QueryFilterFlags::default(),
+            filter_groups: None,
+        }
+    }
+}
+
+/// The output of a character control.
+///
+/// This component is automatically added after the first execution of a character control
+/// based on the `KinematicCharacterController` component with its
+/// `KinematicCharacterController::translation` set to a value other than `None`.
+#[derive(Clone, PartialEq, Debug, Default, Component)]
+pub struct KinematicCharacterControllerOutput {
+    /// Indicates whether the shape is grounded after its kinematic movement.
+    pub grounded: bool,
+    /// The initial desired movement of the character if there were no obstacle.
+    pub desired_translation: Vect,
+    /// The translation calculated by the last character control step taking obstacles into account.
+    pub effective_translation: Vect,
+    /// Collisions between the character and obstacles found in its path.
+    pub collisions: Vec<CharacterCollision>,
+}
+
+/// The allowed movement computed by `RapierContext::move_shape`.
+pub struct MoveShapeOutput {
+    /// Indicates whether the shape is grounded after its kinematic movement.
+    pub grounded: bool,
+    /// The translation calculated by the last character control step taking obstacles into account.
+    pub effective_translation: Vect,
+}

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,0 +1,6 @@
+pub use self::character_controller::{
+    CharacterAutostep, CharacterCollision, CharacterLength, KinematicCharacterController,
+    KinematicCharacterControllerOutput, MoveShapeOptions, MoveShapeOutput,
+};
+
+mod character_controller;

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -3,6 +3,7 @@ use bevy::{prelude::*, reflect::FromReflect};
 use rapier::prelude::{
     Isometry, LockedAxes as RapierLockedAxes, RigidBodyActivation, RigidBodyHandle, RigidBodyType,
 };
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// The Rapier handle of a rigid-body that was inserted to the physics scene.
 #[derive(Copy, Clone, Debug, Component)]
@@ -233,6 +234,61 @@ pub struct ExternalForce {
     pub torque: Vect,
 }
 
+impl ExternalForce {
+    /// A force applied at a specific world-space point of a rigid-body.
+    ///
+    /// # Parameters
+    /// - `force`: the force to apply.
+    /// - `point`: the point (world-space) where the impulse must be applied.
+    /// - `center_of_mass`: the center-of-mass (world-space) of the rigid-body the impulse is being
+    ///   applied to.
+    pub fn at_point(force: Vect, point: Vect, center_of_mass: Vect) -> Self {
+        Self {
+            force,
+            #[cfg(feature = "dim2")]
+            torque: (point - center_of_mass).perp_dot(force),
+            #[cfg(feature = "dim3")]
+            torque: (point - center_of_mass).cross(force),
+        }
+    }
+}
+
+impl Add for ExternalForce {
+    type Output = Self;
+
+    #[inline]
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl Sub for ExternalForce {
+    type Output = Self;
+
+    #[inline]
+    fn sub(mut self, rhs: Self) -> Self::Output {
+        self -= rhs;
+        self
+    }
+}
+
+impl AddAssign for ExternalForce {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.force += rhs.force;
+        self.torque += rhs.torque;
+    }
+}
+
+impl SubAssign for ExternalForce {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.force -= rhs.force;
+        self.torque -= rhs.torque;
+    }
+}
+
 /// Instantaneous external impulse applied continuously to a rigid-body.
 ///
 /// The impulse is only applied once, and whenever it it modified (based
@@ -248,6 +304,61 @@ pub struct ExternalImpulse {
     /// The angular impulse applied to the rigid-body.
     #[cfg(feature = "dim3")]
     pub torque_impulse: Vect,
+}
+
+impl ExternalImpulse {
+    /// An impulse applied at a specific world-space point of a rigid-body.
+    ///
+    /// # Parameters
+    /// - `impulse`: the impulse to apply.
+    /// - `point`: the point (world-space) where the impulse must be applied.
+    /// - `center_of_mass`: the center-of-mass (world-space) of the rigid-body the impulse is being
+    ///   applied to.
+    pub fn at_point(impulse: Vect, point: Vect, center_of_mass: Vect) -> Self {
+        Self {
+            impulse,
+            #[cfg(feature = "dim2")]
+            torque_impulse: (point - center_of_mass).perp_dot(impulse),
+            #[cfg(feature = "dim3")]
+            torque_impulse: (point - center_of_mass).cross(impulse),
+        }
+    }
+}
+
+impl Add for ExternalImpulse {
+    type Output = Self;
+
+    #[inline]
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl Sub for ExternalImpulse {
+    type Output = Self;
+
+    #[inline]
+    fn sub(mut self, rhs: Self) -> Self::Output {
+        self -= rhs;
+        self
+    }
+}
+
+impl AddAssign for ExternalImpulse {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.impulse += rhs.impulse;
+        self.torque_impulse += rhs.torque_impulse;
+    }
+}
+
+impl SubAssign for ExternalImpulse {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.impulse -= rhs.impulse;
+        self.torque_impulse -= rhs.torque_impulse;
+    }
 }
 
 /// Gravity is multiplied by this scaling factor before it's

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -82,9 +82,9 @@ impl From<SharedShape> for Collider {
     }
 }
 
-impl<'a> Into<&'a dyn Shape> for &'a Collider {
-    fn into(self) -> &'a dyn Shape {
-        &*self.raw
+impl<'a> From<&'a Collider> for &'a dyn Shape {
+    fn from(collider: &'a Collider) -> &'a dyn Shape {
+        &*collider.raw
     }
 }
 

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -279,26 +279,21 @@ impl Collider {
     /// Initializes a collider with a heightfield shape defined by its set of height and a scale
     /// factor along each coordinate axis.
     #[cfg(feature = "dim2")]
-    pub fn heightfield(heights: Vec<Real>, scale: Vector<Real>) -> Self {
-        SharedShape::heightfield(DVector::from_vec(heights), scale).into()
+    pub fn heightfield(heights: Vec<Real>, scale: Vect) -> Self {
+        SharedShape::heightfield(DVector::from_vec(heights), scale.into()).into()
     }
 
     /// Initializes a collider with a heightfield shape defined by its set of height (in
     /// column-major format) and a scale factor along each coordinate axis.
     #[cfg(feature = "dim3")]
-    pub fn heightfield(
-        heights: Vec<Real>,
-        num_rows: usize,
-        num_cols: usize,
-        scale: Vector<Real>,
-    ) -> Self {
+    pub fn heightfield(heights: Vec<Real>, num_rows: usize, num_cols: usize, scale: Vect) -> Self {
         assert_eq!(
             heights.len(),
             num_rows * num_cols,
             "Invalid number of heights provided."
         );
         let heights = rapier::na::DMatrix::from_vec(num_rows, num_cols, heights);
-        SharedShape::heightfield(heights, scale).into()
+        SharedShape::heightfield(heights, scale.into()).into()
     }
 
     /// Takes a strongly typed reference of this collider.

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -79,7 +79,7 @@ impl RayIntersection {
 }
 
 /// The result of a time-of-impact (TOI) computation.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Toi {
     /// The time at which the objects touch.
     pub toi: Real,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod pipeline;
 /// The physics plugin and systems.
 pub mod plugin;
 
+/// Components related to character control.
+pub mod control;
 /// The debug-renderer.
 #[cfg(feature = "debug-render")]
 pub mod render;
@@ -66,6 +68,7 @@ pub mod utils;
 
 /// Groups the most often used types.
 pub mod prelude {
+    pub use crate::control::*;
     pub use crate::dynamics::*;
     pub use crate::geometry::*;
     pub use crate::math::*;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -5,7 +5,7 @@ pub use self::physics_hooks::{
     ContactModificationContextView, PairFilterContextView, PhysicsHooksWithQuery,
     PhysicsHooksWithQueryResource,
 };
-pub use query_filter::QueryFilter;
+pub use query_filter::{InteractionGroups, QueryFilter, QueryFilterFlags};
 
 mod events;
 mod physics_hooks;

--- a/src/pipeline/query_filter.rs
+++ b/src/pipeline/query_filter.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::Entity;
-use rapier::geometry::InteractionGroups;
-use rapier::pipeline::QueryFilterFlags;
+
+pub use rapier::geometry::InteractionGroups;
+pub use rapier::pipeline::QueryFilterFlags;
 
 /// A filter tha describes what collider should be included or excluded from a scene query.
 #[derive(Copy, Clone, Default)]
@@ -54,7 +55,7 @@ impl<'a> QueryFilter<'a> {
     }
 
     /// Exclude from the query any collider attached to a kinematic rigid-body.
-    pub fn exclude_dynamic(self) -> Self {
+    pub fn exclude_dynamic() -> Self {
         QueryFilterFlags::EXCLUDE_DYNAMIC.into()
     }
 

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -16,11 +16,13 @@ use crate::pipeline::{CollisionEvent, ContactForceEvent, EventQueue, QueryFilter
 use bevy::prelude::{Entity, EventWriter, GlobalTransform, Query};
 use bevy::render::primitives::Aabb;
 
+use crate::control::{CharacterCollision, MoveShapeOptions, MoveShapeOutput};
 use crate::dynamics::TransformInterpolation;
 use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
 use crate::prelude::RapierRigidBodyHandle;
 #[cfg(feature = "dim2")]
 use bevy::math::Vec3Swizzles;
+use rapier::control::CharacterAutostep;
 
 /// The Rapier context, containing all the state of the physics engine.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -69,6 +71,8 @@ pub struct RapierContext {
     // physics update, to the entity they was attached to.
     #[cfg_attr(feature = "serde-serialize", serde(skip))]
     pub(crate) deleted_colliders: HashMap<ColliderHandle, Entity>,
+    #[cfg_attr(feature = "serde-serialize", serde(skip))]
+    pub(crate) character_collisions_collector: Vec<rapier::control::CharacterCollision>,
 }
 
 impl Default for RapierContext {
@@ -93,6 +97,7 @@ impl Default for RapierContext {
             entity2impulse_joint: HashMap::new(),
             entity2multibody_joint: HashMap::new(),
             deleted_colliders: HashMap::new(),
+            character_collisions_collector: vec![],
         }
     }
 }
@@ -110,7 +115,15 @@ impl RapierContext {
 
     /// Retrieve the Bevy entity the given Rapier collider (identified by its handle) is attached.
     pub fn collider_entity(&self, handle: ColliderHandle) -> Option<Entity> {
-        self.colliders
+        Self::collider_entity_with_set(&self.colliders, handle)
+    }
+
+    // Mostly used to avoid borrowing self completely.
+    pub(crate) fn collider_entity_with_set(
+        colliders: &ColliderSet,
+        handle: ColliderHandle,
+    ) -> Option<Entity> {
+        colliders
             .get(handle)
             .map(|c| Entity::from_bits(c.user_data as u64))
     }
@@ -127,21 +140,39 @@ impl RapierContext {
         filter: QueryFilter,
         f: impl FnOnce(RapierQueryFilter) -> T,
     ) -> T {
+        Self::with_query_filter_elts(
+            &self.entity2collider,
+            &self.entity2body,
+            &self.colliders,
+            filter,
+            f,
+        )
+    }
+
+    fn with_query_filter_elts<T>(
+        entity2collider: &HashMap<Entity, ColliderHandle>,
+        entity2body: &HashMap<Entity, RigidBodyHandle>,
+        colliders: &ColliderSet,
+        filter: QueryFilter,
+        f: impl FnOnce(RapierQueryFilter) -> T,
+    ) -> T {
         let mut rapier_filter = RapierQueryFilter {
             flags: filter.flags,
             groups: filter.groups,
             exclude_collider: filter
                 .exclude_collider
-                .and_then(|c| self.entity2collider.get(&c).copied()),
+                .and_then(|c| entity2collider.get(&c).copied()),
             exclude_rigid_body: filter
                 .exclude_rigid_body
-                .and_then(|b| self.entity2body.get(&b).copied()),
+                .and_then(|b| entity2body.get(&b).copied()),
             predicate: None,
         };
 
         if let Some(predicate) = filter.predicate {
             let wrapped_predicate = |h: ColliderHandle, _: &rapier::geometry::Collider| {
-                self.collider_entity(h).map(predicate).unwrap_or(false)
+                Self::collider_entity_with_set(colliders, h)
+                    .map(predicate)
+                    .unwrap_or(false)
             };
             rapier_filter.predicate = Some(&wrapped_predicate);
             f(rapier_filter)
@@ -306,6 +337,117 @@ impl RapierContext {
     /// The map from entities to multibody joint handles.
     pub fn entity2multibody_joint(&self) -> &HashMap<Entity, MultibodyJointHandle> {
         &self.entity2multibody_joint
+    }
+
+    /// Attempts to move shape, optionally sliding or climbing obstacles.
+    ///
+    /// # Parameters
+    /// * `movement`: the translational movement to apply.
+    /// * `shape`: the shape to move.
+    /// * `shape_translation`: the initial position of the shape.
+    /// * `shape_rotation`: the rotation of the shape.
+    /// * `shape_mass`: the mass of the shape to be considered by the impulse calculation if
+    ///                 `MoveShapeOptions::apply_impulse_to_dynamic_bodies` is set to true.
+    /// * `options`: configures the behavior of the automatic sliding and climbing.
+    /// * `filter`: indicates what collider or rigid-body needs to be ignored by the obstacle detection.
+    /// * `events`: callback run on each obstacle hit by the shape on its path.
+    pub fn move_shape<'a>(
+        &mut self,
+        movement: Vect,
+        shape: &Collider,
+        shape_translation: Vect,
+        shape_rotation: Rot,
+        shape_mass: Real,
+        options: &MoveShapeOptions,
+        filter: QueryFilter,
+        mut events: impl FnMut(CharacterCollision),
+    ) -> MoveShapeOutput {
+        let physics_scale = self.physics_scale;
+        let mut scaled_shape = shape.clone();
+        // TODO: how to set a good number of subdivisions, we don’t have access to the
+        //       RapierConfiguration::scaled_shape_subdivision here.
+        scaled_shape.set_scale(shape.scale / physics_scale, 20);
+
+        let up = options
+            .up
+            .try_into()
+            .expect("The up vector must be non-zero.");
+        let autostep = options.autostep.map(|autostep| CharacterAutostep {
+            max_height: autostep.max_height.map_absolute(|x| x / physics_scale),
+            min_width: autostep.min_width.map_absolute(|x| x / physics_scale),
+            include_dynamic_bodies: autostep.include_dynamic_bodies,
+        });
+        let controller = rapier::control::KinematicCharacterController {
+            up,
+            offset: options.offset.map_absolute(|x| x / physics_scale),
+            slide: options.slide,
+            autostep,
+            max_slope_climb_angle: options.max_slope_climb_angle,
+            min_slope_slide_angle: options.min_slope_slide_angle,
+            snap_to_ground: options
+                .snap_to_ground
+                .map(|x| x.map_absolute(|x| x / physics_scale)),
+        };
+
+        self.character_collisions_collector.clear();
+
+        // TODO: having to grab all the references to avoid having self in
+        //       the closure is ugly.
+        let dt = self.integration_parameters.dt;
+        let colliders = &self.colliders;
+        let bodies = &mut self.bodies;
+        let query_pipeline = &self.query_pipeline;
+        let collisions = &mut self.character_collisions_collector;
+        collisions.clear();
+
+        let result = Self::with_query_filter_elts(
+            &self.entity2collider,
+            &self.entity2body,
+            &self.colliders,
+            filter,
+            move |filter| {
+                let result = controller.move_shape(
+                    dt,
+                    bodies,
+                    colliders,
+                    query_pipeline,
+                    (&scaled_shape).into(),
+                    &(shape_translation / physics_scale, shape_rotation).into(),
+                    (movement / physics_scale).into(),
+                    filter,
+                    |c| {
+                        if let Some(collision) =
+                            CharacterCollision::from_raw_with_set(physics_scale, colliders, &c)
+                        {
+                            events(collision);
+                        }
+                        collisions.push(c);
+                    },
+                );
+
+                if options.apply_impulse_to_dynamic_bodies {
+                    for collision in &*collisions {
+                        controller.solve_character_collision_impulses(
+                            dt,
+                            bodies,
+                            colliders,
+                            query_pipeline,
+                            (&scaled_shape).into(),
+                            shape_mass,
+                            collision,
+                            filter,
+                        )
+                    }
+                }
+
+                result
+            },
+        );
+
+        MoveShapeOutput {
+            effective_translation: (result.translation * physics_scale).into(),
+            grounded: result.grounded,
+        }
     }
 
     /// Find the closest intersection between a ray and a set of collider.
@@ -622,6 +764,7 @@ impl RapierContext {
                 &(shape_vel / self.physics_scale).into(),
                 &*scaled_shape.raw,
                 max_toi,
+                true,
                 filter,
             )
         })?;

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -351,7 +351,8 @@ impl RapierContext {
     /// * `options`: configures the behavior of the automatic sliding and climbing.
     /// * `filter`: indicates what collider or rigid-body needs to be ignored by the obstacle detection.
     /// * `events`: callback run on each obstacle hit by the shape on its path.
-    pub fn move_shape<'a>(
+    #[allow(clippy::too_many_arguments)]
+    pub fn move_shape(
         &mut self,
         movement: Vect,
         shape: &Collider,

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -59,7 +59,11 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
         match stage {
             PhysicsStages::SyncBackend => {
                 let systems = SystemSet::new()
-                    .with_system(bevy::transform::transform_propagate_system) // Run Bevy transform propagation additionaly to sync [`GlobalTransform`]
+                    .with_system(systems::update_character_controls) // Run the character controller befor ethe manual transform propagation.
+                    .with_system(
+                        bevy::transform::transform_propagate_system
+                            .after(systems::update_character_controls),
+                    ) // Run Bevy transform propagation additionally to sync [`GlobalTransform`]
                     .with_system(
                         systems::init_async_colliders
                             .after(bevy::transform::transform_propagate_system),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,4 +1,5 @@
 use crate::plugin::RapierContext;
+use crate::render::lines::DebugLinesConfig;
 use bevy::prelude::*;
 use lines::DebugLines;
 use rapier::math::{Point, Real};
@@ -20,10 +21,12 @@ pub struct ColliderDebugColor(pub Color);
 /// its physics simulation. This is typically useful to check proper
 /// alignment between colliders and your own visual assets.
 pub struct RapierDebugRenderPlugin {
-    /// If set to `false`, depth-testing will be disabled when rendering,
+    /// If set to `true`, depth-testing will be disabled when rendering,
     /// meaning that the debug-render lines will always appear on top
     /// of (won’t be occluded by) your own visual assets.
-    pub depth_test: bool,
+    pub always_on_top: bool,
+    /// Is the debug-rendering enabled?
+    pub enabled: bool,
     /// Control some aspects of the render coloring.
     pub style: DebugRenderStyle,
     /// Flags to select what part of physics scene is rendered (by default
@@ -55,6 +58,20 @@ impl Default for RapierDebugRenderPlugin {
     }
 }
 
+impl RapierDebugRenderPlugin {
+    /// Initialize the render plugin such that its lines are always rendered on top of other objects.
+    pub fn always_on_top(mut self) -> Self {
+        self.always_on_top = true;
+        self
+    }
+
+    /// Initialize the render plugin such that it is initially disabled.
+    pub fn disabled(mut self) -> Self {
+        self.enabled = false;
+        self
+    }
+}
+
 /// Context to control some aspect of the debug-renderer after initialization.
 pub struct DebugRenderContext {
     /// Is the debug-rendering currently enabled?
@@ -62,6 +79,8 @@ pub struct DebugRenderContext {
     /// Pipeline responsible for rendering. Access `pipeline.mode` and `pipeline.style`
     /// to modify the set of rendered elements, and modify the default coloring rules.
     pub pipeline: DebugRenderPipeline,
+    /// Are the debug-lines always rendered on top of other primitives?
+    pub always_on_top: bool,
 }
 
 impl Default for DebugRenderContext {
@@ -69,6 +88,7 @@ impl Default for DebugRenderContext {
         Self {
             enabled: true,
             pipeline: DebugRenderPipeline::default(),
+            always_on_top: true,
         }
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -34,6 +34,7 @@ pub struct RapierDebugRenderPlugin {
     pub mode: DebugRenderMode,
 }
 
+#[allow(clippy::derivable_impls)] // The 3D impl can be derived, but not the 2D impl.
 impl Default for RapierDebugRenderPlugin {
     #[cfg(feature = "dim2")]
     fn default() -> Self {


### PR DESCRIPTION
### Added
- Add a **kinematic character controller** implementation. This feature is accessible in two different ways:
    1. The first approach is to insert the `KinematicCharacterController` component to an entity. If the
    `KinematicCharacterController::custom_shape` field is set, then this shape is used for the character control.
    If this field is `None` then the `Collider` attached to the same entity as the character controller is used.
    The character controller will be automatically updated when the `KinematicCharacterController::movement` is set.
    The result position is written to the `Transform` of the character controller’s entity.
    2. The second, lower level, approach, is to call `RapierContext::move_shape` to compute the possible movement
    of a shape, taking obstacle and sliding into account.
- Add implementations of `Add`, `AddAssign`, `Sub`, `SubAssign` to `ExternalForce` and `ExternalImpulse`.
- Add `ExternalForce::at_point` and `ExternalImpulse::at_point` to apply a force/impulse at a specific point
  of a rigid-body.

The implemented character-controller feature are:
- Slide on uneven terrains
- Interaction with dynamic bodies.
- Climb stairs automatically.
- Automatically snap the body to the floor when going downstairs.
- Prevent sliding up slopes that are too steep
- Prevent sliding down slopes that are not steep enough
- Interactions with moving platforms.
- Report information on the obstacles it hit on its path.