### PR TITLE
Do not write back disabled rigidbodies

### DIFF
--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -489,7 +489,7 @@ pub fn writeback_rigid_bodies(
     config: Res<RapierConfiguration>,
     sim_to_render_time: Res<SimulationToRenderTime>,
     global_transforms: Query<&GlobalTransform>,
-    mut writeback: Query<RigidBodyWritebackComponents>,
+    mut writeback: Query<RigidBodyWritebackComponents, Without<RigidBodyDisabled>>,
 ) {
     let context = &mut *context;
     let scale = context.physics_scale;


### PR DESCRIPTION
Disabled rigidbodies should not be modified by the physics world.

In my case with nested disabled rigidbodies, this led to desync from their initial positions over time.