### PR TITLE
Added `locked_axes()` and `set_locked_axes()` methods for (some) joints

### DIFF
--- a/src/dynamics/fixed_joint.rs
+++ b/src/dynamics/fixed_joint.rs
@@ -81,6 +81,11 @@ impl FixedJoint {
         self.data.set_local_anchor2(anchor2);
         self
     }
+
+    /// Returns the locked axes that are set for the fixed joint.
+    pub fn locked_axes(&self) -> JointAxesMask {
+        self.data.locked_axes()
+    }
 }
 
 impl From<FixedJoint> for GenericJoint {

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -9,6 +9,7 @@ pub use self::rope_joint::*;
 
 use bevy::reflect::Reflect;
 use rapier::dynamics::CoefficientCombineRule as RapierCoefficientCombineRule;
+pub use rapier::dynamics::{JointAxesMask, JointAxis};
 
 #[cfg(feature = "dim3")]
 pub use self::spherical_joint::*;

--- a/src/dynamics/prismatic_joint.rs
+++ b/src/dynamics/prismatic_joint.rs
@@ -86,6 +86,21 @@ impl PrismaticJoint {
         self
     }
 
+    /// Returns the locked axes that are set for the prismatic joint.
+    pub fn locked_axes(&self) -> JointAxesMask {
+        self.data.locked_axes()
+    }
+
+    /// Allows you to set the locked axes for the prismatic joint
+    /// If the inputed axes enable any of the axes that are included in
+    /// `JointAxesMask::LOCKED_PRISMATIC_AXES`, then they won't have an effect.
+    pub fn set_locked_axes(mut self, axes: JointAxesMask) -> Self {
+        let mut filtered_axes = axes;
+        filtered_axes.set(JointAxesMask::LOCKED_PRISMATIC_AXES, false);
+        self.data.lock_axes(filtered_axes);
+        self
+    }
+
     /// The motor affecting the joint’s translational degree of freedom.
     #[must_use]
     pub fn motor(&self) -> Option<&JointMotor> {
@@ -195,6 +210,16 @@ impl PrismaticJointBuilder {
     #[must_use]
     pub fn local_axis2(mut self, axis2: Vect) -> Self {
         self.0.set_local_axis2(axis2);
+        self
+    }
+
+    /// Allows you to set the locked axes for the prismatic joint
+    /// If the inputed axes enable any of the axes that are included in
+    /// `JointAxesMask::LOCKED_PRISMATIC_AXES`, then they won't have an effect.
+    pub fn lock_axes(mut self, axes: JointAxesMask) -> Self {
+        let mut filtered_axes = axes;
+        filtered_axes.set(JointAxesMask::LOCKED_PRISMATIC_AXES, false);
+        self.0.data.lock_axes(filtered_axes);
         self
     }
 

--- a/src/dynamics/revolute_joint.rs
+++ b/src/dynamics/revolute_joint.rs
@@ -77,6 +77,21 @@ impl RevoluteJoint {
         self
     }
 
+    /// Returns the locked axes that are set for the revolute joint.
+    pub fn locked_axes(&self) -> JointAxesMask {
+        self.data.locked_axes()
+    }
+
+    /// Allows you to set the locked axes for the revolute joint
+    /// If the inputed axes enable any of the axes that are included in
+    /// `JointAxesMask::LOCKED_REVOLUTE_AXES`, then they won't have an effect.
+    pub fn set_locked_axes(mut self, axes: JointAxesMask) -> Self {
+        let mut filtered_axes = axes;
+        filtered_axes.set(JointAxesMask::LOCKED_REVOLUTE_AXES, false);
+        self.data.lock_axes(filtered_axes);
+        self
+    }
+
     /// The motor affecting the joint’s rotational degree of freedom.
     #[must_use]
     pub fn motor(&self) -> Option<&JointMotor> {
@@ -186,6 +201,16 @@ impl RevoluteJointBuilder {
     #[must_use]
     pub fn local_anchor2(mut self, anchor2: Vect) -> Self {
         self.0.set_local_anchor2(anchor2);
+        self
+    }
+
+    /// Allows you to set the locked axes for the revolute joint
+    /// If the inputed axes enable any of the axes that are included in
+    /// `JointAxesMask::LOCKED_REVOLUTE_AXES`, then they won't have an effect.
+    pub fn lock_axes(mut self, axes: JointAxesMask) -> Self {
+        let mut filtered_axes = axes;
+        filtered_axes.set(JointAxesMask::LOCKED_REVOLUTE_AXES, false);
+        self.0.data.lock_axes(filtered_axes);
         self
     }
 

--- a/src/dynamics/rope_joint.rs
+++ b/src/dynamics/rope_joint.rs
@@ -83,6 +83,21 @@ impl RopeJoint {
         self
     }
 
+    /// Returns the locked axes that are set for the rope joint.
+    pub fn locked_axes(&self) -> JointAxesMask {
+        self.data.locked_axes()
+    }
+
+    /// Allows you to set the locked axes for the rope joint
+    /// If the inputed axes enable any of the axes that are included in
+    /// `JointAxesMask::LOCKED_FIXED_AXES`, then they won't have an effect.
+    pub fn set_locked_axes(mut self, axes: JointAxesMask) -> Self {
+        let mut filtered_axes = axes;
+        filtered_axes.set(JointAxesMask::LOCKED_FIXED_AXES, false);
+        self.data.lock_axes(filtered_axes);
+        self
+    }
+
     /// The motor affecting the joint’s translational degree of freedom.
     #[must_use]
     pub fn motor(&self, axis: JointAxis) -> Option<&JointMotor> {
@@ -222,6 +237,16 @@ impl RopeJointBuilder {
     #[must_use]
     pub fn local_axis2(mut self, axis2: Vect) -> Self {
         self.0.set_local_axis2(axis2);
+        self
+    }
+
+    /// Allows you to set the locked axes for the rope joint
+    /// If the inputed axes enable any of the axes that are included in
+    /// `JointAxesMask::LOCKED_FIXED_AXES`, then they won't have an effect.
+    pub fn lock_axes(mut self, axes: JointAxesMask) -> Self {
+        let mut filtered_axes = axes;
+        filtered_axes.set(JointAxesMask::LOCKED_FIXED_AXES, false);
+        self.0.data.lock_axes(filtered_axes);
         self
     }
 

--- a/src/dynamics/spherical_joint.rs
+++ b/src/dynamics/spherical_joint.rs
@@ -63,6 +63,21 @@ impl SphericalJoint {
         self
     }
 
+    /// Returns the locked axes that are set for the spherical joint.
+    pub fn locked_axes(&self) -> JointAxesMask {
+        self.data.locked_axes()
+    }
+
+    /// Allows you to set the locked axes for the spherical joint
+    /// If the inputed axes enable any of the axes that are included in
+    /// `JointAxesMask::LOCKED_SPHERICAL_AXES`, then they won't have an effect.
+    pub fn set_locked_axes(mut self, axes: JointAxesMask) -> Self {
+        let mut filtered_axes = axes;
+        filtered_axes.set(JointAxesMask::LOCKED_SPHERICAL_AXES, false);
+        self.data.lock_axes(filtered_axes);
+        self
+    }
+
     /// The motor affecting the joint’s rotational degree of freedom along the specified axis.
     #[must_use]
     pub fn motor(&self, axis: JointAxis) -> Option<&JointMotor> {
@@ -166,6 +181,16 @@ impl SphericalJointBuilder {
     #[must_use]
     pub fn local_anchor2(mut self, anchor2: Vect) -> Self {
         self.0.set_local_anchor2(anchor2);
+        self
+    }
+
+    /// Allows you to set the locked axes for the spherical joint
+    /// If the inputed axes enable any of the axes that are included in
+    /// `JointAxesMask::LOCKED_SPHERICAL_AXES`, then they won't have an effect.
+    pub fn lock_axes(mut self, axes: JointAxesMask) -> Self {
+        let mut filtered_axes = axes;
+        filtered_axes.set(JointAxesMask::LOCKED_SPHERICAL_AXES, false);
+        self.0.data.lock_axes(filtered_axes);
         self
     }
 


### PR DESCRIPTION
### Implemented `locked_axes(&self)` for all of these structs:
- `FixedJoint`
- `PrismaticJoint`
- `RevoluteJoint`
- `RopeJoint`
- `SphericalJoint`

`locked_axes(&self)` returns all of the axes that are currently locked by the joint.

### Implemented `set_locked_axes(&mut self, axes: JointAxesMask)` for all of these structs:
- `PrismaticJoint`
- `RevoluteJoint`
- `RopeJoint`
- `SphericalJoint`

`set_locked_axes(&mut self, axes: JointAxesMask)` allows you to lock axes that aren't already locked by the default axes.

### implemented `lock_axes(&mut self, axes: JointAxesMask)` for all of these structs:
- `PrismaticJointBuilder`
- `RevoluteJointBuilder`
- `RopeJointBuilder`
- `SphericalJointBuilder`

`lock_axes(&mut self, axes: JointAxesMask)` works exactly the same as `set_locked_axes()`, but is only implemented for Joint builders.

### Made `JointAxesMask` and `JointAxis` publicly available, rather than having to import them through rapier.