### PR TITLE
Fix writeback query performance issue

### DIFF
--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -489,7 +489,7 @@ pub fn writeback_rigid_bodies(
     config: Res<RapierConfiguration>,
     sim_to_render_time: Res<SimulationToRenderTime>,
     global_transforms: Query<&GlobalTransform>,
-    mut writeback: Query<RigidBodyWritebackComponents, Without<RigidBodyDisabled>>,
+    mut writeback: Query<RigidBodyWritebackComponents, (With<RigidBody>, Without<RigidBodyDisabled>)>,
 ) {
     let context = &mut *context;
     let scale = context.physics_scale;


### PR DESCRIPTION
Limits the query in writeback_rigid_bodies to only entities with rigid bodies, improving performance in scenes with many non rigidbody entities.

Data from scene with 1000+ entities and 1 rigid body:

Before:
![before](https://user-images.githubusercontent.com/25522615/231701852-aa85e28d-e0e9-4d3b-8765-31ac1711810b.PNG)

After:
![after](https://user-images.githubusercontent.com/25522615/231701983-332146f1-afa2-4746-a801-51f13bf2f6ff.PNG)
