### PR TITLE
Generate convex hull from bevy mesh option

### DIFF
--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -51,6 +51,8 @@ pub enum ComputedColliderShape {
     /// Triangle-mesh.
     #[default]
     TriMesh,
+    /// Convex hull.
+    ConvexHull,
     /// Convex decomposition.
     ConvexDecomposition(VHACDParameters),
 }

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -174,13 +174,13 @@ impl Collider {
     pub fn from_bevy_mesh(mesh: &Mesh, collider_shape: &ComputedColliderShape) -> Option<Self> {
         let Some((vtx, idx)) = extract_mesh_vertices_indices(mesh) else { return None; };
         match collider_shape {
-            ComputedColliderShape::TriMesh => {
-                Some(SharedShape::trimesh_with_flags(vtx, idx, TriMeshFlags::MERGE_DUPLICATE_VERTICES)
-                    .into())
-            },
+            ComputedColliderShape::TriMesh => Some(
+                SharedShape::trimesh_with_flags(vtx, idx, TriMeshFlags::MERGE_DUPLICATE_VERTICES)
+                    .into(),
+            ),
             ComputedColliderShape::ConvexHull => {
                 SharedShape::convex_hull(&vtx).map(|shape| shape.into())
-            },
+            }
             ComputedColliderShape::ConvexDecomposition(params) => {
                 Some(SharedShape::convex_decomposition_with_params(&vtx, &idx, params).into())
             }


### PR DESCRIPTION
Option for generating a more reliable guess at a meshes collider even if it is less accurate.