### PR TITLE
Add the ability to enable/disable colliders or rigid-bodies without removing them from the scene

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -26,7 +26,7 @@ parallel = [ "rapier2d/parallel" ]
 simd-stable = [ "rapier2d/simd-stable" ]
 simd-nightly = [ "rapier2d/simd-nightly" ]
 wasm-bindgen = [ "rapier2d/wasm-bindgen" ]
-serde-serialize = [ "rapier2d/serde-serialize", "serde" ]
+serde-serialize = [ "rapier2d/serde-serialize", "bevy/serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 
 # Enables the AsyncCollider and AsyncSceneCollider components that wait for specific
@@ -38,9 +38,9 @@ async-collider = [ ]
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
-nalgebra = { version = "^0.31.4", features = [ "convert-glam022" ] }
+nalgebra = { version = "0.32.0", features = [ "convert-glam022" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = "0.16.0"
+rapier2d = "0.17.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", optional = true }
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -27,7 +27,7 @@ parallel = [ "rapier3d/parallel" ]
 simd-stable = [ "rapier3d/simd-stable" ]
 simd-nightly = [ "rapier3d/simd-nightly" ]
 wasm-bindgen = [ "rapier3d/wasm-bindgen" ]
-serde-serialize = [ "rapier3d/serde-serialize", "serde" ]
+serde-serialize = [ "rapier3d/serde-serialize", "bevy/serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 headless = [ ]
 
@@ -39,9 +39,9 @@ async-collider = [ ]
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false, features = ["bevy_asset", "bevy_scene"] }
-nalgebra = { version = "^0.31.4", features = [ "convert-glam022" ] }
+nalgebra = { version = "^0.32.0", features = [ "convert-glam022" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = "0.16.0"
+rapier3d = "0.17.0"
 bitflags = "1"
 #bevy_prototype_debug_lines = { version = "0.6", features = ["3d"], optional = true }
 log = "0.4"

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -11,6 +11,7 @@ pub struct RapierRigidBodyHandle(pub RigidBodyHandle);
 
 /// A rigid-body.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Component, Reflect, FromReflect)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[reflect(Component, PartialEq)]
 pub enum RigidBody {
     /// A `RigidBody::Dynamic` body can be affected by all external forces.
@@ -50,12 +51,24 @@ impl From<RigidBody> for RigidBodyType {
     }
 }
 
+impl From<RigidBodyType> for RigidBody {
+    fn from(rigid_body: RigidBodyType) -> RigidBody {
+        match rigid_body {
+            RigidBodyType::Dynamic => RigidBody::Dynamic,
+            RigidBodyType::Fixed => RigidBody::Fixed,
+            RigidBodyType::KinematicPositionBased => RigidBody::KinematicPositionBased,
+            RigidBodyType::KinematicVelocityBased => RigidBody::KinematicVelocityBased,
+        }
+    }
+}
+
 /// The velocity of a rigid-body.
 ///
 /// Use this component to control and/or read the velocity of a dynamic or kinematic rigid-body.
 /// If this component isn’t present, a dynamic rigid-body will still be able to move (you will just
 /// not be able to read/modify its velocity).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect, FromReflect)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[reflect(Component, PartialEq)]
 pub struct Velocity {
     /// The linear velocity of the rigid-body.
@@ -503,3 +516,8 @@ impl TransformInterpolation {
         }
     }
 }
+
+/// Indicates whether or not the rigid-body is disabled explicitly by the user.
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
+pub struct RigidBodyDisabled;

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -64,6 +64,7 @@ pub enum ComputedColliderShape {
 /// A geometric entity that can be attached to a body so it can be affected by contacts
 /// and intersection queries.
 #[derive(Component, Clone)] // TODO: Reflect
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct Collider {
     /// The raw shape from Rapier.
     pub raw: SharedShape,
@@ -499,6 +500,11 @@ impl CollidingEntities {
         self.0.iter().copied()
     }
 }
+
+/// Indicates whether or not the collider is disabled explicitly by the user.
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Component, Reflect, FromReflect)]
+#[reflect(Component, PartialEq)]
+pub struct ColliderDisabled;
 
 /// We restrict the scaling increment to 1.0e-4, to avoid numerical jitter
 /// due to the extraction of scaling factor from the GlobalTransform matrix.

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -325,8 +325,7 @@ impl RapierContext {
     /// Updates the state of the query pipeline, based on the collider positions known
     /// from the last timestep or the last call to `self.propagate_modified_body_positions_to_colliders()`.
     pub fn update_query_pipeline(&mut self) {
-        self.query_pipeline
-            .update(&self.bodies, &self.colliders);
+        self.query_pipeline.update(&self.bodies, &self.colliders);
     }
 
     /// The map from entities to rigid-body handles.

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -254,6 +254,7 @@ impl RapierContext {
                             &mut self.impulse_joints,
                             &mut self.multibody_joints,
                             &mut self.ccd_solver,
+                            None,
                             hooks,
                             events,
                         );
@@ -283,6 +284,7 @@ impl RapierContext {
                         &mut self.impulse_joints,
                         &mut self.multibody_joints,
                         &mut self.ccd_solver,
+                        None,
                         hooks,
                         events,
                     );
@@ -304,6 +306,7 @@ impl RapierContext {
                         &mut self.impulse_joints,
                         &mut self.multibody_joints,
                         &mut self.ccd_solver,
+                        None,
                         hooks,
                         events,
                     );
@@ -323,7 +326,7 @@ impl RapierContext {
     /// from the last timestep or the last call to `self.propagate_modified_body_positions_to_colliders()`.
     pub fn update_query_pipeline(&mut self) {
         self.query_pipeline
-            .update(&self.islands, &self.bodies, &self.colliders);
+            .update(&self.bodies, &self.colliders);
     }
 
     /// The map from entities to rigid-body handles.

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -859,8 +859,10 @@ pub fn init_colliders(
                 // Inserting the collider changed the rigid-body’s mass properties.
                 // Read them back from the engine.
                 if let Some(parent_body) = context.bodies.get(body_handle) {
-                    mprops.0 =
-                        MassProperties::from_rapier(*parent_body.mass_properties(), physics_scale);
+                    mprops.0 = MassProperties::from_rapier(
+                        parent_body.mass_properties().local_mprops,
+                        physics_scale,
+                    );
                 }
             }
             handle

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -7,9 +7,9 @@ use crate::dynamics::{
     ReadMassProperties, RigidBody, Sleeping, TransformInterpolation, Velocity,
 };
 use crate::geometry::{
-    ActiveCollisionTypes, ActiveEvents, ActiveHooks, Collider, ColliderMassProperties,
-    ColliderScale, CollisionGroups, ContactForceEventThreshold, Friction, RapierColliderHandle,
-    Restitution, Sensor, SolverGroups,
+    ActiveCollisionTypes, ActiveEvents, ActiveHooks, Collider, ColliderDisabled,
+    ColliderMassProperties, ColliderScale, CollisionGroups, ContactForceEventThreshold, Friction,
+    RapierColliderHandle, Restitution, Sensor, SolverGroups,
 };
 use crate::pipeline::{
     CollisionEvent, ContactForceEvent, PhysicsHooksWithQueryInstance, PhysicsHooksWithQueryResource,
@@ -17,8 +17,8 @@ use crate::pipeline::{
 use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
 use crate::plugin::{RapierConfiguration, RapierContext};
 use crate::prelude::{
-    get_snapped_scale, CollidingEntities, KinematicCharacterController,
-    KinematicCharacterControllerOutput,
+    CollidingEntities, KinematicCharacterController, KinematicCharacterControllerOutput,
+    RigidBodyDisabled,
 };
 use crate::utils;
 use bevy::ecs::query::WorldQuery;
@@ -58,6 +58,7 @@ pub type RigidBodyComponents<'a> = (
     Option<&'a Dominance>,
     Option<&'a Sleeping>,
     Option<&'a Damping>,
+    Option<&'a RigidBodyDisabled>,
 );
 
 /// Components related to colliders.
@@ -74,6 +75,7 @@ pub type ColliderComponents<'a> = (
     Option<&'a CollisionGroups>,
     Option<&'a SolverGroups>,
     Option<&'a ContactForceEventThreshold>,
+    Option<&'a ColliderDisabled>,
 );
 
 /// System responsible for applying [`GlobalTransform::scale`] and/or [`ColliderScale`] to
@@ -108,7 +110,7 @@ pub fn apply_scale(
             None => transform.compute_transform().scale,
         };
 
-        if shape.scale != get_snapped_scale(effective_scale) {
+        if shape.scale != crate::geometry::get_snapped_scale(effective_scale) {
             shape.set_scale(effective_scale, config.scaled_shape_subdivision);
         }
     }
@@ -137,6 +139,7 @@ pub fn apply_collider_user_changes(
     >,
     changed_solver_groups: Query<(&RapierColliderHandle, &SolverGroups), Changed<SolverGroups>>,
     changed_sensors: Query<(&RapierColliderHandle, &Sensor), Changed<Sensor>>,
+    changed_disabled: Query<(&RapierColliderHandle, &ColliderDisabled), Changed<ColliderDisabled>>,
     changed_contact_force_threshold: Query<
         (&RapierColliderHandle, &ContactForceEventThreshold),
         Changed<ContactForceEventThreshold>,
@@ -217,6 +220,12 @@ pub fn apply_collider_user_changes(
         }
     }
 
+    for (handle, _) in changed_disabled.iter() {
+        if let Some(co) = context.colliders.get_mut(handle.0) {
+            co.set_enabled(false);
+        }
+    }
+
     for (handle, threshold) in changed_contact_force_threshold.iter() {
         if let Some(co) = context.colliders.get_mut(handle.0) {
             co.set_contact_force_event_threshold(threshold.0);
@@ -265,6 +274,10 @@ pub fn apply_rigid_body_user_changes(
     changed_dominance: Query<(&RapierRigidBodyHandle, &Dominance), Changed<Dominance>>,
     changed_sleeping: Query<(&RapierRigidBodyHandle, &Sleeping), Changed<Sleeping>>,
     changed_damping: Query<(&RapierRigidBodyHandle, &Damping), Changed<Damping>>,
+    changed_disabled: Query<
+        (&RapierRigidBodyHandle, &RigidBodyDisabled),
+        Changed<RigidBodyDisabled>,
+    >,
 ) {
     let context = &mut *context;
     let scale = context.physics_scale;
@@ -293,7 +306,7 @@ pub fn apply_rigid_body_user_changes(
     //       position instead of the current one.
     for (handle, rb_type) in changed_rb_types.iter() {
         if let Some(rb) = context.bodies.get_mut(handle.0) {
-            rb.set_body_type((*rb_type).into());
+            rb.set_body_type((*rb_type).into(), true);
         }
     }
 
@@ -426,6 +439,12 @@ pub fn apply_rigid_body_user_changes(
         if let Some(rb) = context.bodies.get_mut(handle.0) {
             rb.set_linear_damping(damping.linear_damping);
             rb.set_angular_damping(damping.angular_damping);
+        }
+    }
+
+    for (handle, _) in changed_disabled.iter() {
+        if let Some(co) = context.bodies.get_mut(handle.0) {
+            co.set_enabled(false);
         }
     }
 }
@@ -754,6 +773,7 @@ pub fn init_colliders(
             collision_groups,
             solver_groups,
             contact_force_event_threshold,
+            disabled,
         ),
         global_transform,
     ) in colliders.iter()
@@ -763,6 +783,7 @@ pub fn init_colliders(
         let mut builder = ColliderBuilder::new(scaled_shape.raw.clone());
 
         builder = builder.sensor(sensor.is_some());
+        builder = builder.enabled(disabled.is_none());
 
         if let Some(mprops) = mprops {
             builder = match mprops {
@@ -879,9 +900,12 @@ pub fn init_rigid_bodies(
         dominance,
         sleep,
         damping,
+        disabled,
     ) in rigid_bodies.iter()
     {
         let mut builder = RigidBodyBuilder::new((*rb).into());
+        builder = builder.enabled(disabled.is_none());
+
         if let Some(transform) = transform {
             builder = builder.position(utils::transform_to_iso(
                 &transform.compute_transform(),
@@ -1072,6 +1096,8 @@ pub fn sync_removals(
     >,
 
     removed_sensors: RemovedComponents<Sensor>,
+    removed_rigid_body_disabled: RemovedComponents<RigidBodyDisabled>,
+    removed_colliders_disabled: RemovedComponents<ColliderDisabled>,
 ) {
     /*
      * Rigid-bodies removal detection.
@@ -1164,12 +1190,28 @@ pub fn sync_removals(
     }
 
     /*
-     * Sensor marker component removal detection.
+     * Marker components removal detection.
      */
     for entity in removed_sensors.iter() {
         if let Some(handle) = context.entity2collider.get(&entity) {
             if let Some(co) = context.colliders.get_mut(*handle) {
                 co.set_sensor(false);
+            }
+        }
+    }
+
+    for entity in removed_colliders_disabled.iter() {
+        if let Some(handle) = context.entity2collider.get(&entity) {
+            if let Some(co) = context.colliders.get_mut(*handle) {
+                co.set_enabled(true);
+            }
+        }
+    }
+
+    for entity in removed_rigid_body_disabled.iter() {
+        if let Some(handle) = context.entity2body.get(&entity) {
+            if let Some(rb) = context.bodies.get_mut(*handle) {
+                rb.set_enabled(true);
             }
         }
     }


### PR DESCRIPTION
This adds the `RigidBodyDisabled` and `ColliderDisabled` component that can be inserted to enable/disable a rigid-body or collider without removing it from the scene.