### PR TITLE
Query filter should use CollisionGroups instead of InteractionGroups

### DIFF
--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -1,11 +1,11 @@
-use crate::geometry::{Collider, Toi};
+use crate::geometry::{Collider, CollisionGroups, Toi};
 use crate::math::{Real, Rot, Vect};
 use bevy::prelude::*;
 
 use crate::plugin::RapierContext;
 pub use rapier::control::CharacterAutostep;
 pub use rapier::control::CharacterLength;
-use rapier::prelude::{ColliderSet, InteractionGroups, QueryFilterFlags};
+use rapier::prelude::{ColliderSet, QueryFilterFlags};
 
 /// A collision between the character and its environment during its movement.
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -137,7 +137,7 @@ pub struct KinematicCharacterController {
     pub filter_flags: QueryFilterFlags,
     /// Groups for filtering-out some colliders from the environment seen by the character
     /// controller.
-    pub filter_groups: Option<InteractionGroups>,
+    pub filter_groups: Option<CollisionGroups>,
 }
 
 impl KinematicCharacterController {

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -1,6 +1,5 @@
 pub use self::collider::*;
 pub use self::shape_views::ColliderView;
-pub use rapier::geometry::InteractionGroups;
 pub use rapier::geometry::SolverFlags;
 pub use rapier::parry::query::TOIStatus;
 pub use rapier::parry::shape::TriMeshFlags;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -5,7 +5,7 @@ pub use self::physics_hooks::{
     ContactModificationContextView, PairFilterContextView, PhysicsHooksWithQuery,
     PhysicsHooksWithQueryResource,
 };
-pub use query_filter::{InteractionGroups, QueryFilter, QueryFilterFlags};
+pub use query_filter::{QueryFilter, QueryFilterFlags};
 
 mod events;
 mod physics_hooks;

--- a/src/pipeline/query_filter.rs
+++ b/src/pipeline/query_filter.rs
@@ -3,7 +3,7 @@ use bevy::prelude::Entity;
 pub use rapier::geometry::InteractionGroups;
 pub use rapier::pipeline::QueryFilterFlags;
 
-use crate::prelude::CollisionGroups;
+use crate::geometry::CollisionGroups;
 
 /// A filter that describes what collider should be included or excluded from a scene query.
 #[derive(Copy, Clone, Default)]

--- a/src/pipeline/query_filter.rs
+++ b/src/pipeline/query_filter.rs
@@ -3,6 +3,8 @@ use bevy::prelude::Entity;
 pub use rapier::geometry::InteractionGroups;
 pub use rapier::pipeline::QueryFilterFlags;
 
+use crate::prelude::CollisionGroups;
+
 /// A filter that describes what collider should be included or excluded from a scene query.
 #[derive(Copy, Clone, Default)]
 pub struct QueryFilter<'a> {
@@ -10,7 +12,7 @@ pub struct QueryFilter<'a> {
     pub flags: QueryFilterFlags,
     /// If set, only colliders with collision groups compatible with this one will
     /// be included in the scene query.
-    pub groups: Option<InteractionGroups>,
+    pub groups: Option<CollisionGroups>,
     /// If set, the collider attached to that entity will be excluded from the query.
     pub exclude_collider: Option<Entity>,
     /// If set, any collider attached to the rigid-body attached to that entity
@@ -29,8 +31,8 @@ impl<'a> From<QueryFilterFlags> for QueryFilter<'a> {
     }
 }
 
-impl<'a> From<InteractionGroups> for QueryFilter<'a> {
-    fn from(groups: InteractionGroups) -> Self {
+impl<'a> From<CollisionGroups> for QueryFilter<'a> {
+    fn from(groups: CollisionGroups) -> Self {
         Self {
             groups: Some(groups),
             ..QueryFilter::default()
@@ -89,7 +91,7 @@ impl<'a> QueryFilter<'a> {
 
     /// Only colliders with collision groups compatible with this one will
     /// be included in the scene query.
-    pub fn groups(mut self, groups: InteractionGroups) -> Self {
+    pub fn groups(mut self, groups: CollisionGroups) -> Self {
         self.groups = Some(groups);
         self
     }

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -18,7 +18,7 @@ use bevy::render::primitives::Aabb;
 use crate::control::{CharacterCollision, MoveShapeOptions, MoveShapeOutput};
 use crate::dynamics::TransformInterpolation;
 use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
-use crate::prelude::RapierRigidBodyHandle;
+use crate::prelude::{CollisionGroups, RapierRigidBodyHandle};
 #[cfg(feature = "dim2")]
 use bevy::math::Vec3Swizzles;
 use rapier::control::CharacterAutostep;
@@ -165,7 +165,7 @@ impl RapierContext {
     ) -> T {
         let mut rapier_filter = RapierQueryFilter {
             flags: filter.flags,
-            groups: filter.groups,
+            groups: filter.groups.map(CollisionGroups::into),
             exclude_collider: filter
                 .exclude_collider
                 .and_then(|c| entity2collider.get(&c).copied()),

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -30,7 +30,6 @@ use std::collections::HashMap;
 use crate::prelude::{AsyncCollider, AsyncSceneCollider};
 
 use crate::control::CharacterCollision;
-use crate::utils::transform_to_iso;
 #[cfg(feature = "dim2")]
 use bevy::math::Vec3Swizzles;
 
@@ -1250,7 +1249,8 @@ pub fn update_character_controls(
                     shape_pos = body.position() * shape_pos
                 } else if let Some(gtransform) = glob_transform {
                     shape_pos =
-                        transform_to_iso(&gtransform.compute_transform(), physics_scale) * shape_pos
+                        utils::transform_to_iso(&gtransform.compute_transform(), physics_scale)
+                            * shape_pos
                 }
 
                 (&*scaled_shape.raw, shape_pos)
@@ -1274,7 +1274,7 @@ pub fn update_character_controls(
 
             let mut filter = QueryFilter {
                 flags: controller.filter_flags,
-                groups: controller.filter_groups,
+                groups: controller.filter_groups.map(|g| g.into()),
                 exclude_collider: None,
                 exclude_rigid_body: None,
                 predicate: None,


### PR DESCRIPTION
It seems that most of the bevy-related functionality must use CollisionGroups instead of the InteractionsGroups. This fix implements the missed transition for the `QueryFilter`.

I am unsure whether one should remove the pub export of the InteractionsGroups though.

Fixes #258 and #265 