### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.18.0 (30 Oct. 2022)
+### Added
+- Add the accessor `RapierContext::physics_scale()` to read the physics scale
+  that was set when initializing the plugin.
+- Add `RapierConfiguration::force_update_from_transform_changes` to force the transform
+  updates even if it is equal to the transform that was previously set. Useful for
+  rollback in networked applications described in [#261](https://github.com/dimforge/bevy_rapier/pull/261).
+- Add `Collider::trimesh_with_flags` to create a triangle mesh collider with custom pre-processing
+  flags.
+
+### Fix
+- Reset the `ExternalImpulse` component after each step automatically.
+- Fix `transform_to_iso` to preserve identical rotations instead of 
+  converting to an intermediate axis-angle representation.
+- Fix **internal edges** of 3D triangle meshes or 3D heightfields generating invalid contacts
+  preventing balls from moving straight. Be sure to set the triangle mesh flag
+  `TriMeshFlags::MERGE_DUPLICATE_VERTICES` when creating the collider if your mesh have duplicated
+  vertices.
+
+### Modified
+- Rename `AABB` to `Aabb` to comply with Rust’s style guide.
+
 ## 0.17.0 (02 Oct. 2022)
 ### Added
 - Add a **kinematic character controller** implementation. This feature is accessible in two different ways:

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = "0.15.0"
+rapier2d = "0.16.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", optional = true }
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
@@ -32,7 +32,7 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = "0.15.0"
+rapier3d = "0.16.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", features = ["3d"], optional = true }
 log = "0.4"

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -3,11 +3,10 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use rapier::prelude::{
-    BroadPhase, CCDSolver, ColliderHandle, ColliderSet, EventHandler, FeatureId,
-    ImpulseJointHandle, ImpulseJointSet, IntegrationParameters, IslandManager,
+    Aabb as RapierAabb, BroadPhase, CCDSolver, ColliderHandle, ColliderSet, EventHandler,
+    FeatureId, ImpulseJointHandle, ImpulseJointSet, IntegrationParameters, IslandManager,
     MultibodyJointHandle, MultibodyJointSet, NarrowPhase, PhysicsHooks, PhysicsPipeline,
     QueryFilter as RapierQueryFilter, QueryPipeline, Ray, Real, RigidBodyHandle, RigidBodySet,
-    AABB,
 };
 
 use crate::geometry::{Collider, PointProjection, RayIntersection, Toi};
@@ -708,19 +707,19 @@ impl RapierContext {
         })
     }
 
-    /// Finds all entities of all the colliders with an AABB intersecting the given AABB.
+    /// Finds all entities of all the colliders with an Aabb intersecting the given Aabb.
     pub fn colliders_with_aabb_intersecting_aabb(
         &self,
         aabb: Aabb,
         mut callback: impl FnMut(Entity) -> bool,
     ) {
         #[cfg(feature = "dim2")]
-        let scaled_aabb = AABB {
+        let scaled_aabb = RapierAabb {
             mins: (aabb.min().xy() / self.physics_scale).into(),
             maxs: (aabb.max().xy() / self.physics_scale).into(),
         };
         #[cfg(feature = "dim3")]
-        let scaled_aabb = AABB {
+        let scaled_aabb = RapierAabb {
             mins: (aabb.min() / self.physics_scale).into(),
             maxs: (aabb.max() / self.physics_scale).into(),
         };

--- a/src/plugin/narrow_phase.rs
+++ b/src/plugin/narrow_phase.rs
@@ -222,12 +222,12 @@ impl<'a> ContactView<'a> {
 
     /// The feature ID of the first shape involved in the contact.
     pub fn fid1(&self) -> u32 {
-        self.raw.fid1
+        self.raw.fid1.0
     }
 
     /// The feature ID of the second shape involved in the contact.
     pub fn fid2(&self) -> u32 {
-        self.raw.fid2
+        self.raw.fid2.0
     }
 
     /// The impulse, along the contact normal, applied by this contact to the first collider's rigid-body.


### PR DESCRIPTION
### Added
- Add the accessor `RapierContext::physics_scale()` to read the physics scale
  that was set when initializing the plugin.
- Add `RapierConfiguration::force_update_from_transform_changes` to force the transform
  updates even if it is equal to the transform that was previously set. Useful for
  rollback in networked applications described in [#261](https://github.com/dimforge/bevy_rapier/pull/261).
- Add `Collider::trimesh_with_flags` to create a triangle mesh collider with custom pre-processing
  flags.

### Fix
- Reset the `ExternalImpulse` component after each step automatically.
- Fix `transform_to_iso` to preserve identical rotations instead of 
  converting to an intermediate axis-angle representation.
- Fix **internal edges** of 3D triangle meshes or 3D heightfields generating invalid contacts
  preventing balls from moving straight. Be sure to set the triangle mesh flag
  `TriMeshFlags::MERGE_DUPLICATE_VERTICES` when creating the collider if your mesh have duplicated
  vertices.

### Modified
- Rename `AABB` to `Aabb` to comply with Rust’s style guide.