### PR TITLE
Bevy dependency version less strict

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -29,7 +29,7 @@ serde-serialize = [ "rapier2d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { version = "0.8", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = "0.15.0"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -29,7 +29,7 @@ serde-serialize = [ "rapier3d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { version = "0.8", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = "0.15.0"


### PR DESCRIPTION
Following a discord discussion: 
https://discord.com/channels/691052431525675048/1029089408734990346

bevy did has a patch for 0.8.1, as bevy_rapier should be compatible with all 0.8.* bevy version, making this change would fix incompatibility versions.