### PR TITLE
Document that CollidingEntities requires ActiveEvents::COLLISION_EVENTS

### DIFF
--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -493,7 +493,9 @@ impl Default for ContactForceEventThreshold {
 /// Component which will be filled (if present) with a list of entities with which the current
 /// entity is currently in contact.
 ///
-/// This currently only updates when on an entity with a `Collider`.
+/// This currently only updates when on an entity with a `Collider`, and if the
+/// [`ActiveEvents::COLLISION_EVENTS`] is set on this entity or the entity it
+/// collided with.
 #[derive(Component, Default, Reflect)]
 #[reflect(Component)]
 pub struct CollidingEntities(pub(crate) HashSet<Entity>);


### PR DESCRIPTION
Looks like this may not have been the case before. I ran into this trying to use CollidingEntities, and was only able to find the cause after looking into its implementation.

Lmk if anything else is needed for this PR!