### PR TITLE
add ability to force update transforms

### DIFF
--- a/src/plugin/configuration.rs
+++ b/src/plugin/configuration.rs
@@ -66,6 +66,8 @@ pub struct RapierConfiguration {
     /// discretized into a convex polyhedron, using `scaled_shape_subdivision` as the number of subdivisions
     /// along each spherical coordinates angle.
     pub scaled_shape_subdivision: u32,
+    /// Specifies if backend sync should always accept tranform changes, which may be from the writeback stage.
+    pub force_update_from_transform_changes: bool,
 }
 
 impl Default for RapierConfiguration {
@@ -83,6 +85,7 @@ impl Default for RapierConfiguration {
                 substeps: 1,
             },
             scaled_shape_subdivision: 10,
+            force_update_from_transform_changes: false,
         }
     }
 }

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -239,6 +239,7 @@ pub fn apply_collider_user_changes(
 /// System responsible for applying changes the user made to a rigid-body-related component.
 pub fn apply_rigid_body_user_changes(
     mut context: ResMut<RapierContext>,
+    config: Res<RapierConfiguration>,
     changed_rb_types: Query<(&RapierRigidBodyHandle, &RigidBody), Changed<RigidBody>>,
     mut changed_transforms: Query<
         (
@@ -301,7 +302,10 @@ pub fn apply_rigid_body_user_changes(
         |handle: &RigidBodyHandle,
          transform: &GlobalTransform,
          last_transform_set: &HashMap<RigidBodyHandle, GlobalTransform>| {
-            if let Some(prev) = last_transform_set.get(handle) {
+            if config.force_update_from_transform_changes {
+                true
+            }
+            else if let Some(prev) = last_transform_set.get(handle) {
                 *prev != *transform
             } else {
                 true

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -304,8 +304,7 @@ pub fn apply_rigid_body_user_changes(
          last_transform_set: &HashMap<RigidBodyHandle, GlobalTransform>| {
             if config.force_update_from_transform_changes {
                 true
-            }
-            else if let Some(prev) = last_transform_set.get(handle) {
+            } else if let Some(prev) = last_transform_set.get(handle) {
                 *prev != *transform
             } else {
                 true


### PR DESCRIPTION
This change allows for transform updates to always be applied.

In my physics simulation, I have a teleporting collider that is positioned based on user inputs.  This simulation exists in a rollback networking-based game, where every public property of `RapierContext` is restored from a previous serialization upon rollbacks.

This change solves an issue when an Player `A` teleports their object, which causes Player `B` rollback.  In `B`'s client, the data is rolled back in both the `Transform` and the `RapierContext`, but the `last_body_transform_set` is not since it is not public outside of the crate.  Since rollbacks re-simulate the inputs using the save state of the prior frame (e.g., before `A` teleported), the `Transform` for `A` is updated once again. When frames are re-simulated, the object `A` teleported is ignored on the resulting frame which causes a desync between the physics state of the two clients. 

I have implemented this as a configuration option because I find it useful to conditionally toggle it during rollbacks only.  This allows updates to only be forced during certain frame re-simulations rather than all the time.