### PR TITLE
Fix Systems For Async Colliders

### DIFF
--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -29,7 +29,6 @@ simd-nightly = [ "rapier3d/simd-nightly" ]
 wasm-bindgen = [ "rapier3d/wasm-bindgen" ]
 serde-serialize = [ "rapier3d/serde-serialize", "bevy/serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
-headless = [ ]
 
 # Enables the AsyncCollider and AsyncSceneCollider components that wait for specific
 # assets to be loaded before creating the actual Collider.

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -77,15 +77,24 @@ where
                     .after(systems::update_character_controls)
                     .in_set(PropagateTransformsSet)
                     .in_set(RapierTransformPropagateSet),
+                #[cfg(feature = "async-collider")]
                 systems::init_async_colliders.after(RapierTransformPropagateSet),
+                #[cfg(feature = "async-collider")]
                 systems::apply_scale.after(systems::init_async_colliders),
+                #[cfg(not(feature = "async-collider"))]
+                systems::apply_scale.after(RapierTransformPropagateSet),
                 systems::apply_collider_user_changes.after(systems::apply_scale),
                 systems::apply_rigid_body_user_changes.after(systems::apply_collider_user_changes),
                 systems::apply_joint_user_changes.after(systems::apply_rigid_body_user_changes),
                 systems::init_rigid_bodies.after(systems::apply_joint_user_changes),
+                #[cfg(feature = "async-collider")]
                 systems::init_colliders
                     .after(systems::init_rigid_bodies)
                     .after(systems::init_async_colliders),
+                #[cfg(not(feature = "async-collider"))]
+                systems::init_colliders
+                    .after(systems::init_rigid_bodies)
+                    .after(RapierTransformPropagateSet),
                 systems::init_joints.after(systems::init_colliders),
                 systems::apply_initial_rigid_body_impulses.after(systems::init_colliders),
                 systems::sync_removals

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -58,17 +58,31 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
     pub fn get_systems(stage: PhysicsStages) -> SystemSet {
         match stage {
             PhysicsStages::SyncBackend => {
-                let systems = SystemSet::new()
+                let mut systems = SystemSet::new()
                     .with_system(systems::update_character_controls) // Run the character controller befor ethe manual transform propagation.
                     .with_system(
                         bevy::transform::transform_propagate_system
                             .after(systems::update_character_controls),
-                    ) // Run Bevy transform propagation additionally to sync [`GlobalTransform`]
-                    .with_system(
-                        systems::init_async_colliders
-                            .after(bevy::transform::transform_propagate_system),
+                    ); // Run Bevy transform propagation additionally to sync [`GlobalTransform`]
+
+                #[cfg(feature = "async-collider")]
+                {
+                    systems = systems
+                        .with_system(
+                            systems::init_async_colliders
+                                .after(bevy::transform::transform_propagate_system),
+                        )
+                        .with_system(systems::apply_scale.after(systems::init_async_colliders))
+                }
+
+                #[cfg(not(feature = "async-collider"))]
+                {
+                    systems = systems.with_system(
+                        systems::apply_scale.after(bevy::transform::transform_propagate_system),
                     )
-                    .with_system(systems::apply_scale.after(systems::init_async_colliders))
+                }
+
+                systems = systems
                     .with_system(systems::apply_collider_user_changes.after(systems::apply_scale))
                     .with_system(
                         systems::apply_rigid_body_user_changes
@@ -80,12 +94,27 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
                     )
                     .with_system(
                         systems::init_rigid_bodies.after(systems::apply_joint_user_changes),
-                    )
-                    .with_system(
+                    );
+
+                #[cfg(feature = "async-collider")]
+                {
+                    systems = systems.with_system(
                         systems::init_colliders
                             .after(systems::init_rigid_bodies)
                             .after(systems::init_async_colliders),
-                    )
+                    );
+                }
+
+                #[cfg(not(feature = "async-collider"))]
+                {
+                    systems = systems.with_system(
+                        systems::init_colliders
+                            .after(systems::init_rigid_bodies)
+                            .after(bevy::transform::transform_propagate_system),
+                    );
+                }
+
+                systems = systems
                     .with_system(systems::init_joints.after(systems::init_colliders))
                     .with_system(
                         systems::apply_initial_rigid_body_impulses.after(systems::init_colliders),
@@ -98,18 +127,12 @@ impl<PhysicsHooksData: 'static + WorldQuery + Send + Sync> RapierPhysicsPlugin<P
 
                 #[cfg(all(feature = "dim3", feature = "async-collider"))]
                 {
-                    systems.with_system(
+                    systems = systems.with_system(
                         systems::init_async_scene_colliders.before(systems::init_async_colliders),
-                    )
+                    );
                 }
-                #[cfg(not(feature = "dim3"))]
-                {
-                    systems
-                }
-                #[cfg(feature = "headless")]
-                {
-                    systems
-                }
+
+                systems
             }
             PhysicsStages::StepSimulation => SystemSet::new()
                 .with_system(systems::step_simulation::<PhysicsHooksData>)

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -669,11 +669,6 @@ pub fn step_simulation<PhysicsHooksData: 'static + WorldQuery + Send + Sync>(
 #[cfg(feature = "dim2")]
 pub fn init_async_colliders() {}
 
-/// NOTE: This does nothing in 3D with headless.
-#[cfg(feature = "headless")]
-#[cfg(feature = "dim3")]
-pub fn init_async_colliders() {}
-
 /// System responsible for creating `Collider` components from `AsyncCollider` components if the
 /// corresponding mesh has become available.
 #[cfg(all(feature = "dim3", feature = "async-collider"))]


### PR DESCRIPTION
This is a quick little fix to adjust which systems get added for the async colliders. Tested it with and without the feature and it seems to be working perfectly in headless with these changes.

I'm not 100% sure if these systems that I've adjusted all require being after Bevy's `transform_propagate_system` so I've just retained the order as if `init_async_colliders` was still there.

Resolves the problem mentioned here:
https://github.com/dimforge/bevy_rapier/pull/306#issuecomment-1383206963