### PR TITLE
fix compile problem on latest bevy

### DIFF
--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -91,7 +91,7 @@ impl<'a> EventHandler for EventQueue<'a> {
         };
 
         if let Ok(mut events) = self.collision_events.write() {
-            events.send(event)
+            events.send(event);
         }
     }
 


### PR DESCRIPTION
bevy `EventWriter::send` now returns an `Id` instead of `()` breaking bevy_rapier.
this change is compatible with current release bevy and latest master