### PR TITLE
Use SystemParam for physics hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+### Modified
+- The `PhysicsHooksWithQuery` trait has been renamed to by the `BevyPhysicsHooks`.
+- Bevy resources and queries accessed by the physics hook are now specified by the implementor of `BevyPhysicsHooks`
+  which must derive Bevy’s `SystemParam` trait. This implies that the physics hook’s `filter_contact_pair` (and
+  all its other methods) no longer take the Bevy `Query` as argument. Queries and resources are accessed through
+  `self`.
+
 ## 0.20.0 (15 Jan. 2023)
 ### Added
 - Add the `RigidBodyDisabled` and `ColliderDisabled` component that can be inserted to disable a rigid-body

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{ecs::system::SystemParam, prelude::*};
 use bevy_rapier2d::prelude::*;
 
 #[derive(PartialEq, Eq, Clone, Copy, Component)]
@@ -11,15 +11,15 @@ enum CustomFilterTag {
 // same user_data value.
 // Note that using collision groups would be a more efficient way of doing
 // this, but we use custom filters instead for demonstration purpose.
-struct SameUserDataFilter;
-impl<'a> PhysicsHooksWithQuery<&'a CustomFilterTag> for SameUserDataFilter {
-    fn filter_contact_pair(
-        &self,
-        context: PairFilterContextView,
-        tags: &Query<&'a CustomFilterTag>,
-    ) -> Option<SolverFlags> {
-        if tags.get(context.collider1()).ok().copied()
-            == tags.get(context.collider2()).ok().copied()
+#[derive(SystemParam)]
+struct SameUserDataFilter<'w, 's> {
+    tags: Query<'w, 's, &'static CustomFilterTag>,
+}
+
+impl BevyPhysicsHooks for SameUserDataFilter<'_, '_> {
+    fn filter_contact_pair(&self, context: PairFilterContextView) -> Option<SolverFlags> {
+        if self.tags.get(context.collider1()).ok().copied()
+            == self.tags.get(context.collider2()).ok().copied()
         {
             Some(SolverFlags::COMPUTE_IMPULSES)
         } else {
@@ -36,7 +36,7 @@ fn main() {
             0xFF as f32 / 255.0,
         )))
         .add_plugins(DefaultPlugins)
-        .add_plugin(RapierPhysicsPlugin::<&CustomFilterTag>::pixels_per_meter(
+        .add_plugin(RapierPhysicsPlugin::<SameUserDataFilter>::pixels_per_meter(
             100.0,
         ))
         .add_plugin(RapierDebugRenderPlugin::default())
@@ -56,10 +56,6 @@ pub fn setup_physics(mut commands: Commands) {
     /*
      * Ground
      */
-    commands.insert_resource(PhysicsHooksWithQueryResource(Box::new(
-        SameUserDataFilter {},
-    )));
-
     let ground_size = 100.0;
 
     commands.spawn((

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,9 +1,8 @@
 pub(crate) use self::events::EventQueue;
 pub use self::events::{CollisionEvent, ContactForceEvent};
-pub(crate) use self::physics_hooks::PhysicsHooksWithQueryInstance;
+pub(crate) use self::physics_hooks::BevyPhysicsHooksAdapter;
 pub use self::physics_hooks::{
-    ContactModificationContextView, PairFilterContextView, PhysicsHooksWithQuery,
-    PhysicsHooksWithQueryResource,
+    BevyPhysicsHooks, ContactModificationContextView, PairFilterContextView,
 };
 pub use query_filter::{QueryFilter, QueryFilterFlags};
 

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -168,34 +168,6 @@ pub enum PhysicsStages {
     DetectDespawn,
 }
 
-// mod foo {
-//     use std::marker::PhantomData;
-
-//     use bevy::{
-//         ecs::system::{SystemParam, SystemParamItem},
-//         prelude::*,
-//     };
-
-//     struct MyPlugin<T: SystemParam>(PhantomData<T>);
-
-//     impl<T> Plugin for MyPlugin<T>
-//     where
-//         T: 'static + SystemParam + Send + Sync,
-//         for<'w, 's> SystemParamItem<'w, 's, T>: 'static,
-//     {
-//         fn build(&self, app: &mut App) {}
-//     }
-
-//     #[derive(SystemParam)]
-//     struct MySystemParam<'w, 's> {
-//         tags: Query<'w, 's, Entity>,
-//     }
-
-//     fn main() {
-//         App::new().add_plugin(MyPlugin::<MySystemParam>(PhantomData));
-//     }
-// }
-
 impl<PhysicsHooks> Plugin for RapierPhysicsPlugin<PhysicsHooks>
 where
     PhysicsHooks: 'static + BevyPhysicsHooks,

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -11,17 +11,15 @@ use crate::geometry::{
     ColliderMassProperties, ColliderScale, CollisionGroups, ContactForceEventThreshold, Friction,
     RapierColliderHandle, Restitution, Sensor, SolverGroups,
 };
-use crate::pipeline::{
-    CollisionEvent, ContactForceEvent, PhysicsHooksWithQueryInstance, PhysicsHooksWithQueryResource,
-};
+use crate::pipeline::{CollisionEvent, ContactForceEvent};
 use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
 use crate::plugin::{RapierConfiguration, RapierContext};
 use crate::prelude::{
-    CollidingEntities, KinematicCharacterController, KinematicCharacterControllerOutput,
-    RigidBodyDisabled,
+    BevyPhysicsHooks, BevyPhysicsHooksAdapter, CollidingEntities, KinematicCharacterController,
+    KinematicCharacterControllerOutput, RigidBodyDisabled,
 };
 use crate::utils;
-use bevy::ecs::query::WorldQuery;
+use bevy::ecs::system::SystemParamItem;
 use bevy::prelude::*;
 use rapier::prelude::*;
 use std::collections::HashMap;
@@ -627,29 +625,27 @@ pub fn writeback_rigid_bodies(
 
 /// System responsible for advancing the physics simulation, and updating the internal state
 /// for scene queries.
-pub fn step_simulation<PhysicsHooksData: 'static + WorldQuery + Send + Sync>(
+pub fn step_simulation<PhysicsHooks>(
     mut context: ResMut<RapierContext>,
     config: Res<RapierConfiguration>,
-    hooks: Res<PhysicsHooksWithQueryResource<PhysicsHooksData>>,
+    hooks: SystemParamItem<PhysicsHooks>,
     (time, mut sim_to_render_time): (Res<Time>, ResMut<SimulationToRenderTime>),
     collision_events: EventWriter<CollisionEvent>,
     contact_force_events: EventWriter<ContactForceEvent>,
-    hooks_data: Query<PhysicsHooksData>,
     interpolation_query: Query<(&RapierRigidBodyHandle, &mut TransformInterpolation)>,
-) {
+) where
+    PhysicsHooks: 'static + BevyPhysicsHooks,
+    for<'w, 's> SystemParamItem<'w, 's, PhysicsHooks>: BevyPhysicsHooks,
+{
     let context = &mut *context;
+    let hooks_adapter = BevyPhysicsHooksAdapter::<PhysicsHooks>::new(hooks);
 
     if config.physics_pipeline_active {
-        let hooks_instance = PhysicsHooksWithQueryInstance {
-            user_data: hooks_data,
-            hooks: &*hooks.0,
-        };
-
         context.step_simulation(
             config.gravity,
             config.timestep_mode,
             Some((collision_events, contact_force_events)),
-            &hooks_instance,
+            &hooks_adapter,
             &time,
             &mut sim_to_render_time,
             Some(interpolation_query),


### PR DESCRIPTION
Use `SystemParam` instead of `WorldQuery` to allow more flexible `World` access by physics hooks

The new API doesn't use a `Resource` to hold the physics hooks' user data anymore. Instead, the user data is the `SystemParam` itself. This `SystemParam` can include access to a `Resource` if needed, so no functionality is lost here.

`PhysicsHooksWithQuery` has been renamed `BevyPhysicsHooks` as it no longer has a query type associated with it - instead, `BevyPhysicsHooks` and `SystemParam` are both implemented by the user onto the same type. Now the only real difference between `rapier::PhysicsHooks` and `bevy_rapier::BevyPhysicsHooks` is that the latter allows the user to use the "get entity" helper methods on `PairFilterContextView` and `ContactModificationContextView`.