### PR TITLE
Clarify argument naming

### DIFF
--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -81,20 +81,20 @@ impl Collider {
 
     /// Initialize a new collider with a cuboid shape defined by its half-extents.
     #[cfg(feature = "dim2")]
-    pub fn cuboid(hx: Real, hy: Real) -> Self {
-        SharedShape::cuboid(hx, hy).into()
+    pub fn cuboid(half_x: Real, half_y: Real) -> Self {
+        SharedShape::cuboid(half_x, half_y).into()
     }
 
     /// Initialize a new collider with a round cuboid shape defined by its half-extents
     /// and border radius.
     #[cfg(feature = "dim2")]
-    pub fn round_cuboid(hx: Real, hy: Real, border_radius: Real) -> Self {
-        SharedShape::round_cuboid(hx, hy, border_radius).into()
+    pub fn round_cuboid(half_x: Real, half_y: Real, border_radius: Real) -> Self {
+        SharedShape::round_cuboid(half_x, half_y, border_radius).into()
     }
 
     /// Initialize a new collider with a capsule shape.
-    pub fn capsule(a: Vect, b: Vect, radius: Real) -> Self {
-        SharedShape::capsule(a.into(), b.into(), radius).into()
+    pub fn capsule(axis: Vect, endpoint: Vect, radius: Real) -> Self {
+        SharedShape::capsule(axis.into(), endpoint.into(), radius).into()
     }
 
     /// Initialize a new collider with a capsule shape aligned with the `x` axis.
@@ -125,8 +125,8 @@ impl Collider {
     /// Initialize a new collider with a round cuboid shape defined by its half-extents
     /// and border radius.
     #[cfg(feature = "dim3")]
-    pub fn round_cuboid(hx: Real, hy: Real, hz: Real, border_radius: Real) -> Self {
-        SharedShape::round_cuboid(hx, hy, hz, border_radius).into()
+    pub fn round_cuboid(half_x: Real, half_y: Real, half_z: Real, border_radius: Real) -> Self {
+        SharedShape::round_cuboid(half_x, half_y, half_z, border_radius).into()
     }
 
     /// Initializes a collider with a segment shape.
@@ -550,12 +550,12 @@ impl Collider {
     /// The point is assumed to be expressed in the local-space of `self`.
     pub fn project_local_point_with_max_dist(
         &self,
-        pt: Vect,
+        point: Vect,
         solid: bool,
         max_dist: Real,
     ) -> Option<PointProjection> {
         self.raw
-            .project_local_point_with_max_dist(&pt.into(), solid, max_dist)
+            .project_local_point_with_max_dist(&point.into(), solid, max_dist)
             .map(Into::into)
     }
 
@@ -564,38 +564,38 @@ impl Collider {
         &self,
         translation: Vect,
         rotation: Rot,
-        pt: Vect,
+        point: Vect,
         solid: bool,
         max_dist: Real,
     ) -> Option<PointProjection> {
         let pos = (translation, rotation).into();
         self.raw
-            .project_point_with_max_dist(&pos, &pt.into(), solid, max_dist)
+            .project_point_with_max_dist(&pos, &point.into(), solid, max_dist)
             .map(Into::into)
     }
 
     /// Projects a point on `self`.
     ///
     /// The point is assumed to be expressed in the local-space of `self`.
-    pub fn project_local_point(&self, pt: Vect, solid: bool) -> PointProjection {
-        self.raw.project_local_point(&pt.into(), solid).into()
+    pub fn project_local_point(&self, point: Vect, solid: bool) -> PointProjection {
+        self.raw.project_local_point(&point.into(), solid).into()
     }
 
     /// Projects a point on the boundary of `self` and returns the id of the
     /// feature the point was projected on.
-    pub fn project_local_point_and_get_feature(&self, pt: Vect) -> (PointProjection, FeatureId) {
-        let (proj, feat) = self.raw.project_local_point_and_get_feature(&pt.into());
+    pub fn project_local_point_and_get_feature(&self, point: Vect) -> (PointProjection, FeatureId) {
+        let (proj, feat) = self.raw.project_local_point_and_get_feature(&point.into());
         (proj.into(), feat)
     }
 
     /// Computes the minimal distance between a point and `self`.
-    pub fn distance_to_local_point(&self, pt: Vect, solid: bool) -> Real {
-        self.raw.distance_to_local_point(&pt.into(), solid)
+    pub fn distance_to_local_point(&self, point: Vect, solid: bool) -> Real {
+        self.raw.distance_to_local_point(&point.into(), solid)
     }
 
     /// Tests if the given point is inside of `self`.
-    pub fn contains_local_point(&self, pt: Vect) -> bool {
-        self.raw.contains_local_point(&pt.into())
+    pub fn contains_local_point(&self, point: Vect) -> bool {
+        self.raw.contains_local_point(&point.into())
     }
 
     /// Projects a point on `self` transformed by `m`.
@@ -603,11 +603,11 @@ impl Collider {
         &self,
         translation: Vect,
         rotation: Rot,
-        pt: Vect,
+        point: Vect,
         solid: bool,
     ) -> PointProjection {
         let pos = (translation, rotation).into();
-        self.raw.project_point(&pos, &pt.into(), solid).into()
+        self.raw.project_point(&pos, &point.into(), solid).into()
     }
 
     /// Computes the minimal distance between a point and `self` transformed by `m`.
@@ -616,11 +616,11 @@ impl Collider {
         &self,
         translation: Vect,
         rotation: Rot,
-        pt: Vect,
+        point: Vect,
         solid: bool,
     ) -> Real {
         let pos = (translation, rotation).into();
-        self.raw.distance_to_point(&pos, &pt.into(), solid)
+        self.raw.distance_to_point(&pos, &point.into(), solid)
     }
 
     /// Projects a point on the boundary of `self` transformed by `m` and returns the id of the
@@ -629,17 +629,17 @@ impl Collider {
         &self,
         translation: Vect,
         rotation: Rot,
-        pt: Vect,
+        point: Vect,
     ) -> (PointProjection, FeatureId) {
         let pos = (translation, rotation).into();
-        let (proj, feat) = self.raw.project_point_and_get_feature(&pos, &pt.into());
+        let (proj, feat) = self.raw.project_point_and_get_feature(&pos, &point.into());
         (proj.into(), feat)
     }
 
     /// Tests if the given point is inside of `self` transformed by `m`.
-    pub fn contains_point(&self, translation: Vect, rotation: Rot, pt: Vect) -> bool {
+    pub fn contains_point(&self, translation: Vect, rotation: Rot, point: Vect) -> bool {
         let pos = (translation, rotation).into();
-        self.raw.contains_point(&pos, &pt.into())
+        self.raw.contains_point(&pos, &point.into())
     }
 
     /// Computes the time of impact between this transform shape and a ray.

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -93,8 +93,8 @@ impl Collider {
     }
 
     /// Initialize a new collider with a capsule shape.
-    pub fn capsule(axis: Vect, endpoint: Vect, radius: Real) -> Self {
-        SharedShape::capsule(axis.into(), endpoint.into(), radius).into()
+    pub fn capsule(start: Vect, end: Vect, radius: Real) -> Self {
+        SharedShape::capsule(start.into(), end.into(), radius).into()
     }
 
     /// Initialize a new collider with a capsule shape aligned with the `x` axis.

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -647,11 +647,11 @@ impl Collider {
         &self,
         ray_origin: Vect,
         ray_dir: Vect,
-        max_toi: Real,
+        max_time_of_impact: Real,
         solid: bool,
     ) -> Option<Real> {
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
-        self.raw.cast_local_ray(&ray, max_toi, solid)
+        self.raw.cast_local_ray(&ray, max_time_of_impact, solid)
     }
 
     /// Computes the time of impact, and normal between this transformed shape and a ray.
@@ -659,19 +659,24 @@ impl Collider {
         &self,
         ray_origin: Vect,
         ray_dir: Vect,
-        max_toi: Real,
+        max_time_of_impact: Real,
         solid: bool,
     ) -> Option<RayIntersection> {
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
         self.raw
-            .cast_local_ray_and_get_normal(&ray, max_toi, solid)
+            .cast_local_ray_and_get_normal(&ray, max_time_of_impact, solid)
             .map(|inter| RayIntersection::from_rapier(inter, ray_origin, ray_dir))
     }
 
     /// Tests whether a ray intersects this transformed shape.
-    pub fn intersects_local_ray(&self, ray_origin: Vect, ray_dir: Vect, max_toi: Real) -> bool {
+    pub fn intersects_local_ray(
+        &self,
+        ray_origin: Vect,
+        ray_dir: Vect,
+        max_time_of_impact: Real,
+    ) -> bool {
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
-        self.raw.intersects_local_ray(&ray, max_toi)
+        self.raw.intersects_local_ray(&ray, max_time_of_impact)
     }
 
     /// Computes the time of impact between this transform shape and a ray.
@@ -681,12 +686,12 @@ impl Collider {
         rotation: Rot,
         ray_origin: Vect,
         ray_dir: Vect,
-        max_toi: Real,
+        max_time_of_impact: Real,
         solid: bool,
     ) -> Option<Real> {
         let pos = (translation, rotation).into();
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
-        self.raw.cast_ray(&pos, &ray, max_toi, solid)
+        self.raw.cast_ray(&pos, &ray, max_time_of_impact, solid)
     }
 
     /// Computes the time of impact, and normal between this transformed shape and a ray.
@@ -696,13 +701,13 @@ impl Collider {
         rotation: Rot,
         ray_origin: Vect,
         ray_dir: Vect,
-        max_toi: Real,
+        max_time_of_impact: Real,
         solid: bool,
     ) -> Option<RayIntersection> {
         let pos = (translation, rotation).into();
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
         self.raw
-            .cast_ray_and_get_normal(&pos, &ray, max_toi, solid)
+            .cast_ray_and_get_normal(&pos, &ray, max_time_of_impact, solid)
             .map(|inter| RayIntersection::from_rapier(inter, ray_origin, ray_dir))
     }
 
@@ -713,11 +718,11 @@ impl Collider {
         rotation: Rot,
         ray_origin: Vect,
         ray_dir: Vect,
-        max_toi: Real,
+        max_time_of_impact: Real,
     ) -> bool {
         let pos = (translation, rotation).into();
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
-        self.raw.intersects_ray(&pos, &ray, max_toi)
+        self.raw.intersects_ray(&pos, &ray, max_time_of_impact)
     }
 }
 

--- a/src/geometry/shape_views/capsule.rs
+++ b/src/geometry/shape_views/capsule.rs
@@ -76,9 +76,9 @@ impl_ref_methods!(CapsuleViewMut);
 
 impl<'a> CapsuleViewMut<'a> {
     /// Set the segment of this capsule.
-    pub fn set_segment(&mut self, a: Vect, b: Vect) {
-        self.raw.segment.a = a.into();
-        self.raw.segment.b = b.into();
+    pub fn set_segment(&mut self, axis: Vect, endpoint: Vect) {
+        self.raw.segment.a = axis.into();
+        self.raw.segment.b = endpoint.into();
     }
 
     /// Set the radius of this capsule.

--- a/src/geometry/shape_views/capsule.rs
+++ b/src/geometry/shape_views/capsule.rs
@@ -76,9 +76,9 @@ impl_ref_methods!(CapsuleViewMut);
 
 impl<'a> CapsuleViewMut<'a> {
     /// Set the segment of this capsule.
-    pub fn set_segment(&mut self, axis: Vect, endpoint: Vect) {
-        self.raw.segment.a = axis.into();
-        self.raw.segment.b = endpoint.into();
+    pub fn set_segment(&mut self, start: Vect, end: Vect) {
+        self.raw.segment.a = start.into();
+        self.raw.segment.b = end.into();
     }
 
     /// Set the radius of this capsule.

--- a/src/geometry/shape_views/heightfield.rs
+++ b/src/geometry/shape_views/heightfield.rs
@@ -38,8 +38,8 @@ macro_rules! impl_ref_methods(
             }
 
             /// Index of the cell a point is on after vertical projection.
-            pub fn cell_at_point(&self, pt: Vect) -> Option<usize> {
-                self.raw.cell_at_point(&pt.into())
+            pub fn cell_at_point(&self, point: Vect) -> Option<usize> {
+                self.raw.cell_at_point(&point.into())
             }
 
             /// Iterator through all the segments of this heightfield.
@@ -103,8 +103,8 @@ macro_rules! impl_ref_methods(
             }
 
             /// Index of the cell a point is on after vertical projection.
-            pub fn cell_at_point(&self, pt: Vect) -> Option<(usize, usize)> {
-                self.raw.cell_at_point(&pt.into())
+            pub fn cell_at_point(&self, point: Vect) -> Option<(usize, usize)> {
+                self.raw.cell_at_point(&point.into())
             }
 
             /// Iterator through all the triangles of this heightfield.


### PR DESCRIPTION
Some function had really unclear argument names, specifically the capsule ones. I was completely stumped when I first saw the capsule function.

Also removed some abbreviations in the arguments, while pt is relatively obvious, it is better to be as explicit as possible in the user facing API.