### PR TITLE
Update `ReadMassProperties` to reflect rapier's mass properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fix
 - Fix debug-renderer lagging one frame behind.
 - Fix Collider `Transform` rotation change not being taken into account by the physics engine.
+- Fix automatic update of `ReadMassProperties`.
 
 ## 0.22.0 (10 July 2023)
 ### Modified

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -172,9 +172,9 @@ impl ReadMassProperties {
 
 /// Entity that likely had their mass properties changed this frame.
 #[derive(Deref, Copy, Clone, Debug, PartialEq, Event)]
-pub struct MassModified(pub Entity);
+pub struct MassModifiedEvent(pub Entity);
 
-impl From<Entity> for MassModified {
+impl From<Entity> for MassModifiedEvent {
     fn from(entity: Entity) -> Self {
         Self(entity)
     }

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -157,7 +157,14 @@ impl Default for AdditionalMassProperties {
 /// and the `AdditionalMassProperties` should be modified instead).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
 #[reflect(Component, PartialEq)]
-pub struct ReadMassProperties(pub MassProperties);
+pub struct ReadMassProperties(MassProperties);
+
+impl ReadMassProperties {
+    /// Get the [`MassProperties`] of this rigid-body.
+    pub fn get(&self) -> &MassProperties {
+        &self.0
+    }
+}
 
 /// Center-of-mass, mass, and angular inertia.
 ///

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -170,6 +170,16 @@ impl ReadMassProperties {
     }
 }
 
+/// Entity that likely had their mass properties changed this frame.
+#[derive(Deref, Copy, Clone, Debug, PartialEq, Event)]
+pub struct MassModified(pub Entity);
+
+impl From<Entity> for MassModified {
+    fn from(entity: Entity) -> Self {
+        Self(entity)
+    }
+}
+
 /// Center-of-mass, mass, and angular inertia.
 ///
 /// This cannot be used as a component. Use the components `ReadMassProperties` to read a rigid-body’s

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -164,6 +164,10 @@ impl ReadMassProperties {
     pub fn get(&self) -> &MassProperties {
         &self.0
     }
+
+    pub(crate) fn set(&mut self, mass_props: MassProperties) {
+        self.0 = mass_props;
+    }
 }
 
 /// Center-of-mass, mass, and angular inertia.

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -106,6 +106,7 @@ where
             PhysicsSet::Writeback => (
                 systems::update_colliding_entities,
                 systems::writeback_rigid_bodies,
+                systems::writeback_mass_properties,
             )
                 .into_configs(),
         }

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -181,6 +181,7 @@ where
         // Insert all of our required resources. Don’t overwrite
         // the `RapierConfiguration` if it already exists.
         app.init_resource::<RapierConfiguration>();
+        app.init_resource::<systems::ModifiedMasses>();
 
         app.insert_resource(SimulationToRenderTime::default())
             .insert_resource(RapierContext {

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -117,7 +117,7 @@ where
                 systems::update_colliding_entities,
                 systems::writeback_rigid_bodies,
                 systems::writeback_mass_properties,
-                Events::<MassModified>::update_system.after(systems::writeback_mass_properties),
+                Events::<MassModifiedEvent>::update_system.after(systems::writeback_mass_properties),
             )
                 .into_configs(),
         }
@@ -199,7 +199,7 @@ where
             })
             .insert_resource(Events::<CollisionEvent>::default())
             .insert_resource(Events::<ContactForceEvent>::default())
-            .insert_resource(Events::<MassModified>::default());
+            .insert_resource(Events::<MassModifiedEvent>::default());
 
         // Add each set as necessary
         if self.default_system_setup {

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -117,7 +117,8 @@ where
                 systems::update_colliding_entities,
                 systems::writeback_rigid_bodies,
                 systems::writeback_mass_properties,
-                Events::<MassModifiedEvent>::update_system.after(systems::writeback_mass_properties),
+                Events::<MassModifiedEvent>::update_system
+                    .after(systems::writeback_mass_properties),
             )
                 .into_configs(),
         }

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -107,8 +107,7 @@ where
                 systems::update_colliding_entities,
                 systems::writeback_rigid_bodies,
                 systems::writeback_mass_properties,
-                Events::<MassModified>::update_system
-                    .after(systems::writeback_mass_properties),
+                Events::<MassModified>::update_system.after(systems::writeback_mass_properties),
             )
                 .into_configs(),
         }

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -107,6 +107,8 @@ where
                 systems::update_colliding_entities,
                 systems::writeback_rigid_bodies,
                 systems::writeback_mass_properties,
+                Events::<MassModified>::update_system
+                    .after(systems::writeback_mass_properties),
             )
                 .into_configs(),
         }
@@ -181,7 +183,6 @@ where
         // Insert all of our required resources. Don’t overwrite
         // the `RapierConfiguration` if it already exists.
         app.init_resource::<RapierConfiguration>();
-        app.init_resource::<systems::ModifiedMasses>();
 
         app.insert_resource(SimulationToRenderTime::default())
             .insert_resource(RapierContext {
@@ -189,7 +190,8 @@ where
                 ..Default::default()
             })
             .insert_resource(Events::<CollisionEvent>::default())
-            .insert_resource(Events::<ContactForceEvent>::default());
+            .insert_resource(Events::<ContactForceEvent>::default())
+            .insert_resource(Events::<MassModified>::default());
 
         // Add each set as necessary
         if self.default_system_setup {

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -16,7 +16,7 @@ use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
 use crate::plugin::{RapierConfiguration, RapierContext};
 use crate::prelude::{
     BevyPhysicsHooks, BevyPhysicsHooksAdapter, CollidingEntities, KinematicCharacterController,
-    KinematicCharacterControllerOutput, RigidBodyDisabled, Vect, MassModified,
+    KinematicCharacterControllerOutput, MassModified, RigidBodyDisabled, Vect,
 };
 use crate::utils;
 use bevy::ecs::system::{StaticSystemParam, SystemParamItem};
@@ -689,7 +689,7 @@ pub fn writeback_mass_properties(
 
     if config.physics_pipeline_active {
         for entity in mass_modified.iter() {
-            if let Some(handle) = context.entity2body.get(&entity).copied() {
+            if let Some(handle) = context.entity2body.get(entity).copied() {
                 if let Some(rb) = context.bodies.get(handle) {
                     if let Ok(mut mass_props) = mass_props.get_mut(**entity) {
                         let new_mass_props =

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -16,7 +16,7 @@ use crate::plugin::configuration::{SimulationToRenderTime, TimestepMode};
 use crate::plugin::{RapierConfiguration, RapierContext};
 use crate::prelude::{
     BevyPhysicsHooks, BevyPhysicsHooksAdapter, CollidingEntities, KinematicCharacterController,
-    KinematicCharacterControllerOutput, MassModified, RigidBodyDisabled,
+    KinematicCharacterControllerOutput, MassModifiedEvent, RigidBodyDisabled,
 };
 use crate::utils;
 use bevy::ecs::system::{StaticSystemParam, SystemParamItem};
@@ -155,7 +155,7 @@ pub fn apply_collider_user_changes(
         Changed<ColliderMassProperties>,
     >,
 
-    mut mass_modified: EventWriter<MassModified>,
+    mut mass_modified: EventWriter<MassModifiedEvent>,
 ) {
     let scale = context.physics_scale;
 
@@ -304,7 +304,7 @@ pub fn apply_rigid_body_user_changes(
         Changed<RigidBodyDisabled>,
     >,
 
-    mut mass_modified: EventWriter<MassModified>,
+    mut mass_modified: EventWriter<MassModifiedEvent>,
 ) {
     let context = &mut *context;
     let scale = context.physics_scale;
@@ -676,7 +676,7 @@ pub fn writeback_mass_properties(
     config: Res<RapierConfiguration>,
 
     mut mass_props: Query<&mut ReadMassProperties>,
-    mut mass_modified: EventReader<MassModified>,
+    mut mass_modified: EventReader<MassModifiedEvent>,
 ) {
     let context = &mut *context;
     let scale = context.physics_scale;
@@ -1181,7 +1181,7 @@ pub fn sync_removals(
     mut removed_rigid_body_disabled: RemovedComponents<RigidBodyDisabled>,
     mut removed_colliders_disabled: RemovedComponents<ColliderDisabled>,
 
-    mut mass_modified: EventWriter<MassModified>,
+    mut mass_modified: EventWriter<MassModifiedEvent>,
 ) {
     /*
      * Rigid-bodies removal detection.

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -546,8 +546,15 @@ pub fn writeback_rigid_bodies(
     let scale = context.physics_scale;
 
     if config.physics_pipeline_active {
-        for (entity, parent, transform, mut interpolation, mut velocity, mut sleeping, mut mass_props) in
-            writeback.iter_mut()
+        for (
+            entity,
+            parent,
+            transform,
+            mut interpolation,
+            mut velocity,
+            mut sleeping,
+            mut mass_props,
+        ) in writeback.iter_mut()
         {
             // TODO: do this the other way round: iterate through Rapier’s RigidBodySet on the active bodies,
             // and update the components accordingly. That way, we don’t have to iterate through the entities that weren’t changed
@@ -697,7 +704,8 @@ pub fn writeback_mass_properties(
             if let Some(handle) = context.entity2body.get(&entity).copied() {
                 if let Some(rb) = context.bodies.get(handle) {
                     if let Ok(mut mass_props) = mass_props.get_mut(entity) {
-                        let new_mass_props = MassProperties::from_rapier(rb.mass_properties().local_mprops, scale);
+                        let new_mass_props =
+                            MassProperties::from_rapier(rb.mass_properties().local_mprops, scale);
 
                         // NOTE: we write the new value only if there was an
                         //       actual change, in order to not trigger bevy’s

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -42,7 +42,6 @@ pub type RigidBodyWritebackComponents<'a> = (
     Option<&'a mut TransformInterpolation>,
     Option<&'a mut Velocity>,
     Option<&'a mut Sleeping>,
-    Option<&'a mut ReadMassProperties>,
 );
 
 /// Components related to rigid-bodies.
@@ -553,7 +552,6 @@ pub fn writeback_rigid_bodies(
             mut interpolation,
             mut velocity,
             mut sleeping,
-            mut mass_props,
         ) in writeback.iter_mut()
         {
             // TODO: do this the other way round: iterate through Rapier’s RigidBodySet on the active bodies,

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -677,7 +677,8 @@ pub fn writeback_rigid_bodies(
 }
 
 /// Entities that likely had their mass properties changed this frame.
-#[derive(Resource, Deref, DerefMut)]
+#[derive(Resource, Deref, DerefMut, Default, Reflect)]
+#[reflect(Resource)]
 pub struct ModifiedMasses(pub Vec<Entity>);
 
 /// System responsible for writing updated mass properties back into the [`ReadMassProperties`] component.

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -1175,6 +1175,8 @@ pub fn sync_removals(
     mut removed_sensors: RemovedComponents<Sensor>,
     mut removed_rigid_body_disabled: RemovedComponents<RigidBodyDisabled>,
     mut removed_colliders_disabled: RemovedComponents<ColliderDisabled>,
+
+    mut modified_masses: ResMut<ModifiedMasses>,
 ) {
     /*
      * Rigid-bodies removal detection.
@@ -1214,6 +1216,10 @@ pub fn sync_removals(
      * Collider removal detection.
      */
     for entity in removed_colliders.iter() {
+        if let Some(body) = context.collider_parent(entity) {
+            modified_masses.push(body);
+        }
+
         if let Some(handle) = context.entity2collider.remove(&entity) {
             context
                 .colliders
@@ -1223,6 +1229,10 @@ pub fn sync_removals(
     }
 
     for entity in orphan_colliders.iter() {
+        if let Some(body) = context.collider_parent(entity) {
+            modified_masses.push(body);
+        }
+
         if let Some(handle) = context.entity2collider.remove(&entity) {
             context
                 .colliders
@@ -1293,7 +1303,6 @@ pub fn sync_removals(
         }
     }
 
-    // TODO: update mass props after collider removal.
     // TODO: what about removing forces?
 }
 

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -545,14 +545,8 @@ pub fn writeback_rigid_bodies(
     let scale = context.physics_scale;
 
     if config.physics_pipeline_active {
-        for (
-            entity,
-            parent,
-            transform,
-            mut interpolation,
-            mut velocity,
-            mut sleeping,
-        ) in writeback.iter_mut()
+        for (entity, parent, transform, mut interpolation, mut velocity, mut sleeping) in
+            writeback.iter_mut()
         {
             // TODO: do this the other way round: iterate through Rapier’s RigidBodySet on the active bodies,
             // and update the components accordingly. That way, we don’t have to iterate through the entities that weren’t changed


### PR DESCRIPTION
Also protects the internal `MassProperties` from direct modification.

Currently a relatively un-optimized version where I don't even try to guess when it would change.

I think I'd like to change this to update only if one of these has changed:
- ColliderMassProperties
- Collider::scale
- AdditionalMassProperties