### PR TITLE
testbed2d combining examples into one

### DIFF
--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -17,7 +17,7 @@ fn main() {
         .run();
 }
 
-fn setup_graphics(mut commands: Commands) {
+pub fn setup_graphics(mut commands: Commands) {
     commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, 20.0, 0.0),
         ..default()

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -46,7 +46,7 @@ impl Stats {
 }
 
 #[derive(Resource)]
-struct Game {
+pub struct Game {
     n_lanes: usize,
     n_rows: usize,
     stats: Stats,
@@ -79,7 +79,9 @@ fn byte_rgb(r: u8, g: u8, b: u8) -> Color {
     Color::rgb(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
 }
 
-fn setup_game(mut commands: Commands, mut game: ResMut<Game>) {
+pub fn setup_game(mut commands: Commands, mut game: ResMut<Game>) {
+    game.current_cube_joints = vec![];
+
     game.cube_colors = vec![
         byte_rgb(0, 244, 243),
         byte_rgb(238, 243, 0),
@@ -219,7 +221,7 @@ fn spawn_block(
         .id()
 }
 
-fn cube_sleep_detection(
+pub fn cube_sleep_detection(
     mut commands: Commands,
     mut game: ResMut<Game>,
     block_query: Query<(Entity, &GlobalTransform)>,

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -18,11 +18,11 @@ fn main() {
         .run();
 }
 
-fn setup_graphics(mut commands: Commands) {
+pub fn setup_graphics(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 }
 
-fn display_events(
+pub fn display_events(
     mut collision_events: EventReader<CollisionEvent>,
     mut contact_force_events: EventReader<ContactForceEvent>,
 ) {

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -17,7 +17,7 @@ fn main() {
         .run();
 }
 
-fn setup_graphics(mut commands: Commands) {
+pub fn setup_graphics(mut commands: Commands) {
     commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, -200.0, 0.0),
         ..default()

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -17,7 +17,7 @@ fn main() {
         .run();
 }
 
-fn setup_graphics(mut commands: Commands) {
+pub fn setup_graphics(mut commands: Commands) {
     commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, 200.0, 0.0),
         ..default()

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -17,7 +17,7 @@ fn main() {
         .run();
 }
 
-fn setup_graphics(mut commands: Commands) {
+pub fn setup_graphics(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 }
 

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -22,9 +22,9 @@ fn main() {
 
 // The float value is the player movement speed in 'pixels/second'.
 #[derive(Component)]
-struct Player(f32);
+pub struct Player(f32);
 
-fn spawn_player(mut commands: Commands, mut rapier_config: ResMut<RapierConfiguration>) {
+pub fn spawn_player(mut commands: Commands, mut rapier_config: ResMut<RapierConfiguration>) {
     // Set gravity to 0.0 and spawn camera.
     rapier_config.gravity = Vec2::ZERO;
     commands.spawn(Camera2dBundle::default());
@@ -48,7 +48,7 @@ fn spawn_player(mut commands: Commands, mut rapier_config: ResMut<RapierConfigur
     ));
 }
 
-fn player_movement(
+pub fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
     mut player_info: Query<(&Player, &mut Velocity)>,
 ) {

--- a/bevy_rapier2d/examples/rope_joint2.rs
+++ b/bevy_rapier2d/examples/rope_joint2.rs
@@ -17,7 +17,7 @@ fn main() {
         .run();
 }
 
-fn setup_graphics(mut commands: Commands) {
+pub fn setup_graphics(mut commands: Commands) {
     commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, -200.0, 0.0),
         ..default()

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -4,6 +4,9 @@ mod despawn2;
 mod events2;
 mod joints2;
 mod joints_despawn2;
+mod locked_rotations2;
+mod multiple_colliders2;
+mod player_movement2;
 mod rope_joint2;
 
 use bevy::prelude::*;
@@ -20,6 +23,9 @@ pub enum Examples {
     Events2,
     Joints2,
     JointsDespawn2,
+    LockedRotation2,
+    MultipleColliders2,
+    PlayerMovement2,
 }
 
 #[derive(Resource, Default)]
@@ -106,6 +112,37 @@ fn main() {
         )
         .add_systems(OnExit(Examples::JointsDespawn2), cleanup)
         //
+        //locked rotations
+        .add_systems(
+            OnEnter(Examples::LockedRotation2),
+            (
+                locked_rotations2::setup_graphics,
+                locked_rotations2::setup_physics,
+            ),
+        )
+        .add_systems(OnExit(Examples::LockedRotation2), cleanup)
+        //
+        //multiple colliders
+        .add_systems(
+            OnEnter(Examples::MultipleColliders2),
+            (
+                multiple_colliders2::setup_graphics,
+                multiple_colliders2::setup_physics,
+            ),
+        )
+        .add_systems(OnExit(Examples::MultipleColliders2), cleanup)
+        //
+        //player movement
+        .add_systems(
+            OnEnter(Examples::PlayerMovement2),
+            player_movement2::spawn_player,
+        )
+        .add_systems(
+            Update,
+            (player_movement2::player_movement).run_if(in_state(Examples::PlayerMovement2)),
+        )
+        .add_systems(OnExit(Examples::PlayerMovement2), cleanup)
+        //
         //testbed
         .add_systems(
             OnEnter(Examples::None),
@@ -153,7 +190,10 @@ fn check_toggle(
             Examples::Despawn2 => Examples::Events2,
             Examples::Events2 => Examples::Joints2,
             Examples::Joints2 => Examples::JointsDespawn2,
-            Examples::JointsDespawn2 => Examples::Boxes2,
+            Examples::JointsDespawn2 => Examples::LockedRotation2,
+            Examples::LockedRotation2 => Examples::MultipleColliders2,
+            Examples::MultipleColliders2 => Examples::PlayerMovement2,
+            Examples::PlayerMovement2 => Examples::Boxes2,
         };
         next_state.set(next);
     }

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -1,0 +1,160 @@
+mod boxes2;
+mod debug_despawn2;
+mod despawn2;
+mod events2;
+mod joints2;
+mod joints_despawn2;
+mod rope_joint2;
+
+use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
+#[derive(Debug, Clone, Eq, PartialEq, Default, Hash, States)]
+pub enum Examples {
+    #[default]
+    None,
+    Boxes2,
+    RopeJoint2,
+    DebugDespawn2,
+    Despawn2,
+    Events2,
+    Joints2,
+    JointsDespawn2,
+}
+
+#[derive(Resource, Default)]
+struct ExamplesRes {
+    entities_before: Vec<Entity>,
+}
+
+fn main() {
+    let mut app = App::new();
+    app.add_state::<Examples>()
+        .init_resource::<ExamplesRes>()
+        .add_plugins((
+            DefaultPlugins,
+            RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
+            RapierDebugRenderPlugin::default(),
+        ))
+        //
+        //boxes2
+        .add_systems(
+            OnEnter(Examples::Boxes2),
+            (boxes2::setup_graphics, boxes2::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Boxes2), cleanup)
+        //
+        // rope joint
+        .add_systems(
+            OnEnter(Examples::RopeJoint2),
+            (rope_joint2::setup_graphics, rope_joint2::setup_physics),
+        )
+        .add_systems(OnExit(Examples::RopeJoint2), cleanup)
+        //
+        //debug despawn
+        .init_resource::<debug_despawn2::Game>()
+        .add_systems(OnEnter(Examples::DebugDespawn2), debug_despawn2::setup_game)
+        .add_systems(
+            Update,
+            debug_despawn2::cube_sleep_detection.run_if(in_state(Examples::DebugDespawn2)),
+        )
+        .add_systems(OnExit(Examples::DebugDespawn2), cleanup)
+        //
+        //despawn2
+        .insert_resource(despawn2::DespawnResource::default())
+        .insert_resource(despawn2::ResizeResource::default())
+        .add_systems(
+            OnEnter(Examples::Despawn2),
+            (despawn2::setup_graphics, despawn2::setup_physics),
+        )
+        .add_systems(
+            Update,
+            (despawn2::despawn, despawn2::resize).run_if(in_state(Examples::Despawn2)),
+        )
+        .add_systems(OnExit(Examples::Despawn2), cleanup)
+        //
+        //events
+        .add_systems(
+            OnEnter(Examples::Events2),
+            (events2::setup_graphics, events2::setup_physics),
+        )
+        .add_systems(
+            Update,
+            events2::display_events.run_if(in_state(Examples::Events2)),
+        )
+        .add_systems(OnExit(Examples::Events2), cleanup)
+        //
+        //events
+        .add_systems(
+            OnEnter(Examples::Joints2),
+            (joints2::setup_graphics, joints2::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Joints2), cleanup)
+        //
+        //despawn2
+        .insert_resource(joints_despawn2::DespawnResource::default())
+        .add_systems(
+            OnEnter(Examples::JointsDespawn2),
+            (
+                joints_despawn2::setup_graphics,
+                joints_despawn2::setup_physics,
+            ),
+        )
+        .add_systems(
+            Update,
+            (joints_despawn2::despawn).run_if(in_state(Examples::JointsDespawn2)),
+        )
+        .add_systems(OnExit(Examples::JointsDespawn2), cleanup)
+        //
+        //testbed
+        .add_systems(
+            OnEnter(Examples::None),
+            |mut next_state: ResMut<NextState<Examples>>| {
+                next_state.set(Examples::Boxes2);
+            },
+        )
+        .add_systems(OnExit(Examples::None), init)
+        .add_systems(Update, check_toggle);
+
+    app.run();
+}
+
+fn init(world: &mut World) {
+    //save all entities that are in the world before setting up any example
+    // to be able to always return to this state when switching from one example to the other
+    world.resource_mut::<ExamplesRes>().entities_before =
+        world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+}
+
+fn cleanup(world: &mut World) {
+    let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
+
+    let remove = world
+        .iter_entities()
+        .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
+        .collect::<Vec<_>>();
+
+    for r in remove {
+        world.despawn(r);
+    }
+}
+
+fn check_toggle(
+    state: Res<State<Examples>>,
+    mut next_state: ResMut<NextState<Examples>>,
+    mouse_input: Res<Input<MouseButton>>,
+) {
+    if mouse_input.just_pressed(MouseButton::Left) {
+        let next = match *state.get() {
+            Examples::None => Examples::Boxes2,
+            Examples::Boxes2 => Examples::RopeJoint2,
+            Examples::RopeJoint2 => Examples::DebugDespawn2,
+            Examples::DebugDespawn2 => Examples::Despawn2,
+            Examples::Despawn2 => Examples::Events2,
+            Examples::Events2 => Examples::Joints2,
+            Examples::Joints2 => Examples::JointsDespawn2,
+            Examples::JointsDespawn2 => Examples::Boxes2,
+        };
+        next_state.set(next);
+    }
+}

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -141,7 +141,12 @@ fn main() {
             Update,
             (player_movement2::player_movement).run_if(in_state(Examples::PlayerMovement2)),
         )
-        .add_systems(OnExit(Examples::PlayerMovement2), cleanup)
+        .add_systems(
+            OnExit(Examples::PlayerMovement2),
+            (cleanup, |mut rapier_config: ResMut<RapierConfiguration>| {
+                rapier_config.gravity = RapierConfiguration::default().gravity;
+            }),
+        )
         //
         //testbed
         .add_systems(

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 mod boxes2;
 mod debug_despawn2;
 mod despawn2;


### PR DESCRIPTION
successor to #445

* no separate crate for examples
* hack in `testbed2` takes a diff of all ecs entities in the world before starting an example and removes all entities that are created else between examples
* despawn mechanics changed to use marker components instead of resource as resources are harder to cleanup properly between examples switches
* use bevy timer for time based events like in despawn examples (more idiomatic and works in testbed as examples start deferred but old timing was absolute)

TODO:
- [x] locked_rotations
- [x] multiples colliders
- [x] player movement