### PR TITLE
Fix Headless Mode

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -28,8 +28,8 @@ wasm-bindgen = [ "rapier2d/wasm-bindgen" ]
 serde-serialize = [ "rapier2d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
-# Enables the AsyncCollider component that creates colliders from an asset that
-# wasn’t loaded yet.
+# Enables the AsyncCollider and AsyncSceneCollider components that wait for specific
+# assets to be loaded before creating the actual Collider.
 # See https://github.com/dimforge/bevy_rapier/issues/296 for a workaround on how
 # to use this when using bevy headless.
 async-collider = [ ]

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -27,6 +27,7 @@ simd-nightly = [ "rapier2d/simd-nightly" ]
 wasm-bindgen = [ "rapier2d/wasm-bindgen" ]
 serde-serialize = [ "rapier2d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
+headless = [ ]
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -18,7 +18,7 @@ path = "../src/lib.rs"
 required-features = [ "dim2" ]
 
 [features]
-default = [ "dim2", "debug-render" ]
+default = [ "dim2", "async-collider", "debug-render" ]
 dim2 = ["bevy/bevy_render"]
 debug-render = [ "bevy/bevy_core_pipeline", "bevy/bevy_render", "bevy/bevy_sprite", "rapier2d/debug-render" ]
 parallel = [ "rapier2d/parallel" ]
@@ -27,7 +27,13 @@ simd-nightly = [ "rapier2d/simd-nightly" ]
 wasm-bindgen = [ "rapier2d/wasm-bindgen" ]
 serde-serialize = [ "rapier2d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
-headless = [ ]
+
+# Enables the AsyncCollider component that creates colliders from an asset that
+# wasn’t loaded yet.
+# See https://github.com/dimforge/bevy_rapier/issues/296 for a workaround on how
+# to use this when using bevy headless.
+async-collider = [ ]
+
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -18,7 +18,7 @@ path = "../src/lib.rs"
 required-features = [ "dim3" ]
 
 [features]
-default = [ "dim3", "debug-render" ]
+default = [ "dim3", "async-collider", "debug-render" ]
 dim3 = ["bevy/bevy_render"]
 debug-render = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "rapier3d/debug-render" ]
 parallel = [ "rapier3d/parallel" ]
@@ -28,6 +28,12 @@ wasm-bindgen = [ "rapier3d/wasm-bindgen" ]
 serde-serialize = [ "rapier3d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 headless = [ ]
+
+# Enables the AsyncCollider component that creates colliders from an asset that
+# wasn’t loaded yet.
+# See https://github.com/dimforge/bevy_rapier/issues/296 for a workaround on how
+# to use this when using bevy headless.
+async-collider = [ ]
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -29,8 +29,8 @@ serde-serialize = [ "rapier3d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 headless = [ ]
 
-# Enables the AsyncCollider component that creates colliders from an asset that
-# wasn’t loaded yet.
+# Enables the AsyncCollider and AsyncSceneCollider components that wait for specific
+# assets to be loaded before creating the actual Collider.
 # See https://github.com/dimforge/bevy_rapier/issues/296 for a workaround on how
 # to use this when using bevy headless.
 async-collider = [ ]

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -27,6 +27,7 @@ simd-nightly = [ "rapier3d/simd-nightly" ]
 wasm-bindgen = [ "rapier3d/wasm-bindgen" ]
 serde-serialize = [ "rapier3d/serde-serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
+headless = [ ]
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,13 +1,11 @@
 use std::fmt;
 
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
-use crate::geometry::VHACDParameters;
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
+use {crate::geometry::VHACDParameters, bevy::utils::HashMap};
+
 use bevy::prelude::*;
 use bevy::reflect::FromReflect;
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
-use bevy::utils::HashMap;
+
 use bevy::utils::HashSet;
 use rapier::geometry::Shape;
 use rapier::prelude::{ColliderHandle, InteractionGroups, SharedShape};
@@ -20,8 +18,7 @@ use crate::math::Vect;
 pub struct RapierColliderHandle(pub ColliderHandle);
 
 /// A component which will be replaced by the specified collider type after the referenced mesh become available.
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 #[derive(Component, Debug, Clone)]
 pub struct AsyncCollider {
     /// Mesh handle to use for collider generation.
@@ -30,8 +27,7 @@ pub struct AsyncCollider {
     pub shape: ComputedColliderShape,
 }
 
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 impl Default for AsyncCollider {
     fn default() -> Self {
         Self {
@@ -42,8 +38,7 @@ impl Default for AsyncCollider {
 }
 
 /// A component which will be replaced the specified collider types on children with meshes after the referenced scene become available.
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 #[derive(Component, Debug, Clone)]
 pub struct AsyncSceneCollider {
     /// Scene handle to use for colliders generation.
@@ -57,8 +52,7 @@ pub struct AsyncSceneCollider {
 }
 
 /// Shape type based on a Bevy mesh asset.
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 #[derive(Debug, Clone)]
 pub enum ComputedColliderShape {
     /// Triangle-mesh.

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 use crate::geometry::VHACDParameters;
 use bevy::prelude::*;
 use bevy::reflect::FromReflect;
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 use bevy::utils::HashMap;
 use bevy::utils::HashSet;
@@ -18,6 +20,7 @@ use crate::math::Vect;
 pub struct RapierColliderHandle(pub ColliderHandle);
 
 /// A component which will be replaced by the specified collider type after the referenced mesh become available.
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 #[derive(Component, Debug, Clone)]
 pub struct AsyncCollider {
@@ -27,6 +30,7 @@ pub struct AsyncCollider {
     pub shape: ComputedColliderShape,
 }
 
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 impl Default for AsyncCollider {
     fn default() -> Self {
@@ -38,6 +42,7 @@ impl Default for AsyncCollider {
 }
 
 /// A component which will be replaced the specified collider types on children with meshes after the referenced scene become available.
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 #[derive(Component, Debug, Clone)]
 pub struct AsyncSceneCollider {
@@ -52,6 +57,7 @@ pub struct AsyncSceneCollider {
 }
 
 /// Shape type based on a Bevy mesh asset.
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 #[derive(Debug, Clone)]
 pub enum ComputedColliderShape {

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "dim2")]
 use na::DVector;
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 use {
     bevy::prelude::*,
@@ -9,6 +10,7 @@ use {
 use rapier::prelude::{FeatureId, Point, Ray, SharedShape, Vector, DIM};
 
 use super::{get_snapped_scale, shape_views::*};
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 use crate::geometry::ComputedColliderShape;
 use crate::geometry::{Collider, PointProjection, RayIntersection, TriMeshFlags, VHACDParameters};
@@ -170,6 +172,7 @@ impl Collider {
     /// Initializes a collider with a Bevy Mesh.
     ///
     /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
+    #[cfg(not(feature = "headless"))]
     #[cfg(feature = "dim3")]
     pub fn from_bevy_mesh(mesh: &Mesh, collider_shape: &ComputedColliderShape) -> Option<Self> {
         let vertices_indices = extract_mesh_vertices_indices(mesh);
@@ -726,6 +729,7 @@ impl Default for Collider {
     }
 }
 
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 #[allow(clippy::type_complexity)]
 fn extract_mesh_vertices_indices(mesh: &Mesh) -> Option<(Vec<na::Point3<Real>>, Vec<[u32; 3]>)> {

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "dim2")]
 use na::DVector;
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 use {
     bevy::prelude::*,
     bevy::render::mesh::{Indices, VertexAttributeValues},
@@ -10,8 +9,7 @@ use {
 use rapier::prelude::{FeatureId, Point, Ray, SharedShape, Vector, DIM};
 
 use super::{get_snapped_scale, shape_views::*};
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 use crate::geometry::ComputedColliderShape;
 use crate::geometry::{Collider, PointProjection, RayIntersection, TriMeshFlags, VHACDParameters};
 use crate::math::{Real, Rot, Vect};
@@ -172,8 +170,7 @@ impl Collider {
     /// Initializes a collider with a Bevy Mesh.
     ///
     /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
-    #[cfg(not(feature = "headless"))]
-    #[cfg(feature = "dim3")]
+    #[cfg(all(feature = "dim3", feature = "async-collider"))]
     pub fn from_bevy_mesh(mesh: &Mesh, collider_shape: &ComputedColliderShape) -> Option<Self> {
         let vertices_indices = extract_mesh_vertices_indices(mesh);
         match collider_shape {
@@ -729,8 +726,7 @@ impl Default for Collider {
     }
 }
 
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 #[allow(clippy::type_complexity)]
 fn extract_mesh_vertices_indices(mesh: &Mesh) -> Option<(Vec<na::Point3<Real>>, Vec<[u32; 3]>)> {
     use rapier::na::point;

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -96,6 +96,8 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                             .after(systems::apply_initial_rigid_body_impulses),
                     );
 
+                    
+                #[cfg(not(feature = "headless"))]
                 #[cfg(feature = "dim3")]
                 {
                     systems.with_system(
@@ -103,6 +105,10 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                     )
                 }
                 #[cfg(not(feature = "dim3"))]
+                {
+                    systems
+                }
+                #[cfg(feature = "headless")]
                 {
                     systems
                 }

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -96,9 +96,7 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                             .after(systems::apply_initial_rigid_body_impulses),
                     );
 
-                    
-                #[cfg(not(feature = "headless"))]
-                #[cfg(feature = "dim3")]
+                #[cfg(all(feature = "dim3", feature = "async-collider"))]
                 {
                     systems.with_system(
                         systems::init_async_scene_colliders.before(systems::init_async_colliders),

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -26,6 +26,7 @@ use bevy::prelude::*;
 use rapier::prelude::*;
 use std::collections::HashMap;
 
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 use crate::prelude::{AsyncCollider, AsyncSceneCollider};
 
@@ -646,11 +647,18 @@ pub fn step_simulation<PhysicsHooksData: 'static + WorldQuery + Send + Sync>(
 }
 
 /// NOTE: This currently does nothing in 2D.
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim2")]
+pub fn init_async_colliders() {}
+
+/// NOTE: This does nothing in 3D with headless.
+#[cfg(feature = "headless")]
+#[cfg(feature = "dim3")]
 pub fn init_async_colliders() {}
 
 /// System responsible for creating `Collider` components from `AsyncCollider` components if the
 /// corresponding mesh has become available.
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 pub fn init_async_colliders(
     mut commands: Commands,
@@ -674,6 +682,7 @@ pub fn init_async_colliders(
 
 /// System responsible for creating `Collider` components from `AsyncSceneCollider` components if the
 /// corresponding scene has become available.
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 pub fn init_async_scene_colliders(
     mut commands: Commands,
@@ -712,6 +721,7 @@ pub fn init_async_scene_colliders(
 }
 
 /// Iterates over all descendants of the `entity` and applies `f`.
+#[cfg(not(feature = "headless"))]
 #[cfg(feature = "dim3")]
 fn traverse_descendants(entity: Entity, children: &Query<&Children>, f: &mut impl FnMut(Entity)) {
     if let Ok(entity_children) = children.get(entity) {
@@ -1355,6 +1365,7 @@ pub fn update_character_controls(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "headless"))]
     #[cfg(feature = "dim3")]
     use bevy::prelude::shape::{Capsule, Cube};
     use bevy::{
@@ -1370,6 +1381,7 @@ mod tests {
 
     use super::*;
     use crate::plugin::{NoUserData, RapierPhysicsPlugin};
+    #[cfg(not(feature = "headless"))]
     #[cfg(feature = "dim3")]
     use crate::prelude::ComputedColliderShape;
 
@@ -1460,6 +1472,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "headless"))]
     #[cfg(feature = "dim3")]
     fn async_collider_initializes() {
         let mut app = App::new();
@@ -1491,6 +1504,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "headless"))]
     #[cfg(feature = "dim3")]
     fn async_scene_collider_initializes() {
         let mut app = App::new();

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -26,8 +26,7 @@ use bevy::prelude::*;
 use rapier::prelude::*;
 use std::collections::HashMap;
 
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 use crate::prelude::{AsyncCollider, AsyncSceneCollider};
 
 use crate::control::CharacterCollision;
@@ -647,7 +646,7 @@ pub fn step_simulation<PhysicsHooksData: 'static + WorldQuery + Send + Sync>(
 }
 
 /// NOTE: This currently does nothing in 2D.
-#[cfg(not(feature = "headless"))]
+#[cfg(feature = "async-collider")]
 #[cfg(feature = "dim2")]
 pub fn init_async_colliders() {}
 
@@ -658,8 +657,7 @@ pub fn init_async_colliders() {}
 
 /// System responsible for creating `Collider` components from `AsyncCollider` components if the
 /// corresponding mesh has become available.
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 pub fn init_async_colliders(
     mut commands: Commands,
     meshes: Res<Assets<Mesh>>,
@@ -682,8 +680,7 @@ pub fn init_async_colliders(
 
 /// System responsible for creating `Collider` components from `AsyncSceneCollider` components if the
 /// corresponding scene has become available.
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 pub fn init_async_scene_colliders(
     mut commands: Commands,
     meshes: Res<Assets<Mesh>>,
@@ -721,8 +718,7 @@ pub fn init_async_scene_colliders(
 }
 
 /// Iterates over all descendants of the `entity` and applies `f`.
-#[cfg(not(feature = "headless"))]
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
 fn traverse_descendants(entity: Entity, children: &Query<&Children>, f: &mut impl FnMut(Entity)) {
     if let Ok(entity_children) = children.get(entity) {
         for child in entity_children.iter().copied() {
@@ -1365,8 +1361,7 @@ pub fn update_character_controls(
 
 #[cfg(test)]
 mod tests {
-    #[cfg(not(feature = "headless"))]
-    #[cfg(feature = "dim3")]
+    #[cfg(all(feature = "dim3", feature = "async-collider"))]
     use bevy::prelude::shape::{Capsule, Cube};
     use bevy::{
         asset::AssetPlugin,
@@ -1381,8 +1376,7 @@ mod tests {
 
     use super::*;
     use crate::plugin::{NoUserData, RapierPhysicsPlugin};
-    #[cfg(not(feature = "headless"))]
-    #[cfg(feature = "dim3")]
+    #[cfg(all(feature = "dim3", feature = "async-collider"))]
     use crate::prelude::ComputedColliderShape;
 
     #[test]
@@ -1472,8 +1466,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "headless"))]
-    #[cfg(feature = "dim3")]
+    #[cfg(all(feature = "dim3", feature = "async-collider"))]
     fn async_collider_initializes() {
         let mut app = App::new();
         app.add_plugin(HeadlessRenderPlugin)
@@ -1504,8 +1497,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "headless"))]
-    #[cfg(feature = "dim3")]
+    #[cfg(all(feature = "dim3", feature = "async-collider"))]
     fn async_scene_collider_initializes() {
         let mut app = App::new();
         app.add_plugin(HeadlessRenderPlugin)


### PR DESCRIPTION
This pull request should fix headless bevy by disabling the async collider functionality when enabled by the new `headless` feature.

Done a quick test and it seems to resolve this issue: https://github.com/dimforge/bevy_rapier/issues/296