### PR TITLE
Fix 3d debug line rendering issue

### DIFF
--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -30,9 +30,10 @@ mod spherical_joint;
 /// Each collider has its combination rule of type
 /// `CoefficientCombineRule`. And the rule
 /// actually used is given by `max(first_combine_rule as usize, second_combine_rule as usize)`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Reflect, FromReflect, Default)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub enum CoefficientCombineRule {
+    #[default]
     /// The two coefficients are averaged.
     Average = 0,
     /// The smallest coefficient is chosen.
@@ -41,12 +42,6 @@ pub enum CoefficientCombineRule {
     Multiply,
     /// The greatest coefficient is chosen.
     Max,
-}
-
-impl Default for CoefficientCombineRule {
-    fn default() -> Self {
-        CoefficientCombineRule::Average
-    }
 }
 
 impl From<CoefficientCombineRule> for RapierCoefficientCombineRule {

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -10,11 +10,12 @@ use std::ops::{Add, AddAssign, Sub, SubAssign};
 pub struct RapierRigidBodyHandle(pub RigidBodyHandle);
 
 /// A rigid-body.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Component, Reflect, FromReflect)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Component, Reflect, FromReflect, Default)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[reflect(Component, PartialEq)]
 pub enum RigidBody {
     /// A `RigidBody::Dynamic` body can be affected by all external forces.
+    #[default]
     Dynamic,
     /// A `RigidBody::Fixed` body cannot be affected by external forces.
     Fixed,
@@ -32,12 +33,6 @@ pub enum RigidBody {
     /// cannot be pushed by anything. In other words, the trajectory of a kinematic body can only be
     /// modified by the user and is independent from any contact or joint it is involved in.
     KinematicVelocityBased,
-}
-
-impl Default for RigidBody {
-    fn default() -> Self {
-        RigidBody::Dynamic
-    }
 }
 
 impl From<RigidBody> for RigidBodyType {

--- a/src/render/lines/render_dim.rs
+++ b/src/render/lines/render_dim.rs
@@ -106,7 +106,7 @@ pub mod r3d {
                 },
                 depth_stencil: Some(DepthStencilState {
                     format: TextureFormat::Depth32Float,
-                    depth_write_enabled: false,
+                    depth_write_enabled: true,
                     depth_compare: CompareFunction::Greater,
                     stencil: default(),
                     bias: default(),


### PR DESCRIPTION
I made a silly mistake while updating to Bevy 0.10 that prevents debug lines from being rendered when they're in front of another mesh.