### PR TITLE
Fix some leftover headless issues

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -19,25 +19,25 @@ required-features = [ "dim2" ]
 
 [features]
 default = [ "dim2", "async-collider", "debug-render-2d" ]
-dim2 = ["bevy/bevy_render"]
-debug-render-2d = [ "bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_render", "rapier2d/debug-render" ]
-debug-render-3d = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "rapier2d/debug-render" ]
+dim2 = []
+debug-render-2d = [ "bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_render", "rapier2d/debug-render", "bevy/bevy_asset" ]
+debug-render-3d = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "rapier2d/debug-render", "bevy/bevy_asset" ]
 parallel = [ "rapier2d/parallel" ]
 simd-stable = [ "rapier2d/simd-stable" ]
 simd-nightly = [ "rapier2d/simd-nightly" ]
 wasm-bindgen = [ "rapier2d/wasm-bindgen" ]
 serde-serialize = [ "rapier2d/serde-serialize", "bevy/serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
+headless = []
 
 # Enables the AsyncCollider and AsyncSceneCollider components that wait for specific
 # assets to be loaded before creating the actual Collider.
 # See https://github.com/dimforge/bevy_rapier/issues/296 for a workaround on how
 # to use this when using bevy headless.
-async-collider = [ ]
-
+async-collider = [ "bevy/bevy_asset", "bevy/bevy_scene" ]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { version = "0.10", default-features = false }
 nalgebra = { version = "0.32.2", features = [ "convert-glam023" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier2d = "0.17.0"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -29,11 +29,6 @@ wasm-bindgen = [ "rapier2d/wasm-bindgen" ]
 serde-serialize = [ "rapier2d/serde-serialize", "bevy/serialize", "serde" ]
 enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 headless = []
-
-# Enables the AsyncCollider and AsyncSceneCollider components that wait for specific
-# assets to be loaded before creating the actual Collider.
-# See https://github.com/dimforge/bevy_rapier/issues/296 for a workaround on how
-# to use this when using bevy headless.
 async-collider = [ "bevy/bevy_asset", "bevy/bevy_scene" ]
 
 [dependencies]

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -19,10 +19,10 @@ required-features = [ "dim3" ]
 
 [features]
 default = [ "dim3", "async-collider", "debug-render-3d" ]
-dim3 = ["bevy/bevy_render"]
+dim3 = []
 debug-render = [ "debug-render-3d" ]
-debug-render-2d = [ "bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_render", "rapier3d/debug-render" ]
-debug-render-3d = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "rapier3d/debug-render" ]
+debug-render-2d = [ "bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_render", "rapier3d/debug-render", "bevy/bevy_asset" ]
+debug-render-3d = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_render", "rapier3d/debug-render", "bevy/bevy_asset" ]
 parallel = [ "rapier3d/parallel" ]
 simd-stable = [ "rapier3d/simd-stable" ]
 simd-nightly = [ "rapier3d/simd-nightly" ]
@@ -35,10 +35,10 @@ headless = [ ]
 # assets to be loaded before creating the actual Collider.
 # See https://github.com/dimforge/bevy_rapier/issues/296 for a workaround on how
 # to use this when using bevy headless.
-async-collider = [ ]
+async-collider = [ "bevy/bevy_asset", "bevy/bevy_scene" ]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = ["bevy_asset", "bevy_scene"] }
+bevy = { version = "0.10", default-features = false }
 nalgebra = { version = "0.32.2", features = [ "convert-glam023" ] }
 # Don't enable the default features because we don't need the ColliderSet/RigidBodySet
 rapier3d = "0.17.0"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -30,11 +30,6 @@ wasm-bindgen = [ "rapier3d/wasm-bindgen" ]
 serde-serialize = [ "rapier3d/serde-serialize", "bevy/serialize", "serde" ]
 enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 headless = [ ]
-
-# Enables the AsyncCollider and AsyncSceneCollider components that wait for specific
-# assets to be loaded before creating the actual Collider.
-# See https://github.com/dimforge/bevy_rapier/issues/296 for a workaround on how
-# to use this when using bevy headless.
 async-collider = [ "bevy/bevy_asset", "bevy/bevy_scene" ]
 
 [dependencies]

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use rapier::prelude::{
-    Aabb as RapierAabb, BroadPhase, CCDSolver, ColliderHandle, ColliderSet, EventHandler,
-    FeatureId, ImpulseJointHandle, ImpulseJointSet, IntegrationParameters, IslandManager,
+    BroadPhase, CCDSolver, ColliderHandle, ColliderSet, EventHandler, FeatureId,
+    ImpulseJointHandle, ImpulseJointSet, IntegrationParameters, IslandManager,
     MultibodyJointHandle, MultibodyJointSet, NarrowPhase, PhysicsHooks, PhysicsPipeline,
     QueryFilter as RapierQueryFilter, QueryPipeline, Ray, Real, RigidBodyHandle, RigidBodySet,
 };
@@ -13,14 +13,11 @@ use crate::geometry::{Collider, PointProjection, RayIntersection, Toi};
 use crate::math::{Rot, Vect};
 use crate::pipeline::{CollisionEvent, ContactForceEvent, EventQueue, QueryFilter};
 use bevy::prelude::{Entity, EventWriter, GlobalTransform, Query};
-use bevy::render::primitives::Aabb;
 
 use crate::control::{CharacterCollision, MoveShapeOptions, MoveShapeOutput};
 use crate::dynamics::TransformInterpolation;
 use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
 use crate::prelude::{CollisionGroups, RapierRigidBodyHandle};
-#[cfg(feature = "dim2")]
-use bevy::math::Vec3Swizzles;
 use rapier::control::CharacterAutostep;
 
 /// The Rapier context, containing all the state of the physics engine.
@@ -711,18 +708,21 @@ impl RapierContext {
     }
 
     /// Finds all entities of all the colliders with an Aabb intersecting the given Aabb.
+    #[cfg(not(feature = "headless"))]
     pub fn colliders_with_aabb_intersecting_aabb(
         &self,
-        aabb: Aabb,
+        aabb: bevy::render::primitives::Aabb,
         mut callback: impl FnMut(Entity) -> bool,
     ) {
         #[cfg(feature = "dim2")]
-        let scaled_aabb = RapierAabb {
+        use bevy::math::Vec3Swizzles;
+        #[cfg(feature = "dim2")]
+        let scaled_aabb = rapier::prelude::Aabb {
             mins: (aabb.min().xy() / self.physics_scale).into(),
             maxs: (aabb.max().xy() / self.physics_scale).into(),
         };
         #[cfg(feature = "dim3")]
-        let scaled_aabb = RapierAabb {
+        let scaled_aabb = rapier::prelude::Aabb {
             mins: (aabb.min() / self.physics_scale).into(),
             maxs: (aabb.max() / self.physics_scale).into(),
         };

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -679,14 +679,8 @@ pub fn step_simulation<Hooks>(
     }
 }
 
-/// NOTE: This currently does nothing in 2D.
-#[cfg(feature = "async-collider")]
-#[cfg(feature = "dim2")]
-pub fn init_async_colliders() {}
-
-/// NOTE: This does nothing in 3D with headless.
-#[cfg(feature = "headless")]
-#[cfg(feature = "dim3")]
+/// NOTE: This currently does nothing in 2D, or without the async-collider feature
+#[cfg(any(feature = "dim2", not(feature = "async-collider")))]
 pub fn init_async_colliders() {}
 
 /// System responsible for creating `Collider` components from `AsyncCollider` components if the


### PR DESCRIPTION
This PR fixes some issues where bevy_rapier enabled unnecessary features for headless applications. It also fixes a compilation error that happened if the async-collider feature was disabled, but headless was not enabled.

With these changes #296 should be fully resolved. Not only will rapier no longer panic at runtime due to missing assets/resources, but you can also run a bevy app with the absolute minimum features like this
```toml
bevy          = {version = "0.10", default-features=false}
bevy_rapier3d = {version = "0.21", default-features=false, features = ["dim3", "headless"]}
```