### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.20.0 (15 Jan. 2023)
+### Added
+- Add the `RigidBodyDisabled` and `ColliderDisabled` component that can be inserted to disable a rigid-body
+  or collider without removing it from the scene.
+
+### Fix
+- Fix spawn position of colliders without rigid bodies.
+- Fix overriding enabled flag in debug render.
+
+### Modified
+- Make debug-rendering enabled by default when inserting the `RapierDebugRenderPlugin` plugin with its default configuration.
+- The `debug-render` feature has been replaced by two features: `debug-render-2d` and `debug-render-3d`. For example, 
+  using `debug-render-2d` with `bevy_rapier3d`, the debug-render will work with 2D cameras (useful, e.g., for top-down games
+  with 3D graphics).
+- In order to facilitate the use of `bevy_rapier` in headless mode, the `AsyncCollider` and `AsyncSceneCollider`
+  components were moved behind the `async-collider` feature (enabled by default). Disabling that feature will
+  make `bevy_rapier` work even with the `MinimalPlugins` inserted insetad of the `DefaultPlugins`.
+- Corrected an API inconsistency where `bevy_rapier` components would sometimes require an `InteracitonGroup` type defined in
+  `rapier`. It has been replaced by the `CollisionGroup` type (defined in `bevy_rapier`).
+- `Velocity::zero,linear,angular` are now const-fn.
+
 ## 0.19.0 (18 Nov. 2022)
 ### Modified
 - Update to Bevy 0.9

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"


### PR DESCRIPTION
### Added
- Add the `RigidBodyDisabled` and `ColliderDisabled` component that can be inserted to disable a rigid-body
  or collider without removing it from the scene.

### Fix
- Fix spawn position of colliders without rigid bodies.
- Fix overriding enabled flag in debug render.

### Modified
- Make debug-rendering enabled by default when inserting the `RapierDebugRenderPlugin` plugin with its default configuration.
- The `debug-render` feature has been replaced by two features: `debug-render-2d` and `debug-render-3d`. For example, 
  using `debug-render-2d` with `bevy_rapier3d`, the debug-render will work with 2D cameras (useful, e.g., for top-down games
  with 3D graphics).
- In order to facilitate the use of `bevy_rapier` in headless mode, the `AsyncCollider` and `AsyncSceneCollider`
  components were moved behind the `async-collider` feature (enabled by default). Disabling that feature will
  make `bevy_rapier` work even with the `MinimalPlugins` inserted insetad of the `DefaultPlugins`.
- Corrected an API inconsistency where `bevy_rapier` components would sometimes require an `InteracitonGroup` type defined in
  `rapier`. It has been replaced by the `CollisionGroup` type (defined in `bevy_rapier`).
- `Velocity::zero,linear,angular` are now const-fn.