### PR TITLE
Fix rigid_body_writeback performance scaling

### DIFF
--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -36,7 +36,7 @@ use bevy::math::Vec3Swizzles;
 
 /// Components that will be updated after a physics step.
 pub type RigidBodyWritebackComponents<'a> = (
-    Entity,
+    &'a RapierRigidBodyHandle,
     Option<&'a Parent>,
     Option<&'a mut Transform>,
     Option<&'a mut TransformInterpolation>,
@@ -495,130 +495,130 @@ pub fn writeback_rigid_bodies(
     let scale = context.physics_scale;
 
     if config.physics_pipeline_active {
-        for (entity, parent, transform, mut interpolation, mut velocity, mut sleeping) in
+        for (handle, parent, transform, mut interpolation, mut velocity, mut sleeping) in
             writeback.iter_mut()
         {
+            let handle = handle.0;
+
             // TODO: do this the other way round: iterate through Rapier’s RigidBodySet on the active bodies,
             // and update the components accordingly. That way, we don’t have to iterate through the entities that weren’t changed
             // by physics (for example because they are sleeping).
-            if let Some(handle) = context.entity2body.get(&entity).copied() {
-                if let Some(rb) = context.bodies.get(handle) {
-                    let mut interpolated_pos = utils::iso_to_transform(rb.position(), scale);
+            if let Some(rb) = context.bodies.get(handle) {
+                let mut interpolated_pos = utils::iso_to_transform(rb.position(), scale);
 
-                    if let TimestepMode::Interpolated { dt, .. } = config.timestep_mode {
-                        if let Some(interpolation) = interpolation.as_deref_mut() {
-                            if interpolation.end.is_none() {
-                                interpolation.end = Some(*rb.position());
-                            }
-
-                            if let Some(interpolated) =
-                                interpolation.lerp_slerp((dt + sim_to_render_time.diff) / dt)
-                            {
-                                interpolated_pos = utils::iso_to_transform(&interpolated, scale);
-                            }
+                if let TimestepMode::Interpolated { dt, .. } = config.timestep_mode {
+                    if let Some(interpolation) = interpolation.as_deref_mut() {
+                        if interpolation.end.is_none() {
+                            interpolation.end = Some(*rb.position());
                         }
-                    }
 
-                    if let Some(mut transform) = transform {
-                        // NOTE: we query the parent’s global transform here, which is a bit
-                        //       unfortunate (performance-wise). An alternative would be to
-                        //       deduce the parent’s global transform from the current entity’s
-                        //       global transform. However, this makes it nearly impossible
-                        //       (because of rounding errors) to predict the exact next value this
-                        //       entity’s global transform will get after the next transform
-                        //       propagation, which breaks our transform modification detection
-                        //       that we do to detect if the user’s transform has to be written
-                        //       into the rigid-body.
-                        if let Some(parent_global_transform) =
-                            parent.and_then(|p| global_transforms.get(**p).ok())
+                        if let Some(interpolated) =
+                            interpolation.lerp_slerp((dt + sim_to_render_time.diff) / dt)
                         {
-                            // We need to compute the new local transform such that:
-                            // curr_parent_global_transform * new_transform = interpolated_pos
-                            // new_transform = curr_parent_global_transform.inverse() * interpolated_pos
-                            let (_, inverse_parent_rotation, inverse_parent_translation) =
-                                parent_global_transform
-                                    .affine()
-                                    .inverse()
-                                    .to_scale_rotation_translation();
-                            let new_rotation = inverse_parent_rotation * interpolated_pos.rotation;
-
-                            #[allow(unused_mut)] // mut is needed in 2D but not in 3D.
-                            let mut new_translation = inverse_parent_rotation
-                                * interpolated_pos.translation
-                                + inverse_parent_translation;
-
-                            // In 2D, preserve the transform `z` component that may have been set by the user
-                            #[cfg(feature = "dim2")]
-                            {
-                                new_translation.z = transform.translation.z;
-                            }
-
-                            if transform.rotation != new_rotation
-                                || transform.translation != new_translation
-                            {
-                                // NOTE: we write the new value only if there was an
-                                //       actual change, in order to not trigger bevy’s
-                                //       change tracking when the values didn’t change.
-                                transform.rotation = new_rotation;
-                                transform.translation = new_translation;
-                            }
-
-                            // NOTE: we need to compute the result of the next transform propagation
-                            //       to make sure that our change detection for transforms is exact
-                            //       despite rounding errors.
-                            let new_global_transform =
-                                parent_global_transform.mul_transform(*transform);
-
-                            context
-                                .last_body_transform_set
-                                .insert(handle, new_global_transform);
-                        } else {
-                            // In 2D, preserve the transform `z` component that may have been set by the user
-                            #[cfg(feature = "dim2")]
-                            {
-                                interpolated_pos.translation.z = transform.translation.z;
-                            }
-
-                            if transform.rotation != interpolated_pos.rotation
-                                || transform.translation != interpolated_pos.translation
-                            {
-                                // NOTE: we write the new value only if there was an
-                                //       actual change, in order to not trigger bevy’s
-                                //       change tracking when the values didn’t change.
-                                transform.rotation = interpolated_pos.rotation;
-                                transform.translation = interpolated_pos.translation;
-                            }
-
-                            context
-                                .last_body_transform_set
-                                .insert(handle, GlobalTransform::from(interpolated_pos));
+                            interpolated_pos = utils::iso_to_transform(&interpolated, scale);
                         }
                     }
+                }
 
-                    if let Some(velocity) = &mut velocity {
-                        let new_vel = Velocity {
-                            linvel: (rb.linvel() * scale).into(),
-                            #[cfg(feature = "dim3")]
-                            angvel: (*rb.angvel()).into(),
-                            #[cfg(feature = "dim2")]
-                            angvel: rb.angvel(),
-                        };
+                if let Some(mut transform) = transform {
+                    // NOTE: we query the parent’s global transform here, which is a bit
+                    //       unfortunate (performance-wise). An alternative would be to
+                    //       deduce the parent’s global transform from the current entity’s
+                    //       global transform. However, this makes it nearly impossible
+                    //       (because of rounding errors) to predict the exact next value this
+                    //       entity’s global transform will get after the next transform
+                    //       propagation, which breaks our transform modification detection
+                    //       that we do to detect if the user’s transform has to be written
+                    //       into the rigid-body.
+                    if let Some(parent_global_transform) =
+                        parent.and_then(|p| global_transforms.get(**p).ok())
+                    {
+                        // We need to compute the new local transform such that:
+                        // curr_parent_global_transform * new_transform = interpolated_pos
+                        // new_transform = curr_parent_global_transform.inverse() * interpolated_pos
+                        let (_, inverse_parent_rotation, inverse_parent_translation) =
+                            parent_global_transform
+                                .affine()
+                                .inverse()
+                                .to_scale_rotation_translation();
+                        let new_rotation = inverse_parent_rotation * interpolated_pos.rotation;
 
-                        // NOTE: we write the new value only if there was an
-                        //       actual change, in order to not trigger bevy’s
-                        //       change tracking when the values didn’t change.
-                        if **velocity != new_vel {
-                            **velocity = new_vel;
+                        #[allow(unused_mut)] // mut is needed in 2D but not in 3D.
+                        let mut new_translation = inverse_parent_rotation
+                            * interpolated_pos.translation
+                            + inverse_parent_translation;
+
+                        // In 2D, preserve the transform `z` component that may have been set by the user
+                        #[cfg(feature = "dim2")]
+                        {
+                            new_translation.z = transform.translation.z;
                         }
+
+                        if transform.rotation != new_rotation
+                            || transform.translation != new_translation
+                        {
+                            // NOTE: we write the new value only if there was an
+                            //       actual change, in order to not trigger bevy’s
+                            //       change tracking when the values didn’t change.
+                            transform.rotation = new_rotation;
+                            transform.translation = new_translation;
+                        }
+
+                        // NOTE: we need to compute the result of the next transform propagation
+                        //       to make sure that our change detection for transforms is exact
+                        //       despite rounding errors.
+                        let new_global_transform =
+                            parent_global_transform.mul_transform(*transform);
+
+                        context
+                            .last_body_transform_set
+                            .insert(handle, new_global_transform);
+                    } else {
+                        // In 2D, preserve the transform `z` component that may have been set by the user
+                        #[cfg(feature = "dim2")]
+                        {
+                            interpolated_pos.translation.z = transform.translation.z;
+                        }
+
+                        if transform.rotation != interpolated_pos.rotation
+                            || transform.translation != interpolated_pos.translation
+                        {
+                            // NOTE: we write the new value only if there was an
+                            //       actual change, in order to not trigger bevy’s
+                            //       change tracking when the values didn’t change.
+                            transform.rotation = interpolated_pos.rotation;
+                            transform.translation = interpolated_pos.translation;
+                        }
+
+                        context
+                            .last_body_transform_set
+                            .insert(handle, GlobalTransform::from(interpolated_pos));
                     }
+                }
 
-                    if let Some(sleeping) = &mut sleeping {
-                        // NOTE: we write the new value only if there was an
-                        //       actual change, in order to not trigger bevy’s
-                        //       change tracking when the values didn’t change.
-                        if sleeping.sleeping != rb.is_sleeping() {
-                            sleeping.sleeping = rb.is_sleeping();
-                        }
+                if let Some(velocity) = &mut velocity {
+                    let new_vel = Velocity {
+                        linvel: (rb.linvel() * scale).into(),
+                        #[cfg(feature = "dim3")]
+                        angvel: (*rb.angvel()).into(),
+                        #[cfg(feature = "dim2")]
+                        angvel: rb.angvel(),
+                    };
+
+                    // NOTE: we write the new value only if there was an
+                    //       actual change, in order to not trigger bevy’s
+                    //       change tracking when the values didn’t change.
+                    if **velocity != new_vel {
+                        **velocity = new_vel;
+                    }
+                }
+
+                if let Some(sleeping) = &mut sleeping {
+                    // NOTE: we write the new value only if there was an
+                    //       actual change, in order to not trigger bevy’s
+                    //       change tracking when the values didn’t change.
+                    if sleeping.sleeping != rb.is_sleeping() {
+                        sleeping.sleeping = rb.is_sleeping();
                     }
                 }
             }


### PR DESCRIPTION
Currently, the `RigidBodyWritebackComponents` query used by the `rigid_body_writeback` system is composed of an `Entity` and several `Option<T>` components, with no concrete by-ref / by-mut borrow to prevent it from checking every entity in the world.

This causes it to scale poorly in scenes with many entities. Consider an example scene with two RigidBody cubes and 8000 non-physics background meshes: `writeback_rigid_bodies` will check all 8002 objects despite only two of them being relevant, which reduces overall frame rate by ~60FPS in my local testing.

This change adds `RapierRigidBodyHandle` to the query as a concrete by-ref borrow, and passes its inner handle directly to the rest of the system rather than looking it up via `entity2body`. This prevents irrelevant entities from being queried, and fixes the aforementioned performance deficit.