### PR TITLE
Create Public Accesor for Physics Scale

### DIFF
--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -103,6 +103,13 @@ impl Default for RapierContext {
 }
 
 impl RapierContext {
+    /// Get the physics scale that was set for this Rapier context.
+    ///
+    /// See [`RapierPhysicsPlugin::with_physics_scale()`][crate::plugin::RapierPhysicsPlugin::with_physics_scale()].
+    pub fn physics_scale(&self) -> Real {
+        self.physics_scale
+    }
+
     /// If the collider attached to `entity` is attached to a rigid-body, this
     /// returns the `Entity` containing that rigid-body.
     pub fn collider_parent(&self, entity: Entity) -> Option<Entity> {


### PR DESCRIPTION
I was trying to make a custom Rapier debug plugin, but since physics scale was private, I couldn't make it render properly without the user manually configuring the scale of the debug renderer to match the scale of the rapier context.

This fixes the issue by adding a public accessor for physics scale.