### PR TITLE
Add Character controller example to bevy_rapier3d.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   check-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check formatting
         run: cargo fmt -- --check
   test:
@@ -21,7 +21,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v1
     - run: sudo apt update && sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
     - name: Clippy for bevy_rapier2d
@@ -41,7 +41,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: rustup target add wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v1
       - name: Clippy bevy_rapier2d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.18.0 (30 Oct. 2022)
+### Added
+- Add the accessor `RapierContext::physics_scale()` to read the physics scale
+  that was set when initializing the plugin.
+- Add `RapierConfiguration::force_update_from_transform_changes` to force the transform
+  updates even if it is equal to the transform that was previously set. Useful for
+  rollback in networked applications described in [#261](https://github.com/dimforge/bevy_rapier/pull/261).
+- Add `Collider::trimesh_with_flags` to create a triangle mesh collider with custom pre-processing
+  flags.
+
+### Fix
+- Reset the `ExternalImpulse` component after each step automatically.
+- Fix `transform_to_iso` to preserve identical rotations instead of 
+  converting to an intermediate axis-angle representation.
+- Fix **internal edges** of 3D triangle meshes or 3D heightfields generating invalid contacts
+  preventing balls from moving straight. Be sure to set the triangle mesh flag
+  `TriMeshFlags::MERGE_DUPLICATE_VERTICES` when creating the collider if your mesh have duplicated
+  vertices.
+
+### Modified
+- Rename `AABB` to `Aabb` to comply with Rust’s style guide.
+
 ## 0.17.0 (02 Oct. 2022)
 ### Added
 - Add a **kinematic character controller** implementation. This feature is accessible in two different ways:

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = "0.15.0"
+rapier2d = "0.16.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", optional = true }
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = "0.15.0"
+rapier3d = "0.16.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", features = ["3d"], optional = true }
 log = "0.4"

--- a/bevy_rapier3d/examples/character_controller3.rs
+++ b/bevy_rapier3d/examples/character_controller3.rs
@@ -182,7 +182,7 @@ fn move_player(
             if output.grounded {
                 gravity = Vec3::ZERO;
             } else {
-                gravity = gravity + output.effective_translation.y;
+                gravity += output.effective_translation.y;
             }
         }
         controller.translation = Some((acceleration_direction + gravity) * time.delta_seconds());

--- a/bevy_rapier3d/examples/character_controller3.rs
+++ b/bevy_rapier3d/examples/character_controller3.rs
@@ -1,0 +1,190 @@
+use bevy::prelude::*;
+use bevy_rapier3d::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
+        .add_plugin(RapierDebugRenderPlugin::default())
+        .add_startup_system(setup_level)
+        .add_startup_system(spawn_player)
+        .add_system(move_player)
+        .run();
+}
+
+fn spawn_player(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let defaults = bevy_rapier3d::control::KinematicCharacterController::default();
+    commands
+        .spawn()
+        .insert_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Box::new(0.5, 1.8, 0.5))),
+            material: materials.add(Color::BLUE.into()),
+            ..default()
+        })
+        .insert(Collider::cylinder(0.9, 0.5))
+        .insert(RigidBody::KinematicVelocityBased)
+        .insert(KinematicCharacterController {
+            translation: Some(Vec3::ZERO),
+            custom_shape: None,
+            custom_mass: None,
+            up: Vec3::Y,
+            offset: CharacterLength::Absolute(0.12),
+            slide: false,
+            autostep: Some(CharacterAutostep {
+                max_height: CharacterLength::Absolute(0.2),
+                min_width: CharacterLength::Absolute(0.1),
+                include_dynamic_bodies: false,
+            }),
+            max_slope_climb_angle: 45.0_f32.to_radians(),
+            min_slope_slide_angle: defaults.min_slope_slide_angle,
+            apply_impulse_to_dynamic_bodies: false,
+            snap_to_ground: Some(CharacterLength::Absolute(0.12)),
+            filter_flags: QueryFilterFlags::empty(),
+            filter_groups: None,
+        })
+        .insert(Transform::from_xyz(0.0, 1.0, 0.0));
+}
+
+fn setup_level(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    commands.spawn_bundle(Camera3dBundle {
+        transform: Transform::from_xyz(0.0, 6., 12.0).looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
+        ..default()
+    });
+
+    commands.spawn_bundle(PointLightBundle {
+        point_light: PointLight {
+            intensity: 9000.0,
+            range: 100.,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(8.0, 16.0, 8.0),
+        ..default()
+    });
+
+    // ground
+    commands
+        .spawn()
+        .insert_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Box::new(20., 0.4, 20.0))),
+            material: materials.add(Color::RED.into()),
+            ..default()
+        })
+        .insert(Collider::cuboid(10., 0.2, 10.0))
+        .insert(RigidBody::Fixed)
+        .insert_bundle(SpatialBundle::from_transform(Transform::from_xyz(
+            0.0, -0.4, 0.0,
+        )));
+
+    commands
+        .spawn()
+        .insert_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Box::new(1.0, 1.0, 1.0))),
+            material: materials.add(Color::YELLOW.into()),
+            ..default()
+        })
+        .insert(Collider::cuboid(0.5, 0.5, 0.5))
+        .insert(RigidBody::Fixed)
+        .insert_bundle(SpatialBundle::from_transform(Transform::from_xyz(
+            5.0, 0.0, 3.0,
+        )));
+
+    commands
+        .spawn()
+        .insert_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Box::new(1.0, 1.0, 1.0))),
+            material: materials.add(Color::YELLOW.into()),
+            ..default()
+        })
+        .insert(Collider::cuboid(0.5, 0.5, 0.5))
+        .insert(RigidBody::Fixed)
+        .insert_bundle(SpatialBundle::from_transform(Transform::from_xyz(
+            -5.0, 0.5, 3.0,
+        )));
+
+    let mut transform = Transform {
+        translation: Vec3::new(-5.0, -0.5, -2.0),
+        rotation: Quat::from_rotation_z(45.0_f32.to_radians()),
+        ..default()
+    };
+    for _ in 0..=8 {
+        transform.translation += Vec3::new(1.0, 0.0, 0.0);
+        commands
+            .spawn()
+            .insert_bundle(PbrBundle {
+                mesh: meshes.add(Mesh::from(shape::Box::new(1.0, 1.0, 3.0))),
+                material: materials.add(Color::GREEN.into()),
+                ..default()
+            })
+            .insert(Collider::cuboid(0.5, 0.5, 1.5))
+            .insert(RigidBody::Fixed)
+            .insert_bundle(SpatialBundle::from_transform(transform));
+    }
+
+    let pos = Vec3::new(-5.0, -0.1, -8.0);
+    let mut transform = Transform::from_xyz(0.0, 0.0, 0.0);
+    for i in 0..=10 {
+        transform.translation = pos + (Vec3::new(1.0, 0.15, 0.0) * i as f32);
+        commands
+            .spawn()
+            .insert_bundle(PbrBundle {
+                mesh: meshes.add(Mesh::from(shape::Box::new(1.0, 0.2, 3.0))),
+                material: materials.add(Color::GREEN.into()),
+                ..default()
+            })
+            .insert(Collider::cuboid(0.5, 0.1, 1.5))
+            .insert(RigidBody::Fixed)
+            .insert_bundle(SpatialBundle::from_transform(transform));
+    }
+
+    commands
+        .spawn()
+        .insert_bundle(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::UVSphere {
+                radius: 1.0,
+                sectors: 32,
+                stacks: 4,
+            })),
+            material: materials.add(Color::GREEN.into()),
+            ..default()
+        })
+        .insert(Collider::ball(1.0))
+        .insert(RigidBody::Fixed)
+        .insert(Transform::from_xyz(0.0, -0.7, -6.0));
+}
+
+fn move_player(
+    time: Res<Time>,
+    input: Res<Input<KeyCode>>,
+    mut controller_query: Query<(
+        &mut KinematicCharacterController,
+        Option<&KinematicCharacterControllerOutput>,
+    )>,
+) {
+    let mut gravity = Vec3::Y * -9.82;
+    let acceleration_direction = Vec3::new(
+        (input.pressed(KeyCode::D) as i8 - input.pressed(KeyCode::A) as i8) as f32,
+        0.0,
+        (input.pressed(KeyCode::S) as i8 - input.pressed(KeyCode::W) as i8) as f32,
+    )
+    .normalize_or_zero()
+        * 9.0;
+    for (mut controller, optional_output) in controller_query.iter_mut() {
+        if let Some(output) = optional_output {
+            if output.grounded {
+                gravity = Vec3::ZERO;
+            } else {
+                gravity = gravity + output.effective_translation.y;
+            }
+        }
+        controller.translation = Some((acceleration_direction + gravity) * time.delta_seconds());
+    }
+}

--- a/bevy_rapier3d/examples/character_controller3.rs
+++ b/bevy_rapier3d/examples/character_controller3.rs
@@ -21,29 +21,28 @@ fn spawn_player(
     commands
         .spawn()
         .insert_bundle(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Box::new(0.5, 1.8, 0.5))),
+            mesh: meshes.add(Mesh::from(shape::Capsule::default())),
             material: materials.add(Color::BLUE.into()),
             ..default()
         })
-        .insert(Collider::cylinder(0.9, 0.5))
-        //.insert(Collider::capsule_y(0.5, 0.5))
+        .insert(Collider::capsule_y(0.5, 0.5))
         .insert(RigidBody::KinematicVelocityBased)
         .insert(KinematicCharacterController {
             translation: Some(Vec3::ZERO),
             custom_shape: None,
             custom_mass: None,
             up: Vec3::Y,
-            offset: CharacterLength::Absolute(0.12),
-            slide: false,
+            offset: defaults.offset,
+            slide: defaults.slide,
             autostep: Some(CharacterAutostep {
-                max_height: CharacterLength::Absolute(0.2),
-                min_width: CharacterLength::Absolute(0.1),
-                include_dynamic_bodies: false,
+                max_height: CharacterLength::Relative(0.25),
+                min_width: CharacterLength::Relative(0.5),
+                include_dynamic_bodies: true,
             }),
-            max_slope_climb_angle: 45.0_f32.to_radians(),
-            min_slope_slide_angle: defaults.min_slope_slide_angle,
+            max_slope_climb_angle: 33.0_f32.to_radians(),
+            min_slope_slide_angle: 33.0_f32.to_radians(),
             apply_impulse_to_dynamic_bodies: false,
-            snap_to_ground: Some(CharacterLength::Absolute(0.12)),
+            snap_to_ground: defaults.snap_to_ground,
             filter_flags: QueryFilterFlags::empty(),
             filter_groups: None,
         })
@@ -112,20 +111,20 @@ fn setup_level(
         )));
 
     let mut transform = Transform {
-        translation: Vec3::new(-8.0, -0.5, -2.0),
-        rotation: Quat::from_rotation_z(45.0_f32.to_radians()),
+        translation: Vec3::new(-12.0, -1.5, -3.0),
+        rotation: Quat::from_rotation_z(33.0_f32.to_radians()),
         ..default()
     };
-    for _ in 0..=6 {
-        transform.translation += Vec3::new(2.0, 0.0, 0.0);
+    for _ in 0..=2 {
+        transform.translation += Vec3::new(6.0, 0.0, 0.0);
         commands
             .spawn()
             .insert_bundle(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Box::new(1.0, 1.0, 3.0))),
+                mesh: meshes.add(Mesh::from(shape::Box::new(3.0, 3.0, 3.0))),
                 material: materials.add(Color::GREEN.into()),
                 ..default()
             })
-            .insert(Collider::cuboid(0.5, 0.5, 1.5))
+            .insert(Collider::cuboid(1.5, 1.5, 1.5))
             .insert(RigidBody::Fixed)
             .insert_bundle(SpatialBundle::from_transform(transform));
     }

--- a/bevy_rapier3d/examples/character_controller3.rs
+++ b/bevy_rapier3d/examples/character_controller3.rs
@@ -26,6 +26,7 @@ fn spawn_player(
             ..default()
         })
         .insert(Collider::cylinder(0.9, 0.5))
+        //.insert(Collider::capsule_y(0.5, 0.5))
         .insert(RigidBody::KinematicVelocityBased)
         .insert(KinematicCharacterController {
             translation: Some(Vec3::ZERO),
@@ -111,12 +112,12 @@ fn setup_level(
         )));
 
     let mut transform = Transform {
-        translation: Vec3::new(-5.0, -0.5, -2.0),
+        translation: Vec3::new(-8.0, -0.5, -2.0),
         rotation: Quat::from_rotation_z(45.0_f32.to_radians()),
         ..default()
     };
-    for _ in 0..=8 {
-        transform.translation += Vec3::new(1.0, 0.0, 0.0);
+    for _ in 0..=6 {
+        transform.translation += Vec3::new(2.0, 0.0, 0.0);
         commands
             .spawn()
             .insert_bundle(PbrBundle {

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -323,6 +323,11 @@ impl ExternalImpulse {
             torque_impulse: (point - center_of_mass).cross(impulse),
         }
     }
+
+    /// Reset the external impulses to zero.
+    pub fn reset(&mut self) {
+        *self = Default::default();
+    }
 }
 
 impl Add for ExternalImpulse {

--- a/src/plugin/configuration.rs
+++ b/src/plugin/configuration.rs
@@ -66,6 +66,8 @@ pub struct RapierConfiguration {
     /// discretized into a convex polyhedron, using `scaled_shape_subdivision` as the number of subdivisions
     /// along each spherical coordinates angle.
     pub scaled_shape_subdivision: u32,
+    /// Specifies if backend sync should always accept tranform changes, which may be from the writeback stage.
+    pub force_update_from_transform_changes: bool,
 }
 
 impl Default for RapierConfiguration {
@@ -83,6 +85,7 @@ impl Default for RapierConfiguration {
                 substeps: 1,
             },
             scaled_shape_subdivision: 10,
+            force_update_from_transform_changes: false,
         }
     }
 }

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -103,6 +103,13 @@ impl Default for RapierContext {
 }
 
 impl RapierContext {
+    /// Get the physics scale that was set for this Rapier context.
+    ///
+    /// See [`RapierPhysicsPlugin::with_physics_scale()`][crate::plugin::RapierPhysicsPlugin::with_physics_scale()].
+    pub fn physics_scale(&self) -> Real {
+        self.physics_scale
+    }
+
     /// If the collider attached to `entity` is attached to a rigid-body, this
     /// returns the `Entity` containing that rigid-body.
     pub fn collider_parent(&self, entity: Entity) -> Option<Entity> {

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -3,11 +3,10 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use rapier::prelude::{
-    BroadPhase, CCDSolver, ColliderHandle, ColliderSet, EventHandler, FeatureId,
-    ImpulseJointHandle, ImpulseJointSet, IntegrationParameters, IslandManager,
+    Aabb as RapierAabb, BroadPhase, CCDSolver, ColliderHandle, ColliderSet, EventHandler,
+    FeatureId, ImpulseJointHandle, ImpulseJointSet, IntegrationParameters, IslandManager,
     MultibodyJointHandle, MultibodyJointSet, NarrowPhase, PhysicsHooks, PhysicsPipeline,
     QueryFilter as RapierQueryFilter, QueryPipeline, Ray, Real, RigidBodyHandle, RigidBodySet,
-    AABB,
 };
 
 use crate::geometry::{Collider, PointProjection, RayIntersection, Toi};
@@ -708,19 +707,19 @@ impl RapierContext {
         })
     }
 
-    /// Finds all entities of all the colliders with an AABB intersecting the given AABB.
+    /// Finds all entities of all the colliders with an Aabb intersecting the given Aabb.
     pub fn colliders_with_aabb_intersecting_aabb(
         &self,
         aabb: Aabb,
         mut callback: impl FnMut(Entity) -> bool,
     ) {
         #[cfg(feature = "dim2")]
-        let scaled_aabb = AABB {
+        let scaled_aabb = RapierAabb {
             mins: (aabb.min().xy() / self.physics_scale).into(),
             maxs: (aabb.max().xy() / self.physics_scale).into(),
         };
         #[cfg(feature = "dim3")]
-        let scaled_aabb = AABB {
+        let scaled_aabb = RapierAabb {
             mins: (aabb.min() / self.physics_scale).into(),
             maxs: (aabb.max() / self.physics_scale).into(),
         };

--- a/src/plugin/narrow_phase.rs
+++ b/src/plugin/narrow_phase.rs
@@ -222,12 +222,12 @@ impl<'a> ContactView<'a> {
 
     /// The feature ID of the first shape involved in the contact.
     pub fn fid1(&self) -> u32 {
-        self.raw.fid1
+        self.raw.fid1.0
     }
 
     /// The feature ID of the second shape involved in the contact.
     pub fn fid2(&self) -> u32 {
-        self.raw.fid2
+        self.raw.fid2.0
     }
 
     /// The impulse, along the contact normal, applied by this contact to the first collider's rigid-body.

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -239,6 +239,7 @@ pub fn apply_collider_user_changes(
 /// System responsible for applying changes the user made to a rigid-body-related component.
 pub fn apply_rigid_body_user_changes(
     mut context: ResMut<RapierContext>,
+    config: Res<RapierConfiguration>,
     changed_rb_types: Query<(&RapierRigidBodyHandle, &RigidBody), Changed<RigidBody>>,
     mut changed_transforms: Query<
         (
@@ -304,7 +305,9 @@ pub fn apply_rigid_body_user_changes(
         |handle: &RigidBodyHandle,
          transform: &GlobalTransform,
          last_transform_set: &HashMap<RigidBodyHandle, GlobalTransform>| {
-            if let Some(prev) = last_transform_set.get(handle) {
+            if config.force_update_from_transform_changes {
+                true
+            } else if let Some(prev) = last_transform_set.get(handle) {
                 *prev != *transform
             } else {
                 true

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -42,8 +42,27 @@ pub(crate) fn transform_to_iso(transform: &Transform, physics_scale: Real) -> Is
 /// The translation is divided by the `physics_scale`.
 #[cfg(feature = "dim3")]
 pub(crate) fn transform_to_iso(transform: &Transform, physics_scale: Real) -> Isometry<Real> {
-    Isometry::new(
+    Isometry::from_parts(
         (transform.translation / physics_scale).into(),
-        transform.rotation.to_scaled_axis().into(),
+        transform.rotation.into(),
     )
+}
+
+#[cfg(test)]
+#[cfg(feature = "dim3")]
+mod tests {
+    use super::*;
+    use bevy::prelude::Transform;
+
+    #[test]
+    fn convert_back_to_equal_transform() {
+        let transform = Transform {
+            translation: bevy::prelude::Vec3::new(-2.1855694e-8, 0.0, 0.0),
+            rotation: bevy::prelude::Quat::from_xyzw(0.99999994, 0.0, 1.6292068e-7, 0.0)
+                .normalize(),
+            ..Default::default()
+        };
+        let converted_transform = iso_to_transform(&transform_to_iso(&transform, 1.0), 1.0);
+        assert_eq!(converted_transform, transform);
+    }
 }


### PR DESCRIPTION
Adds an example for how to use the newly implemented KinematicCharacterController.