### PR TITLE
Expose `stop_at_penetration` parameter and hide time-of-impact details behind an `Option`

### DIFF
--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -104,7 +104,8 @@ pub struct ToiDetails {
 }
 
 impl Toi {
-    pub(crate) fn from_rapier(physics_scale: Real, toi: rapier::parry::query::TOI) -> Self {
+    /// Convert from internal `rapier::Toi`.
+    pub fn from_rapier(physics_scale: Real, toi: rapier::parry::query::TOI) -> Self {
         let details = if toi.status != TOIStatus::Penetrating {
             Some(ToiDetails {
                 witness1: (toi.witness1 * physics_scale).into(),

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -117,8 +117,8 @@ impl Toi {
         };
         Self {
             toi: toi.toi,
-            details: details,
             status: toi.status,
+            details,
         }
     }
 }

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -759,11 +759,19 @@ impl RapierContext {
     /// collider, and are in world space.
     ///
     /// # Parameters
-    /// * `shape_pos` - The initial position of the shape to cast.
+    /// * `shape_pos` - The initial translation of the shape to cast.
+    /// * `shape_rot` - The rotation of the shape to cast.
     /// * `shape_vel` - The constant velocity of the shape to cast (i.e. the cast direction).
     /// * `shape` - The shape to cast.
     /// * `max_toi` - The maximum time-of-impact that can be reported by this cast. This effectively
     ///   limits the distance traveled by the shape to `shapeVel.norm() * maxToi`.
+    /// * `stop_at_penetration` - If the casted shape starts in a penetration state with any
+    ///    collider, two results are possible. If `stop_at_penetration` is `true` then, the
+    ///    result will have a `toi` equal to `start_time`. If `stop_at_penetration` is `false`
+    ///    then the nonlinear shape-casting will see if further motion wrt. the penetration normal
+    ///    would result in tunnelling. If it does not (i.e. we have a separating velocity along
+    ///    that normal) then the nonlinear shape-casting will attempt to find another impact,
+    ///    at a time `> start_time` that could result in tunnelling.
     /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
     #[allow(clippy::too_many_arguments)]
     pub fn cast_shape(
@@ -773,6 +781,7 @@ impl RapierContext {
         shape_vel: Vect,
         shape: &Collider,
         max_toi: Real,
+        stop_at_penetration: bool,
         filter: QueryFilter,
     ) -> Option<(Entity, Toi)> {
         let scaled_transform = (shape_pos / self.physics_scale, shape_rot).into();
@@ -789,7 +798,7 @@ impl RapierContext {
                 &(shape_vel / self.physics_scale).into(),
                 &*scaled_shape.raw,
                 max_toi,
-                true,
+                stop_at_penetration,
                 filter,
             )
         })?;


### PR DESCRIPTION
Currently these values can be `undefined` which might cause some weird bugs for users, so ideally I think it is hidden if we reasonably know the results won't be useful. I also don't think that the documentation saying the witnesses/normals are local space. At least the witness points seem to be world-space in the times I've used this method. Will need to dive a bit deeper into that though.