### PR TITLE
Fix overriding enabled flag in debug render

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -99,7 +99,7 @@ impl Plugin for RapierDebugRenderPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(lines::DebugLinesPlugin::always_on_top(self.always_on_top))
             .insert_resource(DebugRenderContext {
-                enabled: true,
+                enabled: self.enabled,
                 pipeline: DebugRenderPipeline::new(self.style, self.mode),
                 always_on_top: self.always_on_top,
             })


### PR DESCRIPTION
For some reason rapier overrides the enabled flag in debug renderer to true, even though user can set it when initializing the plugin. Inserting a resource is therefore required in order to disable it by default. This fixes it.