### PR TITLE
Clean up `SyncBackend` SystemConfigs, apply scale after `init_colliders`

### DIFF
--- a/bevy_rapier2d/examples/custom_system_setup2.rs
+++ b/bevy_rapier2d/examples/custom_system_setup2.rs
@@ -20,7 +20,6 @@ fn main() {
         PostUpdate,
         (
             PhysicsSet::SyncBackend,
-            PhysicsSet::SyncBackendFlush,
             PhysicsSet::StepSimulation,
             PhysicsSet::Writeback,
         )
@@ -33,8 +32,6 @@ fn main() {
         (
             RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::SyncBackend)
                 .in_set(PhysicsSet::SyncBackend),
-            RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::SyncBackendFlush)
-                .in_set(PhysicsSet::SyncBackendFlush),
             (
                 RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::StepSimulation),
                 despawn_one_box,

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -20,7 +20,6 @@ fn main() {
         PostUpdate,
         (
             PhysicsSet::SyncBackend,
-            PhysicsSet::SyncBackendFlush,
             PhysicsSet::StepSimulation,
             PhysicsSet::Writeback,
         )
@@ -33,8 +32,6 @@ fn main() {
         (
             RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::SyncBackend)
                 .in_set(PhysicsSet::SyncBackend),
-            RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::SyncBackendFlush)
-                .in_set(PhysicsSet::SyncBackendFlush),
             (
                 RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::StepSimulation),
                 despawn_one_box,

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -73,6 +73,7 @@ where
                     .in_set(RapierTransformPropagateSet),
                 #[cfg(all(feature = "dim3", feature = "async-collider"))]
                 systems::init_async_scene_colliders.after(bevy::scene::scene_spawner_system),
+                #[cfg(all(feature = "dim3", feature = "async-collider"))]
                 systems::init_async_colliders,
                 systems::init_rigid_bodies,
                 systems::init_colliders,

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -73,7 +73,9 @@ where
                     .after(systems::update_character_controls)
                     .in_set(RapierTransformPropagateSet),
                 systems::init_async_colliders.after(RapierTransformPropagateSet),
-                systems::apply_scale.after(systems::init_async_colliders),
+                systems::apply_scale
+                    .after(systems::init_async_colliders)
+                    .after(systems::init_colliders),
                 systems::apply_collider_user_changes.after(systems::apply_scale),
                 systems::apply_rigid_body_user_changes.after(systems::apply_collider_user_changes),
                 systems::apply_joint_user_changes.after(systems::apply_rigid_body_user_changes),

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -77,16 +77,17 @@ where
                 systems::init_rigid_bodies,
                 systems::init_colliders,
                 systems::init_joints,
+                systems::sync_removals,
+                // Run this here so the folowwing systems do not have a 1 frame delay.
+                apply_deferred,
                 systems::apply_scale,
                 systems::apply_collider_user_changes,
                 systems::apply_rigid_body_user_changes,
                 systems::apply_joint_user_changes,
                 systems::apply_initial_rigid_body_impulses,
-                systems::sync_removals,
             )
                 .chain()
                 .into_configs(),
-            PhysicsSet::SyncBackendFlush => (apply_deferred,).into_configs(),
             PhysicsSet::StepSimulation => (
                 systems::step_simulation::<PhysicsHooks>,
                 Events::<CollisionEvent>::update_system
@@ -127,8 +128,6 @@ pub enum PhysicsSet {
     /// initializing) backend data structures with current component state.
     /// These systems typically run at the after [`CoreSet::Update`].
     SyncBackend,
-    /// The copy of [`apply_system_buffers`] that runs immediately after [`PhysicsSet::SyncBackend`].
-    SyncBackendFlush,
     /// The systems responsible for advancing the physics simulation, and
     /// updating the internal state for scene queries.
     /// These systems typically run immediately after [`PhysicsSet::SyncBackend`].
@@ -187,7 +186,6 @@ where
                 PostUpdate,
                 (
                     PhysicsSet::SyncBackend,
-                    PhysicsSet::SyncBackendFlush,
                     PhysicsSet::StepSimulation,
                     PhysicsSet::Writeback,
                 )
@@ -199,8 +197,6 @@ where
                 PostUpdate,
                 (
                     Self::get_systems(PhysicsSet::SyncBackend).in_set(PhysicsSet::SyncBackend),
-                    Self::get_systems(PhysicsSet::SyncBackendFlush)
-                        .in_set(PhysicsSet::SyncBackendFlush),
                     Self::get_systems(PhysicsSet::StepSimulation)
                         .in_set(PhysicsSet::StepSimulation),
                     Self::get_systems(PhysicsSet::Writeback).in_set(PhysicsSet::Writeback),

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -70,31 +70,21 @@ where
                     bevy::transform::systems::propagate_transforms,
                 )
                     .chain()
-                    .after(systems::update_character_controls)
                     .in_set(RapierTransformPropagateSet),
-                systems::init_async_colliders.after(RapierTransformPropagateSet),
-                systems::apply_scale
-                    .after(systems::init_async_colliders)
-                    .after(systems::init_colliders),
-                systems::apply_collider_user_changes.after(systems::apply_scale),
-                systems::apply_rigid_body_user_changes.after(systems::apply_collider_user_changes),
-                systems::apply_joint_user_changes.after(systems::apply_rigid_body_user_changes),
-                systems::init_rigid_bodies.after(systems::apply_joint_user_changes),
-                systems::init_colliders
-                    .after(systems::init_rigid_bodies)
-                    .after(systems::init_async_colliders),
-                systems::init_joints.after(systems::init_colliders),
-                systems::apply_initial_rigid_body_impulses
-                    .after(systems::init_colliders)
-                    .ambiguous_with(systems::init_joints),
-                systems::sync_removals
-                    .after(systems::init_joints)
-                    .after(systems::apply_initial_rigid_body_impulses),
                 #[cfg(all(feature = "dim3", feature = "async-collider"))]
-                systems::init_async_scene_colliders
-                    .after(bevy::scene::scene_spawner_system)
-                    .before(systems::init_async_colliders),
+                systems::init_async_scene_colliders.after(bevy::scene::scene_spawner_system),
+                systems::init_async_colliders,
+                systems::init_rigid_bodies,
+                systems::init_colliders,
+                systems::init_joints,
+                systems::apply_scale,
+                systems::apply_collider_user_changes,
+                systems::apply_rigid_body_user_changes,
+                systems::apply_joint_user_changes,
+                systems::apply_initial_rigid_body_impulses,
+                systems::sync_removals,
             )
+                .chain()
                 .into_configs(),
             PhysicsSet::SyncBackendFlush => (apply_deferred,).into_configs(),
             PhysicsSet::StepSimulation => (

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -695,10 +695,6 @@ pub fn step_simulation<Hooks>(
     }
 }
 
-/// NOTE: This currently does nothing in 2D, or without the async-collider feature
-#[cfg(any(feature = "dim2", not(feature = "async-collider")))]
-pub fn init_async_colliders() {}
-
 /// System responsible for creating `Collider` components from `AsyncCollider` components if the
 /// corresponding mesh has become available.
 #[cfg(all(feature = "dim3", feature = "async-collider"))]


### PR DESCRIPTION
- Refactors the `SyncBackend` into a chain of systems as that was what it effectively was beforehand.
- `SyncBackendFlush` is merged into `SyncBackend` before the `apply_*` systems are run so we can avoid a 1 frame delay.
- `apply_scale` is now ran after `init_colliders`, prior to this it would cause intermittent issues where scale was not applied until the next `Changed<Collider>`.
- Removes the 2d/no async-colliders feature dummy system, I'm assuming it was used because of errors from adding systems to the app?