### PR TITLE
Exclude sensor collision by default from KinematicCharacterController

### DIFF
--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -180,7 +180,7 @@ impl Default for KinematicCharacterController {
             min_slope_slide_angle: def.min_slope_slide_angle,
             apply_impulse_to_dynamic_bodies: true,
             snap_to_ground: def.snap_to_ground,
-            filter_flags: QueryFilterFlags::default(),
+            filter_flags: QueryFilterFlags::default() | QueryFilterFlags::EXCLUDE_SENSORS,
             filter_groups: None,
         }
     }


### PR DESCRIPTION
I think this fixes an issue someone opened, but I couldn't find it. Anyways, it doesn't make sense for a `KinematicCharacterController` to be physically colliding / displaced by sensors, so let's change the default.

Edit: Resolves #351