### PR TITLE
Update the integration parameter delta time

### DIFF
--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -217,6 +217,8 @@ impl RapierContext {
                 time_scale,
                 substeps,
             } => {
+                self.integration_parameters.dt = dt;
+
                 sim_to_render_time.diff += time.delta_seconds();
 
                 while sim_to_render_time.diff > 0.0 {
@@ -265,9 +267,10 @@ impl RapierContext {
                 time_scale,
                 substeps,
             } => {
+                self.integration_parameters.dt = (time.delta_seconds() * time_scale).min(max_dt);
+
                 let mut substep_integration_parameters = self.integration_parameters;
-                substep_integration_parameters.dt =
-                    (time.delta_seconds() * time_scale).min(max_dt) / (substeps as Real);
+                substep_integration_parameters.dt /= substeps as Real;
 
                 for _ in 0..substeps {
                     self.pipeline.step(
@@ -288,6 +291,8 @@ impl RapierContext {
                 }
             }
             TimestepMode::Fixed { dt, substeps } => {
+                self.integration_parameters.dt = dt;
+
                 let mut substep_integration_parameters = self.integration_parameters;
                 substep_integration_parameters.dt = dt / (substeps as Real);
 


### PR DESCRIPTION
This is expected to be accurate by a good bit of users of the library, including rapier's KCC impl here. So we should probably keep it updated/accurate with what the simulation is actually stepping by.

Some thoughts: We might want to do this in a separate function from step_simulation, in something like `PreUpdate` or `First`, because a lot of users are likely to have their systems ordered before `PhysicsSet::StepSimulation`. This means there would be a 1 frame lag here, so we'd be reading the previous frame time rather than next.