### PR TITLE
Implement helper function to get velocity of rigid body at specific point

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -116,6 +116,19 @@ impl Velocity {
             angvel,
         }
     }
+
+    /// Get linear velocity of specific world-space point of a rigid-body.
+    ///
+    /// # Parameters
+    /// - `point`: the point (world-space) to compute the velocity for.
+    /// - `center_of_mass`: the center-of-mass (world-space) of the rigid-body the velocity belongs to.
+    pub fn linear_velocity_at_point(&self, point: Vect, center_of_mass: Vect) -> Vect {
+        #[cfg(feature = "dim2")]
+        return self.linvel + Vect::from_angle(self.angvel).perp_dot(point - center_of_mass);
+
+        #[cfg(feature = "dim3")]
+        return self.linvel + self.angvel.cross(point - center_of_mass);
+    }
 }
 
 /// Mass-properties of a rigid-body, added to the contributions of its attached colliders.

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -124,7 +124,7 @@ impl Velocity {
     /// - `center_of_mass`: the center-of-mass (world-space) of the rigid-body the velocity belongs to.
     pub fn linear_velocity_at_point(&self, point: Vect, center_of_mass: Vect) -> Vect {
         #[cfg(feature = "dim2")]
-        return self.linvel + Vect::from_angle(self.angvel).perp_dot(point - center_of_mass);
+        return self.linvel + self.angvel * (point - center_of_mass).perp();
 
         #[cfg(feature = "dim3")]
         return self.linvel + self.angvel.cross(point - center_of_mass);


### PR DESCRIPTION
Adds function similar to `ExternalForce::at_point` and `ExternalImpulse::at_point` to Velocity, so we can get the linear velocity of rigid body at specific point instead of velocity of the center-of-mass.

I was not sure about the naming, Unity names this [`GetPointVelocity`](https://docs.unity3d.com/ScriptReference/Rigidbody.GetPointVelocity.html) and Unreal names this [`GetPhysicsLinearVelocityAtPoint`](https://docs.unrealengine.com/5.1/en-US/API/Runtime/Engine/Components/UPrimitiveComponent/GetPhysicsLinearVelocityAtPoint/).

The calling of this function differs a bit from `ExternalForce::at_point` in that it is not associated function, but member function of `Velocity`, meaning you call it on `Velocity` instance. If this is not desired, I can change it.

Also I am not sure if the math for the 2D part is correct, I tested this only for 3D, please correct me if it is wrong.