### PR TITLE
Update IslandsManager after deleting rigid bodies

### DIFF
--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -1217,6 +1217,8 @@ pub fn sync_removals(
         commands.entity(entity).remove::<RapierRigidBodyHandle>();
     }
 
+    context.islands.cleanup_removed_rigid_bodies(&mut context.bodies);
+
     /*
      * Collider removal detection.
      */


### PR DESCRIPTION
Without updating the IslandsManager after removing rigid bodies, later systems may try to access the removed bodies. For example, calling IslandsManager::active_kinematic_bodies() sometimes returns invalid handles if cleanup_removed_rigid_bodies() is not called after rigid bodies are removed. Potentially fixes issue #285.