### PR TITLE
Update for Bevy 0.11-dev : Schedule-First API.

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -37,7 +37,7 @@ async-collider = [ ]
 
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "0.32.2", features = [ "convert-glam023" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = "0.17.0"
@@ -47,7 +47,7 @@ log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false, features = ["x11"]}
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["x11"]}
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.23", features = [ "approx" ] }

--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -11,8 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -40,8 +40,8 @@ fn main() {
             100.0,
         ))
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, setup_graphics)
+        .add_systems(Startup, setup_physics)
         .run();
 }
 

--- a/bevy_rapier2d/examples/custom_system_setup2.rs
+++ b/bevy_rapier2d/examples/custom_system_setup2.rs
@@ -1,4 +1,6 @@
-use bevy::{core::FrameCount, ecs::schedule::ScheduleLabel, prelude::*};
+use bevy::{
+    core::FrameCount, ecs::schedule::ScheduleLabel, prelude::*, transform::TransformSystem,
+};
 use bevy_rapier2d::prelude::*;
 
 #[derive(ScheduleLabel, Hash, Debug, PartialEq, Eq, Clone)]
@@ -14,14 +16,10 @@ fn main() {
     )))
     .add_plugins(DefaultPlugins)
     .add_plugin(RapierDebugRenderPlugin::default())
-    .add_startup_system(setup_graphics)
-    .add_startup_system(setup_physics)
-    .add_system(
-        (|world: &mut World| {
-            world.run_schedule(SpecialSchedule);
-        })
-        .in_base_set(CoreSet::PostUpdate),
-    );
+    .add_systems(Startup, (setup_graphics, setup_physics))
+    .add_systems(PostUpdate, |world: &mut World| {
+        world.run_schedule(SpecialSchedule);
+    });
 
     // Do the setup however we want, maybe in its very own schedule
     let mut schedule = Schedule::new();
@@ -33,28 +31,29 @@ fn main() {
             PhysicsSet::StepSimulation,
             PhysicsSet::Writeback,
         )
-            .chain(),
+            .chain()
+            .before(TransformSystem::TransformPropagate),
     );
 
     schedule.add_systems(
         RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::SyncBackend)
-            .in_base_set(PhysicsSet::SyncBackend),
+            .in_set(PhysicsSet::SyncBackend),
     );
 
     schedule.add_systems(
         RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::SyncBackendFlush)
-            .in_base_set(PhysicsSet::SyncBackendFlush),
+            .in_set(PhysicsSet::SyncBackendFlush),
     );
 
     schedule.add_systems(
         RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::StepSimulation)
-            .in_base_set(PhysicsSet::StepSimulation),
+            .in_set(PhysicsSet::StepSimulation),
     );
-    schedule.add_system(despawn_one_box.in_base_set(PhysicsSet::StepSimulation));
+    schedule.add_systems(despawn_one_box.in_set(PhysicsSet::StepSimulation));
 
     schedule.add_systems(
         RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::Writeback)
-            .in_base_set(PhysicsSet::Writeback),
+            .in_set(PhysicsSet::Writeback),
     );
 
     app.add_schedule(SpecialSchedule, schedule)

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -10,8 +10,8 @@ fn main() {
         .init_resource::<Game>()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_game)
-        .add_system(cube_sleep_detection)
+        .add_systems(Startup, setup_game)
+        .add_systems(Update, cube_sleep_detection)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
         .run();

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -23,10 +23,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
-        .add_system(despawn)
-        .add_system(resize)
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .add_systems(Update, (despawn, resize))
         .run();
 }
 

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -11,9 +11,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
-        .add_system(display_events.in_base_set(CoreSet::PostUpdate))
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .add_systems(PostUpdate, display_events)
         .run();
 }
 

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -11,8 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier2d/examples/joints_despawn2.rs
+++ b/bevy_rapier2d/examples/joints_despawn2.rs
@@ -17,9 +17,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
-        .add_system(despawn)
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .add_systems(Update, despawn)
         .run();
 }
 

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -11,8 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -11,8 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -11,8 +11,8 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(spawn_player)
-        .add_system(player_movement)
+        .add_systems(Startup, spawn_player)
+        .add_systems(Update, player_movement)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugin(RapierDebugRenderPlugin::default())
         .run();

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -38,7 +38,7 @@ headless = [ ]
 async-collider = [ ]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["bevy_asset", "bevy_scene"] }
 nalgebra = { version = "0.32.2", features = [ "convert-glam023" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = "0.17.0"
@@ -48,7 +48,7 @@ log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false, features = ["x11"]}
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["x11"]}
 approx = "0.5.1"
 glam = { version = "0.23", features = [ "approx" ] }
 

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -11,8 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -38,8 +38,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<SameUserDataFilter>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -14,14 +14,10 @@ fn main() {
     )))
     .add_plugins(DefaultPlugins)
     .add_plugin(RapierDebugRenderPlugin::default())
-    .add_startup_system(setup_graphics)
-    .add_startup_system(setup_physics)
-    .add_system(
-        (|world: &mut World| {
-            world.run_schedule(SpecialSchedule);
-        })
-        .in_base_set(CoreSet::PostUpdate),
-    );
+    .add_systems(Startup, (setup_graphics, setup_physics))
+    .add_systems(PostUpdate, |world: &mut World| {
+        world.run_schedule(SpecialSchedule);
+    });
 
     // Do the setup however we want, maybe in its very own schedule
     let mut schedule = Schedule::new();
@@ -38,23 +34,23 @@ fn main() {
 
     schedule.add_systems(
         RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::SyncBackend)
-            .in_base_set(PhysicsSet::SyncBackend),
+            .in_set(PhysicsSet::SyncBackend),
     );
 
     schedule.add_systems(
         RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::SyncBackendFlush)
-            .in_base_set(PhysicsSet::SyncBackendFlush),
+            .in_set(PhysicsSet::SyncBackendFlush),
     );
 
     schedule.add_systems(
         RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::StepSimulation)
-            .in_base_set(PhysicsSet::StepSimulation),
+            .in_set(PhysicsSet::StepSimulation),
     );
-    schedule.add_system(despawn_one_box.in_base_set(PhysicsSet::StepSimulation));
+    schedule.add_systems(despawn_one_box.in_set(PhysicsSet::StepSimulation));
 
     schedule.add_systems(
         RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::Writeback)
-            .in_base_set(PhysicsSet::Writeback),
+            .in_set(PhysicsSet::Writeback),
     );
 
     app.add_schedule(SpecialSchedule, schedule)

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -17,9 +17,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
-        .add_system(despawn)
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .add_systems(Update, despawn)
         .run();
 }
 

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -11,9 +11,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
-        .add_system(display_events.in_base_set(CoreSet::PostUpdate))
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .add_systems(PostUpdate, display_events)
         .run();
 }
 

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -11,8 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -17,9 +17,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
-        .add_system(despawn)
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .add_systems(Update, despawn)
         .run();
 }
 

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -11,8 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier3d/examples/multiple_colliders3.rs
+++ b/bevy_rapier3d/examples/multiple_colliders3.rs
@@ -11,8 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -12,9 +12,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
-        .add_system(cast_ray)
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .add_systems(Update, cast_ray)
         .run();
 }
 

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -13,10 +13,9 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugin(RapierDebugRenderPlugin::default())
-        .add_startup_system(setup_graphics)
-        .add_startup_system(setup_physics)
+        .add_systems(Startup, (setup_graphics, setup_physics))
         .insert_resource(BallState::default())
-        .add_system(ball_spawner)
+        .add_systems(Update, ball_spawner)
         .run();
 }
 

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -1421,7 +1421,7 @@ mod tests {
     fn colliding_entities_updates() {
         let mut app = App::new();
         app.add_event::<CollisionEvent>()
-            .add_system(update_colliding_entities);
+            .add_systems(Update, update_colliding_entities);
 
         let entity1 = app.world.spawn(CollidingEntities::default()).id();
         let entity2 = app.world.spawn(CollidingEntities::default()).id();
@@ -1508,7 +1508,7 @@ mod tests {
     fn async_collider_initializes() {
         let mut app = App::new();
         app.add_plugin(HeadlessRenderPlugin)
-            .add_system(init_async_colliders);
+            .add_systems(Update, init_async_colliders);
 
         let mut meshes = app.world.resource_mut::<Assets<Mesh>>();
         let cube = meshes.add(Cube::default().into());
@@ -1534,8 +1534,10 @@ mod tests {
         use bevy::scene::scene_spawner_system;
 
         let mut app = App::new();
-        app.add_plugin(HeadlessRenderPlugin)
-            .add_system(init_async_scene_colliders.after(scene_spawner_system));
+        app.add_plugin(HeadlessRenderPlugin).add_systems(
+            Update,
+            init_async_scene_colliders.after(scene_spawner_system),
+        );
 
         let mut meshes = app.world.resource_mut::<Assets<Mesh>>();
         let cube_handle = meshes.add(Cube::default().into());

--- a/src/render/lines/mod.rs
+++ b/src/render/lines/mod.rs
@@ -24,10 +24,12 @@ use bevy::{
         render_resource::PrimitiveTopology,
         render_resource::Shader,
         view::NoFrustumCulling,
-        Extract,
+        Extract, Render,
     },
 };
 use std::sync::{Arc, RwLock};
+
+use crate::plugin::PhysicsSet;
 
 mod render_dim;
 
@@ -116,12 +118,8 @@ impl Plugin for DebugLinesPlugin {
 
         let lines_config = DebugLinesConfig::always_on_top(self.always_on_top);
         app.init_resource::<DebugLines>()
-            .add_startup_system(setup)
-            .add_system(
-                update
-                    .in_base_set(CoreSet::PostUpdate)
-                    .in_set(DrawLinesLabel),
-            )
+            .add_systems(Startup, setup)
+            .add_systems(PostUpdate, update.in_set(DrawLinesLabel))
             .insert_resource(lines_config.clone());
 
         #[cfg(feature = "debug-render-3d")]
@@ -129,18 +127,18 @@ impl Plugin for DebugLinesPlugin {
             .add_render_command::<dim3::Phase, dim3::DrawDebugLines>()
             .init_resource::<dim3::DebugLinePipeline>()
             .init_resource::<SpecializedMeshPipelines<dim3::DebugLinePipeline>>()
-            .add_system(dim3::queue.in_set(RenderSet::Queue));
+            .add_systems(Render, dim3::queue.in_set(RenderSet::Queue));
 
         #[cfg(feature = "debug-render-2d")]
         app.sub_app_mut(RenderApp)
             .add_render_command::<dim2::Phase, dim2::DrawDebugLines>()
             .init_resource::<dim2::DebugLinePipeline>()
             .init_resource::<SpecializedMeshPipelines<dim2::DebugLinePipeline>>()
-            .add_system(dim2::queue.in_set(RenderSet::Queue));
+            .add_systems(Render, dim2::queue.in_set(RenderSet::Queue));
 
         app.sub_app_mut(RenderApp)
             .insert_resource(lines_config)
-            .add_system(extract.in_schedule(ExtractSchedule));
+            .add_systems(ExtractSchedule, extract);
 
         #[cfg(feature = "debug-render-3d")]
         info!("Loaded 3d debug lines plugin.");

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,3 +1,4 @@
+use crate::plugin::PhysicsSet;
 use crate::render::lines::DebugLinesConfig;
 use crate::{plugin::RapierContext, render::lines::DrawLinesLabel};
 use bevy::prelude::*;
@@ -103,10 +104,11 @@ impl Plugin for RapierDebugRenderPlugin {
                 pipeline: DebugRenderPipeline::new(self.style, self.mode),
                 always_on_top: self.always_on_top,
             })
-            .add_system(
+            .add_systems(
+                PostUpdate,
                 debug_render_scene
-                    .in_base_set(CoreSet::PostUpdate)
-                    .before(DrawLinesLabel),
+                    .before(DrawLinesLabel)
+                    .after(PhysicsSet::Writeback),
             );
     }
 }


### PR DESCRIPTION
Good Morning/Afternoon, Dimforge Team,

I have forked the repo and written changes required to work with the new Schedule-First API.

The API has been devised in bevyengine/bevy#8079, and I wanted to use them ASAP, so I thought I'd make my efforts public.

TL;DR for the above PR: `add_startup_system`/`add_system` have been deprecated in favour of `add_systems`. `Render` has its own `ScheduleLabel` now as well.

FYI: this is the first time I've ever contributed to an open-source project, so please let me know if there's anything I could have done differently.

*Reminder:* I changed the Cargo dependency for bevy to use the GitHub URL, please change to 0.11 once it has been finalised.

^ I don't mean to seem condescending in the line above, I just know that I would forget to change it, so I'm trying to be courteous.