### PR TITLE
Update to Bevy 0.9

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -30,7 +30,7 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.9.0-dev", default-features = false, features = ["bevy_asset", "bevy_scene"] }
-nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
+nalgebra = { version = "^0.31.1", features = [ "convert-glam022" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = "0.16.0"
 bitflags = "1"
@@ -42,7 +42,7 @@ serde = { version = "1", features = [ "derive" ], optional = true}
 bevy = { version = "0.9.0-dev", default-features = false, features = ["x11"]}
 oorandom = "11"
 approx = "0.5.1"
-glam = { version = "0.21", features = [ "approx" ] }
+glam = { version = "0.22", features = [ "approx" ] }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -30,7 +30,7 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
-nalgebra = { version = "^0.31.1", features = [ "convert-glam022" ] }
+nalgebra = { version = "^0.31.4", features = [ "convert-glam022" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = "0.16.0"
 bitflags = "1"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -29,7 +29,7 @@ serde-serialize = [ "rapier2d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.9.0-dev", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam022" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = "0.16.0"
@@ -39,7 +39,7 @@ log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
-bevy = { version = "0.9.0-dev", default-features = false, features = ["x11"]}
+bevy = { version = "0.9.0", default-features = false, features = ["x11"]}
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.22", features = [ "approx" ] }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -29,7 +29,7 @@ serde-serialize = [ "rapier2d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { version = "0.9.0-dev", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = "0.16.0"
@@ -39,7 +39,7 @@ log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
-bevy = { version = "0.8", default-features = false, features = ["x11"]}
+bevy = { version = "0.9.0-dev", default-features = false, features = ["x11"]}
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.21", features = [ "approx" ] }

--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -18,7 +17,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle {
+    commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, 20.0, 0.0),
         ..default()
     });
@@ -31,13 +30,10 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 500.0;
     let ground_height = 10.0;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            0.0 * -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 0.0 * -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height),
+    ));
 
     /*
      * Create the cubes
@@ -56,10 +52,11 @@ pub fn setup_physics(mut commands: Commands) {
             let x = i as f32 * shift - centerx + offset;
             let y = j as f32 * shift + centery + 30.0;
 
-            commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, 0.0)))
-                .insert(RigidBody::Dynamic)
-                .insert(Collider::cuboid(rad, rad));
+            commands.spawn((
+                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                RigidBody::Dynamic,
+                Collider::cuboid(rad, rad),
+            ));
         }
 
         offset -= 0.05 * rad * (num as f32 - 1.0);

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -35,7 +35,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<&CustomFilterTag>::pixels_per_meter(
             100.0,
@@ -47,7 +46,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle {
+    commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, 20.0, 0.0),
         ..default()
     });
@@ -63,15 +62,17 @@ pub fn setup_physics(mut commands: Commands) {
 
     let ground_size = 100.0;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, -100.0, 0.0)))
-        .insert(Collider::cuboid(ground_size, 12.0))
-        .insert(CustomFilterTag::GroupA);
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -100.0, 0.0)),
+        Collider::cuboid(ground_size, 12.0),
+        CustomFilterTag::GroupA,
+    ));
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)))
-        .insert(Collider::cuboid(ground_size, 12.0))
-        .insert(CustomFilterTag::GroupB);
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
+        Collider::cuboid(ground_size, 12.0),
+        CustomFilterTag::GroupB,
+    ));
 
     /*
      * Create the cubes
@@ -92,13 +93,14 @@ pub fn setup_physics(mut commands: Commands) {
             let y = j as f32 * shift + centery + 20.0;
             group_id += 1;
 
-            commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, 0.0)))
-                .insert(RigidBody::Dynamic)
-                .insert(Collider::cuboid(rad, rad))
-                .insert(ActiveHooks::FILTER_CONTACT_PAIRS)
-                .insert(tags[group_id % 2])
-                .insert(ColliderDebugColor(colors[group_id % 2]));
+            commands.spawn((
+                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                RigidBody::Dynamic,
+                Collider::cuboid(rad, rad),
+                ActiveHooks::FILTER_CONTACT_PAIRS,
+                tags[group_id % 2],
+                ColliderDebugColor(colors[group_id % 2]),
+            ));
         }
     }
 }

--- a/bevy_rapier2d/examples/custom_system_setup2.rs
+++ b/bevy_rapier2d/examples/custom_system_setup2.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{core::FrameCount, prelude::*};
 use bevy_rapier2d::prelude::*;
 
 struct SpecialStagingPlugin {
@@ -37,8 +37,6 @@ impl Stage for SpecialStage {
     }
 }
 
-struct FrameCount(u32);
-
 fn main() {
     let mut app = App::new();
 
@@ -47,8 +45,6 @@ fn main() {
         0xF9 as f32 / 255.0,
         0xFF as f32 / 255.0,
     )))
-    .insert_resource(Msaa::default())
-    .insert_resource(FrameCount(0))
     .add_plugins(DefaultPlugins)
     .add_plugin(RapierDebugRenderPlugin::default())
     .add_startup_system(setup_graphics)
@@ -123,7 +119,7 @@ fn despawn_one_box(
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle {
+    commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, 20.0, 0.0),
         ..default()
     });
@@ -136,13 +132,10 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 500.0;
     let ground_height = 10.0;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            0.0 * -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 0.0 * -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height),
+    ));
 
     /*
      * Create the cubes
@@ -161,10 +154,11 @@ pub fn setup_physics(mut commands: Commands) {
             let x = i as f32 * shift - centerx + offset;
             let y = j as f32 * shift + centery + 30.0;
 
-            commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, 0.0)))
-                .insert(RigidBody::Dynamic)
-                .insert(Collider::cuboid(rad, rad));
+            commands.spawn((
+                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                RigidBody::Dynamic,
+                Collider::cuboid(rad, rad),
+            ));
         }
 
         offset -= 0.05 * rad * (num as f32 - 1.0);

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -90,7 +90,7 @@ fn setup_game(mut commands: Commands, mut game: ResMut<Game>) {
 
     commands.spawn(Camera2dBundle::default());
 
-    setup_board(&mut commands, &*game);
+    setup_board(&mut commands, &game);
 
     // initial cube
     spawn_cube(&mut commands, &mut game);

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -9,7 +9,6 @@ fn main() {
     App::new()
         .init_resource::<Game>()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup_game)
         .add_system(cube_sleep_detection)
@@ -44,6 +43,7 @@ impl Stats {
     }
 }
 
+#[derive(Resource)]
 struct Game {
     n_lanes: usize,
     n_rows: usize,
@@ -88,7 +88,7 @@ fn setup_game(mut commands: Commands, mut game: ResMut<Game>) {
         byte_rgb(255, 0, 0),
     ];
 
-    commands.spawn().insert_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 
     setup_board(&mut commands, &*game);
 
@@ -126,8 +126,8 @@ fn setup_board(commands: &mut Commands, game: &Game) {
     let floor_y = game.floor_y();
 
     // Add floor
-    commands
-        .spawn_bundle(SpriteBundle {
+    commands.spawn((
+        SpriteBundle {
             sprite: Sprite {
                 color: Color::rgb(0.5, 0.5, 0.5),
                 custom_size: Some(Vec2::new(game.n_lanes as f32 * 30.0, 60.0)),
@@ -135,12 +135,10 @@ fn setup_board(commands: &mut Commands, game: &Game) {
             },
             transform: Transform::from_xyz(0.0, floor_y - 30.0 * 0.5, 0.0),
             ..Default::default()
-        })
-        .insert(RigidBody::Fixed)
-        .insert(Collider::cuboid(
-            game.n_lanes as f32 * 30.0 / 2.0,
-            60.0 / 2.0,
-        ));
+        },
+        RigidBody::Fixed,
+        Collider::cuboid(game.n_lanes as f32 * 30.0 / 2.0, 60.0 / 2.0),
+    ));
 }
 
 fn spawn_cube(commands: &mut Commands, game: &mut Game) {
@@ -168,8 +166,7 @@ fn spawn_cube(commands: &mut Commands, game: &mut Game) {
             .entity(block_entities[*j])
             .with_children(|children| {
                 let id = children
-                    .spawn()
-                    .insert(ImpulseJoint::new(
+                    .spawn(ImpulseJoint::new(
                         block_entities[*i],
                         RevoluteJointBuilder::new()
                             .local_anchor1(anchor_1)
@@ -199,22 +196,24 @@ fn spawn_block(
     let linear_damping = 3.0;
 
     commands
-        .spawn_bundle(SpriteBundle {
-            sprite: Sprite {
-                color: game.cube_colors[kind as usize],
-                custom_size: Some(Vec2::new(30.0, 30.0)),
+        .spawn((
+            SpriteBundle {
+                sprite: Sprite {
+                    color: game.cube_colors[kind as usize],
+                    custom_size: Some(Vec2::new(30.0, 30.0)),
+                    ..Default::default()
+                },
+                transform: Transform::from_xyz(x, y, 0.0),
                 ..Default::default()
             },
-            transform: Transform::from_xyz(x, y, 0.0),
-            ..Default::default()
-        })
-        .insert(RigidBody::Dynamic)
-        .insert(Damping {
-            linear_damping,
-            angular_damping: 0.0,
-        })
-        .insert(Collider::cuboid(30.0 / 2.0, 30.0 / 2.0))
-        .insert(Block)
+            RigidBody::Dynamic,
+            Damping {
+                linear_damping,
+                angular_damping: 0.0,
+            },
+            Collider::cuboid(30.0 / 2.0, 30.0 / 2.0),
+            Block,
+        ))
         .id()
 }
 

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -1,12 +1,12 @@
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
-#[derive(Default)]
+#[derive(Resource, Default)]
 pub struct DespawnResource {
     pub entities: Vec<Entity>,
 }
 
-#[derive(Default)]
+#[derive(Resource, Default)]
 pub struct ResizeResource {
     pub entities: Vec<Entity>,
 }
@@ -18,7 +18,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .insert_resource(DespawnResource::default())
         .insert_resource(ResizeResource::default())
         .add_plugins(DefaultPlugins)
@@ -32,7 +31,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle {
+    commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, 20.0, 0.0),
         ..default()
     });
@@ -48,27 +47,18 @@ pub fn setup_physics(
      */
     let ground_size = 250.0;
 
-    let entity = commands
-        .spawn()
-        .insert(Collider::cuboid(ground_size, 12.0))
-        .id();
+    let entity = commands.spawn(Collider::cuboid(ground_size, 12.0)).id();
     despawn.entities.push(entity);
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            ground_size,
-            ground_size * 2.0,
-            0.0,
-        )))
-        .insert(Collider::cuboid(12.0, ground_size * 2.0));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(ground_size, ground_size * 2.0, 0.0)),
+        Collider::cuboid(12.0, ground_size * 2.0),
+    ));
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            -ground_size,
-            ground_size * 2.0,
-            0.0,
-        )))
-        .insert(Collider::cuboid(12.0, ground_size * 2.0));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(-ground_size, ground_size * 2.0, 0.0)),
+        Collider::cuboid(12.0, ground_size * 2.0),
+    ));
 
     /*
      * Create the cubes
@@ -86,9 +76,11 @@ pub fn setup_physics(
             let y = j as f32 * shift + centery + 2.0;
 
             let entity = commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, 0.0)))
-                .insert(RigidBody::Dynamic)
-                .insert(Collider::cuboid(rad, rad))
+                .spawn((
+                    TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                    RigidBody::Dynamic,
+                    Collider::cuboid(rad, rad),
+                ))
                 .id();
 
             if (i + j * num) % 100 == 0 {
@@ -99,7 +91,7 @@ pub fn setup_physics(
 }
 
 pub fn despawn(mut commands: Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
-    if time.seconds_since_startup() > 5.0 {
+    if time.elapsed_seconds() > 5.0 {
         for entity in &despawn.entities {
             println!("Despawning ground entity");
             commands.entity(*entity).despawn();
@@ -109,7 +101,7 @@ pub fn despawn(mut commands: Commands, time: Res<Time>, mut despawn: ResMut<Desp
 }
 
 pub fn resize(mut commands: Commands, time: Res<Time>, mut resize: ResMut<ResizeResource>) {
-    if time.seconds_since_startup() > 6.0 {
+    if time.elapsed_seconds() > 6.0 {
         for entity in &resize.entities {
             println!("Resizing a block");
             commands

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -19,7 +18,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 }
 
 fn display_events(
@@ -39,19 +38,22 @@ pub fn setup_physics(mut commands: Commands) {
     /*
      * Ground
      */
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, -24.0, 0.0)))
-        .insert(Collider::cuboid(80.0, 20.0));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -24.0, 0.0)),
+        Collider::cuboid(80.0, 20.0),
+    ));
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 100.0, 0.0)))
-        .insert(Collider::cuboid(80.0, 30.0))
-        .insert(Sensor);
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 100.0, 0.0)),
+        Collider::cuboid(80.0, 30.0),
+        Sensor,
+    ));
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 260.0, 0.0)))
-        .insert(RigidBody::Dynamic)
-        .insert(Collider::cuboid(10.0, 10.0))
-        .insert(ActiveEvents::COLLISION_EVENTS)
-        .insert(ContactForceEventThreshold(10.0));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 260.0, 0.0)),
+        RigidBody::Dynamic,
+        Collider::cuboid(10.0, 10.0),
+        ActiveEvents::COLLISION_EVENTS,
+        ContactForceEventThreshold(10.0),
+    ));
 }

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -18,7 +17,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle {
+    commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, -200.0, 0.0),
         ..default()
     });
@@ -45,13 +44,11 @@ pub fn setup_physics(mut commands: Commands) {
             };
 
             let child_entity = commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-                    fk * shift,
-                    -fi * shift,
-                    0.0,
-                )))
-                .insert(rigid_body)
-                .insert(Collider::cuboid(rad, rad))
+                .spawn((
+                    TransformBundle::from(Transform::from_xyz(fk * shift, -fi * shift, 0.0)),
+                    rigid_body,
+                    Collider::cuboid(rad, rad),
+                ))
                 .id();
 
             // Vertical joint.
@@ -62,7 +59,7 @@ pub fn setup_physics(mut commands: Commands) {
                     // NOTE: we want to attach multiple impulse joints to this entity, so
                     //       we need to add the components to children of the entity. Otherwise
                     //       the second joint component would just overwrite the first one.
-                    cmd.spawn().insert(ImpulseJoint::new(parent_entity, joint));
+                    cmd.spawn(ImpulseJoint::new(parent_entity, joint));
                 });
             }
 
@@ -75,7 +72,7 @@ pub fn setup_physics(mut commands: Commands) {
                     // NOTE: we want to attach multiple impulse joints to this entity, so
                     //       we need to add the components to children of the entity. Otherwise
                     //       the second joint component would just overwrite the first one.
-                    cmd.spawn().insert(ImpulseJoint::new(parent_entity, joint));
+                    cmd.spawn(ImpulseJoint::new(parent_entity, joint));
                 });
             }
 

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -18,7 +17,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle {
+    commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, 200.0, 0.0),
         ..default()
     });
@@ -31,31 +30,30 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 500.0;
     let ground_height = 10.0;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height),
+    ));
 
     /*
      * A rectangle that only rotate.
      */
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 300.0, 0.0)))
-        .insert(RigidBody::Dynamic)
-        .insert(LockedAxes::TRANSLATION_LOCKED)
-        .insert(Collider::cuboid(200.0, 60.0));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 300.0, 0.0)),
+        RigidBody::Dynamic,
+        LockedAxes::TRANSLATION_LOCKED,
+        Collider::cuboid(200.0, 60.0),
+    ));
 
     /*
      * A tilted cuboid that cannot rotate.
      */
-    commands
-        .spawn_bundle(TransformBundle::from(
+    commands.spawn((
+        TransformBundle::from(
             Transform::from_xyz(50.0, 500.0, 0.0).with_rotation(Quat::from_rotation_z(1.0)),
-        ))
-        .insert(RigidBody::Dynamic)
-        .insert(LockedAxes::ROTATION_LOCKED)
-        .insert(Collider::cuboid(60.0, 40.0));
+        ),
+        RigidBody::Dynamic,
+        LockedAxes::ROTATION_LOCKED,
+        Collider::cuboid(60.0, 40.0),
+    ));
 }

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -18,7 +17,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -28,13 +27,10 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 500.0;
     let ground_height = 1.0;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height),
+    ));
 
     /*
      * Create the cubes
@@ -54,24 +50,20 @@ pub fn setup_physics(mut commands: Commands) {
             let y = j as f32 * (shift * 5.0) + centery + 3.0;
 
             commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, 0.0)))
-                .insert(RigidBody::Dynamic)
+                .spawn((
+                    TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                    RigidBody::Dynamic,
+                ))
                 .with_children(|children| {
-                    children.spawn().insert(Collider::cuboid(rad * 10.0, rad));
-                    children
-                        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-                            rad * 10.0,
-                            rad * 10.0,
-                            0.0,
-                        )))
-                        .insert(Collider::cuboid(rad, rad * 10.0));
-                    children
-                        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-                            -rad * 10.0,
-                            rad * 10.0,
-                            0.0,
-                        )))
-                        .insert(Collider::cuboid(rad, rad * 10.0));
+                    children.spawn(Collider::cuboid(rad * 10.0, rad));
+                    children.spawn((
+                        TransformBundle::from(Transform::from_xyz(rad * 10.0, rad * 10.0, 0.0)),
+                        Collider::cuboid(rad, rad * 10.0),
+                    ));
+                    children.spawn((
+                        TransformBundle::from(Transform::from_xyz(-rad * 10.0, rad * 10.0, 0.0)),
+                        Collider::cuboid(rad, rad * 10.0),
+                    ));
                 });
         }
 

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -3,13 +3,15 @@ use bevy_rapier2d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
-            title: "Player Movement Example".to_string(),
-            width: 1000.0,
-            height: 1000.0,
-            ..Default::default()
-        })
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                title: "Player Movement Example".to_string(),
+                width: 1000.0,
+                height: 1000.0,
+                ..Default::default()
+            },
+            ..default()
+        }))
         .add_startup_system(spawn_player)
         .add_system(player_movement)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
@@ -24,36 +26,36 @@ struct Player(f32);
 fn spawn_player(mut commands: Commands, mut rapier_config: ResMut<RapierConfiguration>) {
     // Set gravity to 0.0 and spawn camera.
     rapier_config.gravity = Vec2::ZERO;
-    commands.spawn().insert_bundle(Camera2dBundle::default());
+    commands.spawn(Camera2dBundle::default());
 
     let sprite_size = 100.0;
 
     // Spawn entity with `Player` struct as a component for access in movement query.
-    commands
-        .spawn()
-        .insert_bundle(SpriteBundle {
+    commands.spawn((
+        SpriteBundle {
             sprite: Sprite {
                 color: Color::rgb(0.0, 0.0, 0.0),
                 custom_size: Some(Vec2::new(sprite_size, sprite_size)),
                 ..Default::default()
             },
             ..Default::default()
-        })
-        .insert(RigidBody::Dynamic)
-        .insert(Velocity::zero())
-        .insert(Collider::ball(sprite_size / 2.0))
-        .insert(Player(100.0));
+        },
+        RigidBody::Dynamic,
+        Velocity::zero(),
+        Collider::ball(sprite_size / 2.0),
+        Player(100.0),
+    ));
 }
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
     mut player_info: Query<(&Player, &mut Velocity)>,
 ) {
-    for (player, mut rb_vels) in player_info.iter_mut() {
-        let up = keyboard_input.pressed(KeyCode::W) || keyboard_input.pressed(KeyCode::Up);
-        let down = keyboard_input.pressed(KeyCode::S) || keyboard_input.pressed(KeyCode::Down);
-        let left = keyboard_input.pressed(KeyCode::A) || keyboard_input.pressed(KeyCode::Left);
-        let right = keyboard_input.pressed(KeyCode::D) || keyboard_input.pressed(KeyCode::Right);
+    for (player, mut rb_vels) in &mut player_info {
+        let up = keyboard_input.any_pressed([KeyCode::W, KeyCode::Up]);
+        let down = keyboard_input.any_pressed([KeyCode::S, KeyCode::Down]);
+        let left = keyboard_input.any_pressed([KeyCode::A, KeyCode::Left]);
+        let right = keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]);
 
         let x_axis = -(left as i8) + right as i8;
         let y_axis = -(down as i8) + up as i8;

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -29,7 +29,7 @@ serde-serialize = [ "rapier3d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.9.0-dev", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam022" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = "0.16.0"
@@ -39,7 +39,7 @@ log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
-bevy = { version = "0.9.0-dev", default-features = false, features = ["x11"]}
+bevy = { version = "0.9.0", default-features = false, features = ["x11"]}
 approx = "0.5.1"
 glam = { version = "0.22", features = [ "approx" ] }
 

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -30,7 +30,7 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.9.0-dev", default-features = false, features = ["bevy_asset", "bevy_scene"] }
-nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
+nalgebra = { version = "^0.31.1", features = [ "convert-glam022" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = "0.16.0"
 bitflags = "1"
@@ -41,7 +41,7 @@ serde = { version = "1", features = [ "derive" ], optional = true}
 [dev-dependencies]
 bevy = { version = "0.9.0-dev", default-features = false, features = ["x11"]}
 approx = "0.5.1"
-glam = { version = "0.21", features = [ "approx" ] }
+glam = { version = "0.22", features = [ "approx" ] }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -30,7 +30,7 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
-nalgebra = { version = "^0.31.1", features = [ "convert-glam022" ] }
+nalgebra = { version = "^0.31.4", features = [ "convert-glam022" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = "0.16.0"
 bitflags = "1"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -29,7 +29,7 @@ serde-serialize = [ "rapier3d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 
 [dependencies]
-bevy = { version = "0.8.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { version = "0.9.0-dev", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "^0.31.1", features = [ "convert-glam021" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = "0.16.0"
@@ -39,7 +39,7 @@ log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
-bevy = { version = "0.8", default-features = false, features = ["x11"]}
+bevy = { version = "0.9.0-dev", default-features = false, features = ["x11"]}
 approx = "0.5.1"
 glam = { version = "0.21", features = [ "approx" ] }
 

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -18,7 +17,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-30.0, 30.0, 100.0)
             .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
         ..Default::default()
@@ -32,13 +31,10 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 200.1;
     let ground_height = 0.1;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height, ground_size));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height, ground_size),
+    ));
 
     /*
      * Create the cubes
@@ -68,15 +64,16 @@ pub fn setup_physics(mut commands: Commands) {
                 color += 1;
 
                 commands
-                    .spawn_bundle(TransformBundle::from(Transform::from_rotation(
+                    .spawn(TransformBundle::from(Transform::from_rotation(
                         Quat::from_rotation_x(0.2),
                     )))
                     .with_children(|child| {
-                        child
-                            .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, z)))
-                            .insert(RigidBody::Dynamic)
-                            .insert(Collider::cuboid(rad, rad, rad))
-                            .insert(ColliderDebugColor(colors[color % 3]));
+                        child.spawn((
+                            TransformBundle::from(Transform::from_xyz(x, y, z)),
+                            RigidBody::Dynamic,
+                            Collider::cuboid(rad, rad, rad),
+                            ColliderDebugColor(colors[color % 3]),
+                        ));
                     });
             }
         }

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -35,7 +35,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<&CustomFilterTag>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -45,7 +44,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-30.0, 30.0, 100.0)
             .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
         ..Default::default()
@@ -62,15 +61,17 @@ pub fn setup_physics(mut commands: Commands) {
 
     let ground_size = 10.0;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, -10.0, 0.0)))
-        .insert(Collider::cuboid(ground_size, 1.2, ground_size))
-        .insert(CustomFilterTag::GroupA);
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -10.0, 0.0)),
+        Collider::cuboid(ground_size, 1.2, ground_size),
+        CustomFilterTag::GroupA,
+    ));
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)))
-        .insert(Collider::cuboid(ground_size, 1.2, ground_size))
-        .insert(CustomFilterTag::GroupB);
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
+        Collider::cuboid(ground_size, 1.2, ground_size),
+        CustomFilterTag::GroupB,
+    ));
 
     /*
      * Create the cubes
@@ -91,13 +92,14 @@ pub fn setup_physics(mut commands: Commands) {
             let y = j as f32 * shift + centery + 2.0;
             group_id += 1;
 
-            commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, 0.0)))
-                .insert(RigidBody::Dynamic)
-                .insert(Collider::cuboid(rad, rad, rad))
-                .insert(ActiveHooks::FILTER_CONTACT_PAIRS)
-                .insert(tags[group_id % 2])
-                .insert(ColliderDebugColor(colors[group_id % 2]));
+            commands.spawn((
+                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                RigidBody::Dynamic,
+                Collider::cuboid(rad, rad, rad),
+                ActiveHooks::FILTER_CONTACT_PAIRS,
+                tags[group_id % 2],
+                ColliderDebugColor(colors[group_id % 2]),
+            ));
         }
     }
 }

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, core::FrameCount};
 use bevy_rapier3d::prelude::*;
 
 struct SpecialStagingPlugin {
@@ -37,8 +37,6 @@ impl Stage for SpecialStage {
     }
 }
 
-struct FrameCount(u32);
-
 fn main() {
     let mut app = App::new();
 
@@ -47,8 +45,6 @@ fn main() {
         0xF9 as f32 / 255.0,
         0xFF as f32 / 255.0,
     )))
-    .insert_resource(Msaa::default())
-    .insert_resource(FrameCount(0))
     .add_plugins(DefaultPlugins)
     .add_plugin(RapierDebugRenderPlugin::default())
     .add_startup_system(setup_graphics)
@@ -119,7 +115,7 @@ fn despawn_one_box(
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-30.0, 30.0, 100.0)
             .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
         ..Default::default()
@@ -133,13 +129,10 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 200.1;
     let ground_height = 0.1;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height, ground_size));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height, ground_size),
+    ));
 
     /*
      * Create the cubes
@@ -168,11 +161,12 @@ pub fn setup_physics(mut commands: Commands) {
                 let z = k as f32 * shift - centerz + offset;
                 color += 1;
 
-                commands
-                    .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, z)))
-                    .insert(RigidBody::Dynamic)
-                    .insert(Collider::cuboid(rad, rad, rad))
-                    .insert(ColliderDebugColor(colors[color % 3]));
+                commands.spawn((
+                    TransformBundle::from(Transform::from_xyz(x, y, z)),
+                    RigidBody::Dynamic,
+                    Collider::cuboid(rad, rad, rad),
+                    ColliderDebugColor(colors[color % 3]),
+                ));
             }
         }
 

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, core::FrameCount};
+use bevy::{core::FrameCount, prelude::*};
 use bevy_rapier3d::prelude::*;
 
 struct SpecialStagingPlugin {

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
-#[derive(Default)]
+#[derive(Resource, Default)]
 pub struct DespawnResource {
     pub entity: Option<Entity>,
 }
@@ -13,7 +13,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .insert_resource(DespawnResource::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
@@ -25,7 +24,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-30.0, 30.0, 100.0)
             .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
         ..Default::default()
@@ -40,12 +39,10 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
     let ground_height = 0.1;
 
     let ground_entity = commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height, ground_size))
+        .spawn((
+            TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+            Collider::cuboid(ground_size, ground_height, ground_size),
+        ))
         .id();
     despawn.entity = Some(ground_entity);
     /*
@@ -75,11 +72,12 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
                 let z = k as f32 * shift - centerz + offset;
                 color += 1;
 
-                commands
-                    .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, z)))
-                    .insert(RigidBody::Dynamic)
-                    .insert(Collider::cuboid(rad, rad, rad))
-                    .insert(ColliderDebugColor(colors[color % 3]));
+                commands.spawn((
+                    TransformBundle::from(Transform::from_xyz(x, y, z)),
+                    RigidBody::Dynamic,
+                    Collider::cuboid(rad, rad, rad),
+                    ColliderDebugColor(colors[color % 3]),
+                ));
             }
         }
 
@@ -88,7 +86,7 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
 }
 
 pub fn despawn(mut commands: Commands, time: Res<Time>, mut despawn: ResMut<DespawnResource>) {
-    if time.seconds_since_startup() > 5.0 {
+    if time.elapsed_seconds() > 5.0 {
         if let Some(entity) = despawn.entity {
             println!("Despawning ground entity");
             commands.entity(entity).despawn();

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -19,7 +18,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 0.0, 25.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..Default::default()
     });
@@ -42,19 +41,22 @@ pub fn setup_physics(mut commands: Commands) {
     /*
      * Ground
      */
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, -1.2, 0.0)))
-        .insert(Collider::cuboid(4.0, 1.0, 1.0));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -1.2, 0.0)),
+        Collider::cuboid(4.0, 1.0, 1.0),
+    ));
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)))
-        .insert(Collider::cuboid(4.0, 1.5, 1.0))
-        .insert(Sensor);
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)),
+        Collider::cuboid(4.0, 1.5, 1.0),
+        Sensor,
+    ));
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 13.0, 0.0)))
-        .insert(RigidBody::Dynamic)
-        .insert(Collider::cuboid(0.5, 0.5, 0.5))
-        .insert(ActiveEvents::COLLISION_EVENTS)
-        .insert(ContactForceEventThreshold(30.0));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 13.0, 0.0)),
+        RigidBody::Dynamic,
+        Collider::cuboid(0.5, 0.5, 0.5),
+        ActiveEvents::COLLISION_EVENTS,
+        ContactForceEventThreshold(30.0),
+    ));
 }

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -18,7 +17,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(15.0, 5.0, 42.0)
             .looking_at(Vec3::new(13.0, 1.0, 1.0), Vec3::Y),
         ..Default::default()
@@ -30,11 +29,11 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
     let shift = 1.0;
 
     let mut curr_parent = commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            origin.x, origin.y, origin.z,
-        )))
-        .insert(RigidBody::Fixed)
-        .insert(Collider::cuboid(rad, rad, rad))
+        .spawn((
+            TransformBundle::from(Transform::from_xyz(origin.x, origin.y, origin.z)),
+            RigidBody::Fixed,
+            Collider::cuboid(rad, rad, rad),
+        ))
         .id();
 
     for i in 0..num {
@@ -52,14 +51,12 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
         let joint = ImpulseJoint::new(curr_parent, prism);
 
         curr_parent = commands
-            .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-                origin.x,
-                origin.y,
-                origin.z + dz,
-            )))
-            .insert(RigidBody::Dynamic)
-            .insert(Collider::cuboid(rad, rad, rad))
-            .insert(joint)
+            .spawn((
+                TransformBundle::from(Transform::from_xyz(origin.x, origin.y, origin.z + dz)),
+                RigidBody::Dynamic,
+                Collider::cuboid(rad, rad, rad),
+                joint,
+            ))
             .id();
     }
 }
@@ -69,11 +66,11 @@ fn create_revolute_joints(commands: &mut Commands, origin: Vec3, num: usize) {
     let shift = 2.0;
 
     let mut curr_parent = commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            origin.x, origin.y, 0.0,
-        )))
-        .insert(RigidBody::Fixed)
-        .insert(Collider::cuboid(rad, rad, rad))
+        .spawn((
+            TransformBundle::from(Transform::from_xyz(origin.x, origin.y, 0.0)),
+            RigidBody::Fixed,
+            Collider::cuboid(rad, rad, rad),
+        ))
         .id();
 
     for i in 0..num {
@@ -89,11 +86,11 @@ fn create_revolute_joints(commands: &mut Commands, origin: Vec3, num: usize) {
         let mut handles = [curr_parent; 4];
         for k in 0..4 {
             handles[k] = commands
-                .spawn_bundle(TransformBundle::from(Transform::from_translation(
-                    positions[k],
-                )))
-                .insert(RigidBody::Dynamic)
-                .insert(Collider::cuboid(rad, rad, rad))
+                .spawn((
+                    TransformBundle::from(Transform::from_translation(positions[k])),
+                    RigidBody::Dynamic,
+                    Collider::cuboid(rad, rad, rad),
+                ))
                 .id();
         }
 
@@ -146,13 +143,15 @@ fn create_fixed_joints(commands: &mut Commands, origin: Vec3, num: usize) {
             };
 
             let child_entity = commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-                    origin.x + fk * shift,
-                    origin.y,
-                    origin.z + fi * shift,
-                )))
-                .insert(rigid_body)
-                .insert(Collider::ball(rad))
+                .spawn((
+                    TransformBundle::from(Transform::from_xyz(
+                        origin.x + fk * shift,
+                        origin.y,
+                        origin.z + fi * shift,
+                    )),
+                    rigid_body,
+                    Collider::ball(rad),
+                ))
                 .id();
 
             // Vertical joint.
@@ -163,9 +162,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Vec3, num: usize) {
                     // NOTE: we want to attach multiple impulse joints to this entity, so
                     //       we need to add the components to children of the entity. Otherwise
                     //       the second joint component would just overwrite the first one.
-                    children
-                        .spawn()
-                        .insert(ImpulseJoint::new(parent_entity, joint));
+                    children.spawn(ImpulseJoint::new(parent_entity, joint));
                 });
             }
 
@@ -178,9 +175,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Vec3, num: usize) {
                     // NOTE: we want to attach multiple impulse joints to this entity, so
                     //       we need to add the components to children of the entity. Otherwise
                     //       the second joint component would just overwrite the first one.
-                    children
-                        .spawn()
-                        .insert(ImpulseJoint::new(parent_entity, joint));
+                    children.spawn(ImpulseJoint::new(parent_entity, joint));
                 });
             }
 
@@ -207,13 +202,11 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
             };
 
             let child_entity = commands
-                .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-                    fk * shift,
-                    0.0,
-                    fi * shift,
-                )))
-                .insert(rigid_body)
-                .insert(Collider::ball(rad))
+                .spawn((
+                    TransformBundle::from(Transform::from_xyz(fk * shift, 0.0, fi * shift)),
+                    rigid_body,
+                    Collider::ball(rad),
+                ))
                 .id();
 
             // Vertical joint.
@@ -224,9 +217,7 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
                     // NOTE: we want to attach multiple impulse joints to this entity, so
                     //       we need to add the components to children of the entity. Otherwise
                     //       the second joint component would just overwrite the first one.
-                    children
-                        .spawn()
-                        .insert(ImpulseJoint::new(parent_entity, joint));
+                    children.spawn(ImpulseJoint::new(parent_entity, joint));
                 });
             }
 
@@ -239,9 +230,7 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
                     // NOTE: we want to attach multiple impulse joints to this entity, so
                     //       we need to add the components to children of the entity. Otherwise
                     //       the second joint component would just overwrite the first one.
-                    children
-                        .spawn()
-                        .insert(ImpulseJoint::new(parent_entity, joint));
+                    children.spawn(ImpulseJoint::new(parent_entity, joint));
                 });
             }
 

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -18,7 +17,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(10.0, 3.0, 0.0)
             .looking_at(Vec3::new(0.0, 3.0, 0.0), Vec3::Y),
         ..Default::default()
@@ -32,35 +31,32 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 5.0;
     let ground_height = 0.1;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height, ground_size));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height, ground_size),
+    ));
 
     /*
      * A rectangle that only rotates along the `x` axis.
      */
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(0.0, 3.0, 0.0)))
-        .insert(RigidBody::Dynamic)
-        .insert(
-            LockedAxes::TRANSLATION_LOCKED
-                | LockedAxes::ROTATION_LOCKED_Y
-                | LockedAxes::ROTATION_LOCKED_Z,
-        )
-        .insert(Collider::cuboid(0.2, 0.6, 2.0));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 3.0, 0.0)),
+        RigidBody::Dynamic,
+        LockedAxes::TRANSLATION_LOCKED
+            | LockedAxes::ROTATION_LOCKED_Y
+            | LockedAxes::ROTATION_LOCKED_Z,
+        Collider::cuboid(0.2, 0.6, 2.0),
+    ));
 
     /*
      * A tilted cuboid that cannot rotate.
      */
-    commands
-        .spawn_bundle(TransformBundle::from(
+    commands.spawn((
+        TransformBundle::from(
             Transform::from_xyz(0.0, 5.0, 0.0).with_rotation(Quat::from_rotation_x(1.0)),
-        ))
-        .insert(RigidBody::Dynamic)
-        .insert(LockedAxes::ROTATION_LOCKED)
-        .insert(Collider::cuboid(0.6, 0.4, 0.4));
+        ),
+        RigidBody::Dynamic,
+        LockedAxes::ROTATION_LOCKED,
+        Collider::cuboid(0.6, 0.4, 0.4),
+    ));
 }

--- a/bevy_rapier3d/examples/multiple_colliders3.rs
+++ b/bevy_rapier3d/examples/multiple_colliders3.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -18,7 +17,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-30.0, 30.0, 100.0)
             .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
         ..Default::default()
@@ -32,13 +31,10 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 50.0;
     let ground_height = 0.1;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height, ground_size));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height, ground_size),
+    ));
 
     /*
      * Create the cubes
@@ -69,29 +65,29 @@ pub fn setup_physics(mut commands: Commands) {
 
                 // Crate a rigid-body with multiple colliders attached, using Bevy hierarchy.
                 commands
-                    .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, z)))
-                    .insert(RigidBody::Dynamic)
+                    .spawn((
+                        TransformBundle::from(Transform::from_xyz(x, y, z)),
+                        RigidBody::Dynamic,
+                    ))
                     .with_children(|children| {
-                        children
-                            .spawn()
-                            .insert(Collider::cuboid(rad * 10.0, rad, rad))
-                            .insert(ColliderDebugColor(colors[color % 3]));
-                        children
-                            .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-                                rad * 10.0,
-                                rad * 10.0,
-                                0.0,
-                            )))
-                            .insert(Collider::cuboid(rad, rad * 10.0, rad))
-                            .insert(ColliderDebugColor(colors[color % 3]));
-                        children
-                            .spawn_bundle(TransformBundle::from(Transform::from_xyz(
+                        children.spawn((
+                            Collider::cuboid(rad * 10.0, rad, rad),
+                            ColliderDebugColor(colors[color % 3]),
+                        ));
+                        children.spawn((
+                            TransformBundle::from(Transform::from_xyz(rad * 10.0, rad * 10.0, 0.0)),
+                            Collider::cuboid(rad, rad * 10.0, rad),
+                            ColliderDebugColor(colors[color % 3]),
+                        ));
+                        children.spawn((
+                            TransformBundle::from(Transform::from_xyz(
                                 -rad * 10.0,
                                 rad * 10.0,
                                 0.0,
-                            )))
-                            .insert(Collider::cuboid(rad, rad * 10.0, rad))
-                            .insert(ColliderDebugColor(colors[color % 3]));
+                            )),
+                            Collider::cuboid(rad, rad * 10.0, rad),
+                            ColliderDebugColor(colors[color % 3]),
+                        ));
                     });
             }
         }

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -8,7 +8,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -19,7 +18,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-30.0, 30.0, 100.0)
             .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
         ..Default::default()
@@ -33,13 +32,10 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 200.1;
     let ground_height = 0.1;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
-            0.0,
-            -ground_height,
-            0.0,
-        )))
-        .insert(Collider::cuboid(ground_size, ground_height, ground_size));
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Collider::cuboid(ground_size, ground_height, ground_size),
+    ));
 
     /*
      * Create the cubes
@@ -62,10 +58,11 @@ pub fn setup_physics(mut commands: Commands) {
                 let z = k as f32 * shift - centerz + offset;
 
                 // Build the rigid body.
-                commands
-                    .spawn_bundle(TransformBundle::from(Transform::from_xyz(x, y, z)))
-                    .insert(RigidBody::Dynamic)
-                    .insert(Collider::cuboid(rad, rad, rad));
+                commands.spawn((
+                    TransformBundle::from(Transform::from_xyz(x, y, z)),
+                    RigidBody::Dynamic,
+                    Collider::cuboid(rad, rad, rad),
+                ));
             }
         }
 

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -48,7 +48,7 @@ pub fn setup_physics(mut commands: Commands) {
     }
     for i in 0..segments {
         // Two triangles making up a flat quad for each segment of the ramp.
-        indices.push([2 * i + 0, 2 * i + 1, 2 * i + 2]);
+        indices.push([2 * i, 2 * i + 1, 2 * i + 2]);
         indices.push([2 * i + 2, 2 * i + 1, 2 * i + 3]);
     }
 
@@ -82,8 +82,8 @@ pub fn setup_physics(mut commands: Commands) {
             let row0 = ix * (segments + 1);
             let row1 = (ix + 1) * (segments + 1);
             // Two triangles making up a not-very-flat quad for each segment of the bowl.
-            indices.push([row0 + iz + 0, row0 + iz + 1, row1 + iz + 0]);
-            indices.push([row1 + iz + 0, row0 + iz + 1, row1 + iz + 1]);
+            indices.push([row0 + iz, row0 + iz + 1, row1 + iz]);
+            indices.push([row1 + iz, row0 + iz + 1, row1 + iz + 1]);
         }
     }
     // Position so ramp connects smoothly

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -10,7 +10,6 @@ fn main() {
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
         )))
-        .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -22,7 +21,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn_bundle(Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-15.0, 8.0, 15.0)
             .looking_at(Vec3::new(-5.0, 0.0, 5.0), Vec3::Y),
         ..Default::default()
@@ -53,9 +52,7 @@ pub fn setup_physics(mut commands: Commands) {
         indices.push([2 * i + 2, 2 * i + 1, 2 * i + 3]);
     }
 
-    commands
-        .spawn()
-        .insert(Collider::trimesh(vertices, indices));
+    commands.spawn(Collider::trimesh(vertices, indices));
 
     // Create a bowl with a cosine cross-section,
     // so that we can join the end of the ramp smoothly
@@ -91,15 +88,17 @@ pub fn setup_physics(mut commands: Commands) {
     }
     // Position so ramp connects smoothly
     // to one edge of the lip of the bowl.
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(
             -bowl_size.x / 2.0,
             -bowl_size.y / 2.0,
             bowl_size.z / 2.0 - ramp_size.z / 2.0,
-        )))
-        .insert(Collider::trimesh(vertices, indices));
+        )),
+        Collider::trimesh(vertices, indices),
+    ));
 }
 
+#[derive(Resource)]
 struct BallState {
     seconds_until_next_spawn: f32,
     seconds_between_spawns: f32,
@@ -139,15 +138,16 @@ fn ball_spawner(
     let ramp_size = ramp_size();
     let rad = 0.3;
 
-    commands
-        .spawn_bundle(TransformBundle::from(Transform::from_xyz(
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(
             ramp_size.x * 0.9,
             ramp_size.y / 2.0 + rad * 3.0,
             0.0,
-        )))
-        .insert(RigidBody::Dynamic)
-        .insert(Collider::ball(rad))
-        .insert(Restitution::new(0.5));
+        )),
+        RigidBody::Dynamic,
+        Collider::ball(rad),
+        Restitution::new(0.5),
+    ));
 
     ball_state.balls_spawned += 1;
 }

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -19,8 +19,7 @@ pub struct RapierColliderHandle(pub ColliderHandle);
 
 /// A component which will be replaced by the specified collider type after the referenced mesh become available.
 #[cfg(feature = "dim3")]
-#[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component)]
+#[derive(Component, Debug, Clone)]
 pub struct AsyncCollider {
     /// Mesh handle to use for collider generation.
     pub handle: Handle<Mesh>,
@@ -54,7 +53,7 @@ pub struct AsyncSceneCollider {
 
 /// Shape type based on a Bevy mesh asset.
 #[cfg(feature = "dim3")]
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone)]
 pub enum ComputedColliderShape {
     /// Triangle-mesh.
     TriMesh,

--- a/src/pipeline/physics_hooks.rs
+++ b/src/pipeline/physics_hooks.rs
@@ -201,6 +201,7 @@ where
 }
 
 /// Resource containing the user-defined physics hooks.
+#[derive(Resource)]
 pub struct PhysicsHooksWithQueryResource<UserData: WorldQuery>(
     pub Box<dyn PhysicsHooksWithQuery<UserData>>,
 );

--- a/src/plugin/configuration.rs
+++ b/src/plugin/configuration.rs
@@ -1,7 +1,9 @@
+use bevy::prelude::Resource;
+
 use crate::math::Vect;
 
 /// Difference between simulation and rendering time
-#[derive(Default)]
+#[derive(Resource, Default)]
 pub struct SimulationToRenderTime {
     /// Difference between simulation and rendering time
     pub diff: f32,
@@ -47,7 +49,7 @@ pub enum TimestepMode {
     },
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Resource, Copy, Clone, Debug)]
 /// A resource for specifying configuration information for the physics simulation
 pub struct RapierConfiguration {
     /// Specifying the gravity of the physics simulation.

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -1,4 +1,4 @@
-use bevy::time::Time;
+use bevy::prelude::*;
 use std::collections::HashMap;
 use std::sync::RwLock;
 
@@ -25,6 +25,7 @@ use rapier::control::CharacterAutostep;
 
 /// The Rapier context, containing all the state of the physics engine.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Resource)]
 pub struct RapierContext {
     /// The island manager, which detects what object is sleeping
     /// (not moving much) to reduce computations.

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -184,9 +184,6 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> Plugin
             .register_type::<SolverGroups>()
             .register_type::<ContactForceEventThreshold>();
 
-        #[cfg(feature = "dim3")]
-        app.register_type::<AsyncCollider>();
-
         // Insert all of our required resources. Don’t overwrite
         // the `RapierConfiguration` if it already exists.
         if app.world.get_resource::<RapierConfiguration>().is_none() {

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -1664,7 +1664,8 @@ mod tests {
             .add_plugin(WindowPlugin::default())
             .add_plugin(AssetPlugin::default())
             .add_plugin(ScenePlugin::default())
-            .add_plugin(RenderPlugin::default());
+            .add_plugin(RenderPlugin::default())
+            .add_plugin(ImagePlugin::default());
         }
     }
 }

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -1363,8 +1363,8 @@ mod tests {
         app.add_event::<CollisionEvent>()
             .add_system(update_colliding_entities);
 
-        let entity1 = app.world.spawn().insert(CollidingEntities::default()).id();
-        let entity2 = app.world.spawn().insert(CollidingEntities::default()).id();
+        let entity1 = app.world.spawn(CollidingEntities::default()).id();
+        let entity2 = app.world.spawn(CollidingEntities::default()).id();
 
         let mut collision_events = app
             .world
@@ -1455,8 +1455,7 @@ mod tests {
 
         let entity = app
             .world
-            .spawn()
-            .insert(AsyncCollider {
+            .spawn(AsyncCollider {
                 handle: cube,
                 shape: ComputedColliderShape::TriMesh,
             })
@@ -1485,18 +1484,8 @@ mod tests {
         let mut meshes = app.world.resource_mut::<Assets<Mesh>>();
         let cube_handle = meshes.add(Cube::default().into());
         let capsule_handle = meshes.add(Capsule::default().into());
-        let cube = app
-            .world
-            .spawn()
-            .insert(Name::new("Cube"))
-            .insert(cube_handle)
-            .id();
-        let capsule = app
-            .world
-            .spawn()
-            .insert(Name::new("Capsule"))
-            .insert(capsule_handle)
-            .id();
+        let cube = app.world.spawn((Name::new("Cube"), cube_handle)).id();
+        let capsule = app.world.spawn((Name::new("Capsule"), capsule_handle)).id();
 
         let mut scenes = app.world.resource_mut::<Assets<Scene>>();
         let scene = scenes.add(Scene::new(World::new()));
@@ -1505,8 +1494,7 @@ mod tests {
         named_shapes.insert("Capsule".to_string(), None);
         let parent = app
             .world
-            .spawn()
-            .insert(AsyncSceneCollider {
+            .spawn(AsyncSceneCollider {
                 handle: scene,
                 shape: Some(ComputedColliderShape::TriMesh),
                 named_shapes,
@@ -1558,15 +1546,15 @@ mod tests {
         for (child_transform, parent_transform) in [zero, same, different] {
             let child = app
                 .world
-                .spawn()
-                .insert_bundle(TransformBundle::from(child_transform))
-                .insert(RigidBody::Fixed)
-                .insert(Collider::ball(1.0))
+                .spawn((
+                    TransformBundle::from(child_transform),
+                    RigidBody::Fixed,
+                    Collider::ball(1.0),
+                ))
                 .id();
 
             app.world
-                .spawn()
-                .insert_bundle(TransformBundle::from(parent_transform))
+                .spawn(TransformBundle::from(parent_transform))
                 .push_children(&[child]);
 
             app.update();
@@ -1616,16 +1604,12 @@ mod tests {
         for (child_transform, parent_transform) in [zero, same, different] {
             let child = app
                 .world
-                .spawn()
-                .insert_bundle(TransformBundle::from(child_transform))
-                .insert(Collider::ball(1.0))
+                .spawn((TransformBundle::from(child_transform), Collider::ball(1.0)))
                 .id();
 
             let parent = app
                 .world
-                .spawn()
-                .insert_bundle(TransformBundle::from(parent_transform))
-                .insert(RigidBody::Fixed)
+                .spawn((TransformBundle::from(parent_transform), RigidBody::Fixed))
                 .push_children(&[child])
                 .id();
 

--- a/src/render/lines/mod.rs
+++ b/src/render/lines/mod.rs
@@ -174,16 +174,11 @@ fn setup(mut cmds: Commands, mut meshes: ResMut<Assets<Mesh>>) {
         // https://github.com/Toqozz/bevy_debug_lines/issues/16
         //mesh.set_indices(Some(Indices::U16(Vec::with_capacity(MAX_POINTS_PER_MESH))));
 
-        cmds.spawn_bundle((
+        cmds.spawn((
             dim::into_handle(meshes.add(mesh)),
             #[cfg(feature = "dim3")]
-            bevy::pbr::NotShadowCaster,
-            #[cfg(feature = "dim3")]
-            bevy::pbr::NotShadowReceiver,
-            Transform::default(),
-            GlobalTransform::default(),
-            Visibility::default(),
-            ComputedVisibility::default(),
+            (bevy::pbr::NotShadowCaster, bevy::pbr::NotShadowReceiver),
+            SpatialBundle::VISIBLE_IDENTITY,
             NoFrustumCulling,
             DebugLinesMesh(i),
         ));

--- a/src/render/lines/mod.rs
+++ b/src/render/lines/mod.rs
@@ -69,7 +69,7 @@ pub(crate) const SHADER_FILE: &str = include_str!("debuglines.wgsl");
 pub(crate) const DEBUG_LINES_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 17477439189930443325);
 
-#[derive(Clone)]
+#[derive(Resource, Clone)]
 pub(crate) struct DebugLinesConfig {
     pub always_on_top: Arc<RwLock<bool>>, // Don’t know how to do this properly since this resource lives in a sub-app.
 }
@@ -276,7 +276,7 @@ pub(crate) struct RenderDebugLinesMesh;
 ///     );
 /// }
 /// ```
-#[derive(Default)]
+#[derive(Resource, Default)]
 pub struct DebugLines {
     pub positions: Vec<[f32; 3]>,
     pub colors: Vec<[f32; 4]>,

--- a/src/render/lines/render_dim.rs
+++ b/src/render/lines/render_dim.rs
@@ -25,6 +25,7 @@ pub mod r3d {
 
     use super::super::{DebugLinesConfig, RenderDebugLinesMesh, DEBUG_LINES_SHADER_HANDLE};
 
+    #[derive(Resource)]
     pub(crate) struct DebugLinePipeline {
         mesh_pipeline: MeshPipeline,
         shader: Handle<Shader>,
@@ -203,6 +204,7 @@ pub mod r2d {
 
     use super::super::{RenderDebugLinesMesh, DEBUG_LINES_SHADER_HANDLE};
 
+    #[derive(Resource)]
     pub(crate) struct DebugLinePipeline {
         mesh_pipeline: Mesh2dPipeline,
         shader: Handle<Shader>,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -74,6 +74,7 @@ impl RapierDebugRenderPlugin {
 }
 
 /// Context to control some aspect of the debug-renderer after initialization.
+#[derive(Resource)]
 pub struct DebugRenderContext {
     /// Is the debug-rendering currently enabled?
     pub enabled: bool,


### PR DESCRIPTION
~Blocked on a new release of `nalgebra` for the `convert-glam022` feature.~

`bevy_reflect`'s handling of enums was changed, which now (correctly, I think) causes the `Reflect` derive for `AsyncCollider` to fail because it contains an item that is not `Reflect`.

99% of the changes this time is an update to entity spawning API.

Resolves #269