### PR TITLE
Reset external impulse each step after applying

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -323,6 +323,11 @@ impl ExternalImpulse {
             torque_impulse: (point - center_of_mass).cross(impulse),
         }
     }
+
+    /// Reset the external impulses to zero.
+    pub fn reset(&mut self) {
+        *self = Default::default();
+    }
 }
 
 impl Add for ExternalImpulse {


### PR DESCRIPTION
Makes it more consistent with most usecases of impulses, also generally more ergonomic for having third party things hooking into the `ExternalImpulse` component, since they can just do `impulse.impulse += my_impulse`.