### PR TITLE
Abort publish.sh on first error

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/bin/sh
+set -e
 
 tmp=$(mktemp -d)
 


### PR DESCRIPTION
Exit from `publish.sh` script immediately after any command returns non-0 status code. Continuing after error could result in a broken package being published.
Also change default interpreter to `/bin/sh` to avoid redundant dependency on Bash.