### PR TITLE
Support EffectiveCharacterMovement addition of is_sliding_down_slope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Added
+
+- Expose `is_sliding_down_slope` to both `MoveShapeOutput` and `KinematicCharacterControllerOutput`
+
 ## v0.26.0 (05 May 2024)
 
 **This is an update to Rapier 0.19 which includes several stability improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Derive `Debug` for `LockedAxes`.
-- Expose `is_sliding_down_slope` to both `MoveShapeOutput` and `KinematicCharacterControllerOutput`
+- Expose `is_sliding_down_slope` to both `MoveShapeOutput` and `KinematicCharacterControllerOutput`.
 
 ## v0.26.0 (05 May 2024)
 

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -217,6 +217,8 @@ pub struct KinematicCharacterControllerOutput {
     pub effective_translation: Vect,
     /// Collisions between the character and obstacles found in its path.
     pub collisions: Vec<CharacterCollision>,
+    /// Indicates whether the shape is sliding down a slope after its kinematic movement.
+    pub is_sliding_down_slope: bool,
 }
 
 /// The allowed movement computed by `RapierContext::move_shape`.
@@ -225,4 +227,6 @@ pub struct MoveShapeOutput {
     pub grounded: bool,
     /// The translation calculated by the last character control step taking obstacles into account.
     pub effective_translation: Vect,
+    /// Indicates whether the shape is sliding down a slope after its kinematic movement.
+    pub is_sliding_down_slope: bool,
 }

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -468,6 +468,7 @@ impl RapierContext {
         MoveShapeOutput {
             effective_translation: result.translation.into(),
             grounded: result.grounded,
+            is_sliding_down_slope: result.is_sliding_down_slope,
         }
     }
 

--- a/src/plugin/systems/character_controller.rs
+++ b/src/plugin/systems/character_controller.rs
@@ -150,6 +150,7 @@ pub fn update_character_controls(
                 output.grounded = movement.grounded;
                 output.collisions.clear();
                 output.collisions.extend(converted_collisions);
+                output.is_sliding_down_slope = movement.is_sliding_down_slope;
             } else {
                 commands
                     .entity(entity)
@@ -158,6 +159,7 @@ pub fn update_character_controls(
                         effective_translation: movement.translation.into(),
                         grounded: movement.grounded,
                         collisions: converted_collisions.collect(),
+                        is_sliding_down_slope: movement.is_sliding_down_slope,
                     });
             }
 


### PR DESCRIPTION
Resolves #352

Adds `is_sliding_down_slope` to both `MoveShapeOutput` and `KinematicCharacterControllerOutput`

Needs to wait for https://github.com/dimforge/rapier/commit/11d145b11ac24942d7d9c7e30df773d305a540a8 to be added to a release