### PR TITLE
RapierContext::colliders convenience method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Added
+- Add `RapierContext::rigid_body_colliders` to retrieve all collider entities attached to this rigid-body.
+
 ## 0.22.0 (10 July 2023)
 ### Modified
 - Update to Bevy 0.11.

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -117,6 +117,20 @@ impl RapierContext {
             .and_then(|h| self.rigid_body_entity(h))
     }
 
+    /// If entity is a rigid-body, this returns the collider `Entity`s attached
+    /// to that rigid-body.
+    pub fn colliders(&self, entity: Entity) -> impl Iterator<Item = Entity> + '_ {
+        self.entity2body()
+            .get(&entity)
+            .map(|handle| self.bodies.get(*handle))
+            .flatten()
+            .map(|body| body.colliders())
+            .map(|colliders| colliders.iter().filter_map(|handle| self.collider_entity(*handle)))
+            .map(|colliders| colliders)
+            .into_iter()
+            .flatten()
+    }
+
     /// Retrieve the Bevy entity the given Rapier collider (identified by its handle) is attached.
     pub fn collider_entity(&self, handle: ColliderHandle) -> Option<Entity> {
         Self::collider_entity_with_set(&self.colliders, handle)

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -124,9 +124,11 @@ impl RapierContext {
             .get(&entity)
             .map(|handle| self.bodies.get(*handle))
             .flatten()
-            .map(|body| body.colliders())
-            .map(|colliders| colliders.iter().filter_map(|handle| self.collider_entity(*handle)))
-            .map(|colliders| colliders)
+            .map(|body| {
+                body.colliders()
+                    .iter()
+                    .filter_map(|handle| self.collider_entity(*handle))
+            })
             .into_iter()
             .flatten()
     }

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -122,8 +122,7 @@ impl RapierContext {
     pub fn colliders(&self, entity: Entity) -> impl Iterator<Item = Entity> + '_ {
         self.entity2body()
             .get(&entity)
-            .map(|handle| self.bodies.get(*handle))
-            .flatten()
+            .and_then(|handle| self.bodies.get(*handle))
             .map(|body| {
                 body.colliders()
                     .iter()

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -119,7 +119,7 @@ impl RapierContext {
 
     /// If entity is a rigid-body, this returns the collider `Entity`s attached
     /// to that rigid-body.
-    pub fn colliders(&self, entity: Entity) -> impl Iterator<Item = Entity> + '_ {
+    pub fn rigid_body_colliders(&self, entity: Entity) -> impl Iterator<Item = Entity> + '_ {
         self.entity2body()
             .get(&entity)
             .and_then(|handle| self.bodies.get(*handle))


### PR DESCRIPTION
Inverse method of `collider_parent` for getting all of the colliders of a rigidbody.