### PR TITLE
snap changed collider scales to avoid circular updates

### DIFF
--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -499,3 +499,19 @@ impl CollidingEntities {
         self.0.iter().copied()
     }
 }
+
+/// We restrict the scaling increment to 1.0e-4, to avoid numerical jitter
+/// due to the extraction of scaling factor from the GlobalTransform matrix.
+pub fn get_snapped_scale(scale: Vect) -> Vect {
+    fn snap_value(new: f32) -> f32 {
+        const PRECISION: f32 = 1.0e4;
+        (new * PRECISION).round() / PRECISION
+    }
+
+    Vect {
+        x: snap_value(scale.x),
+        y: snap_value(scale.y),
+        #[cfg(feature = "dim3")]
+        z: snap_value(scale.z),
+    }
+}

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -8,7 +8,7 @@ use {
 
 use rapier::prelude::{FeatureId, Point, Ray, SharedShape, Vector, DIM};
 
-use super::shape_views::*;
+use super::{get_snapped_scale, shape_views::*};
 #[cfg(feature = "dim3")]
 use crate::geometry::ComputedColliderShape;
 use crate::geometry::{Collider, PointProjection, RayIntersection, TriMeshFlags, VHACDParameters};
@@ -518,18 +518,8 @@ impl Collider {
     /// with a non-uniform scale results in an ellipse which isn’t supported),
     /// the shape is approximated by a convex polygon/convex polyhedron using
     /// `num_subdivisions` subdivisions.
-    pub fn set_scale(&mut self, mut scale: Vect, num_subdivisions: u32) {
-        /// We restrict the scaling increment to 1.0e-4, to avoid numerical jitter
-        /// due to the extraction of scaling factor from the GlobalTransform matrix.
-        fn snap_value(new: &mut f32) {
-            const PRECISION: f32 = 1.0e4;
-            *new = (*new * PRECISION).round() / PRECISION;
-        }
-
-        snap_value(&mut scale.x);
-        snap_value(&mut scale.y);
-        #[cfg(feature = "dim3")]
-        snap_value(&mut scale.z);
+    pub fn set_scale(&mut self, scale: Vect, num_subdivisions: u32) {
+        let scale = get_snapped_scale(scale);
 
         if scale == self.scale {
             // Nothing to do.

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -17,7 +17,8 @@ use crate::pipeline::{
 use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
 use crate::plugin::{RapierConfiguration, RapierContext};
 use crate::prelude::{
-    CollidingEntities, KinematicCharacterController, KinematicCharacterControllerOutput,
+    get_snapped_scale, CollidingEntities, KinematicCharacterController,
+    KinematicCharacterControllerOutput,
 };
 use crate::utils;
 use bevy::ecs::query::WorldQuery;
@@ -108,7 +109,7 @@ pub fn apply_scale(
             None => transform.compute_transform().scale,
         };
 
-        if shape.scale != effective_scale {
+        if shape.scale != get_snapped_scale(effective_scale) {
             shape.set_scale(effective_scale, config.scaled_shape_subdivision);
         }
     }


### PR DESCRIPTION
Previously, scales were being always-applied to rolling ball colliders that do not specify a `ColliderScale` when the snapped value was in effect. This occurs because as the ball rolls, numerical constraints were not being checked in `apply_scale`, leading to always updating the collider scale, but snapping the value only on update.  On the next sync, since the Bevy change detector has gone off for the collider shape, it would then set the scale a second time.  This process would repeat as long as the ball was rolling.

A workaround to this issue is to apply a `ColliderScale::Absolute` to the ball so the scale never changes.

This change resolves the issue by only changing the collider when the effective change is different from the would-be snapped value along with the scaled collider.