### PR TITLE
Update to Rapier 0.18

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -34,10 +34,8 @@ async-collider = [ "bevy/bevy_asset", "bevy/bevy_scene" ]
 [dependencies]
 bevy = { version = "0.12", default-features = false }
 nalgebra = { version = "0.32.3", features = [ "convert-glam024" ] }
-# Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier2d = "0.17.0"
+rapier2d = "0.18.0"
 bitflags = "2.4"
-#bevy_prototype_debug_lines = { version = "0.6", optional = true }
 log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 

--- a/bevy_rapier2d/examples/rope_joint2.rs
+++ b/bevy_rapier2d/examples/rope_joint2.rs
@@ -36,9 +36,7 @@ pub fn setup_physics(mut commands: Commands) {
         ))
         .id();
 
-    let joint = RopeJointBuilder::new()
-        .local_anchor2(Vec2::new(rope_length, 0.0))
-        .limits([0.0, rope_length]);
+    let joint = RopeJointBuilder::new(rope_length).local_anchor2(Vec2::new(rope_length, 0.0));
 
     commands
         .spawn((

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -35,10 +35,8 @@ async-collider = [ "bevy/bevy_asset", "bevy/bevy_scene" ]
 [dependencies]
 bevy = { version = "0.12", default-features = false }
 nalgebra = { version = "0.32.3", features = [ "convert-glam024" ] }
-# Don't enable the default features because we don't need the ColliderSet/RigidBodySet
-rapier3d = "0.17"
+rapier3d = "0.18"
 bitflags = "2.4"
-#bevy_prototype_debug_lines = { version = "0.6", features = ["3d"], optional = true }
 log = "0.4"
 serde = { version = "1", features = [ "derive" ], optional = true}
 

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -77,9 +77,7 @@ fn create_rope_joints(commands: &mut Commands, origin: Vect, num: usize) {
     for i in 0..num {
         let dz = (i + 1) as f32 * shift;
 
-        let rope = RopeJointBuilder::new()
-            .local_anchor2(Vec3::new(0.0, 0.0, -shift))
-            .limits([0.0, 2.0]);
+        let rope = RopeJointBuilder::new(2.0).local_anchor2(Vec3::new(0.0, 0.0, -shift));
         let joint = ImpulseJoint::new(curr_parent, rope);
 
         curr_parent = commands

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -6,6 +6,7 @@ pub use self::fixed_joint::*;
 pub use self::prismatic_joint::*;
 pub use self::revolute_joint::*;
 pub use self::rope_joint::*;
+pub use self::spring_joint::*;
 
 use bevy::reflect::Reflect;
 use rapier::dynamics::CoefficientCombineRule as RapierCoefficientCombineRule;
@@ -24,6 +25,7 @@ mod rope_joint;
 
 #[cfg(feature = "dim3")]
 mod spherical_joint;
+mod spring_joint;
 
 /// Rules used to combine two coefficients.
 ///

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -580,3 +580,16 @@ impl TransformInterpolation {
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Component, Reflect)]
 #[reflect(Component, PartialEq)]
 pub struct RigidBodyDisabled;
+
+/// Set the additional number of solver iterations run for a rigid-body and
+/// everything interacting with it.
+///
+/// Increasing this number will help improve simulation accuracy on this rigid-body
+/// and every rigid-body interacting directly or indirectly with it (through joints
+/// or contacts). This implies a performance hit.
+///
+/// The default value is 0, meaning exactly [`IntegrationParameters::num_solver_iterations`] will
+/// be used as number of solver iterations for this body.
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Component, Reflect)]
+#[reflect(Component, PartialEq)]
+pub struct AdditionalSolverIterations(pub usize);

--- a/src/dynamics/spring_joint.rs
+++ b/src/dynamics/spring_joint.rs
@@ -80,9 +80,9 @@ impl SpringJoint {
     }
 }
 
-impl Into<GenericJoint> for SpringJoint {
-    fn into(self) -> GenericJoint {
-        self.data
+impl From<SpringJoint> for GenericJoint {
+    fn from(val: SpringJoint) -> GenericJoint {
+        val.data
     }
 }
 
@@ -142,8 +142,8 @@ impl SpringJointBuilder {
     }
 }
 
-impl Into<GenericJoint> for SpringJointBuilder {
-    fn into(self) -> GenericJoint {
-        self.0.into()
+impl From<SpringJointBuilder> for GenericJoint {
+    fn from(val: SpringJointBuilder) -> GenericJoint {
+        val.0.into()
     }
 }

--- a/src/dynamics/spring_joint.rs
+++ b/src/dynamics/spring_joint.rs
@@ -1,0 +1,149 @@
+use crate::dynamics::{GenericJoint, GenericJointBuilder, JointAxesMask};
+use crate::dynamics::{JointAxis, MotorModel};
+use crate::math::{Real, Vect};
+
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(transparent)]
+/// A spring-damper joint, applies a force proportional to the distance between two objects.
+///
+/// The spring is integrated implicitly, implying that even an undamped spring will be subject to some
+/// amount of numerical damping (so it will eventually come to a rest). More solver iterations, or smaller
+/// timesteps, will lower the effect of numerical damping, providing a more realistic result.
+pub struct SpringJoint {
+    /// The underlying joint data.
+    pub data: GenericJoint,
+}
+
+impl SpringJoint {
+    /// Creates a new spring joint limiting the max distance between two bodies.
+    ///
+    /// The `max_dist` must be strictly greater than 0.0.
+    pub fn new(rest_length: Real, stiffness: Real, damping: Real) -> Self {
+        let data = GenericJointBuilder::new(JointAxesMask::empty())
+            .coupled_axes(JointAxesMask::LIN_AXES)
+            .motor_position(JointAxis::X, rest_length, stiffness, damping)
+            .motor_model(JointAxis::X, MotorModel::ForceBased)
+            .build();
+        Self { data }
+    }
+
+    /// The underlying generic joint.
+    pub fn data(&self) -> &GenericJoint {
+        &self.data
+    }
+
+    /// Are contacts between the attached rigid-bodies enabled?
+    pub fn contacts_enabled(&self) -> bool {
+        self.data.contacts_enabled()
+    }
+
+    /// Sets whether contacts between the attached rigid-bodies are enabled.
+    pub fn set_contacts_enabled(&mut self, enabled: bool) -> &mut Self {
+        self.data.set_contacts_enabled(enabled);
+        self
+    }
+
+    /// The joint’s anchor, expressed in the local-space of the first rigid-body.
+    #[must_use]
+    pub fn local_anchor1(&self) -> Vect {
+        self.data.local_anchor1()
+    }
+
+    /// Sets the joint’s anchor, expressed in the local-space of the first rigid-body.
+    pub fn set_local_anchor1(&mut self, anchor1: Vect) -> &mut Self {
+        self.data.set_local_anchor1(anchor1);
+        self
+    }
+
+    /// The joint’s anchor, expressed in the local-space of the second rigid-body.
+    #[must_use]
+    pub fn local_anchor2(&self) -> Vect {
+        self.data.local_anchor2()
+    }
+
+    /// Sets the joint’s anchor, expressed in the local-space of the second rigid-body.
+    pub fn set_local_anchor2(&mut self, anchor2: Vect) -> &mut Self {
+        self.data.set_local_anchor2(anchor2);
+        self
+    }
+
+    /// Set the spring model used by this joint to reach the desired target velocity and position.
+    ///
+    /// Setting this to `MotorModel::ForceBased` (which is the default value for this joint) makes the spring constants
+    /// (stiffness and damping) parameter understood as in the regular spring-mass-damper system. With
+    /// `MotorModel::AccelerationBased`, the spring constants will be automatically scaled by the attached masses,
+    /// making the spring more mass-independent.
+    pub fn set_spring_model(&mut self, model: MotorModel) -> &mut Self {
+        self.data.set_motor_model(JointAxis::X, model);
+        self
+    }
+}
+
+impl Into<GenericJoint> for SpringJoint {
+    fn into(self) -> GenericJoint {
+        self.data
+    }
+}
+
+/// A [SpringJoint] joint using the builder pattern.
+///
+/// This builds a spring-damper joint which applies a force proportional to the distance between two objects.
+/// See the documentation of [SpringJoint] for more information on its behavior.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct SpringJointBuilder(pub SpringJoint);
+
+impl SpringJointBuilder {
+    /// Creates a new builder for spring joints.
+    ///
+    /// This axis is expressed in the local-space of both rigid-bodies.
+    pub fn new(rest_length: Real, stiffness: Real, damping: Real) -> Self {
+        Self(SpringJoint::new(rest_length, stiffness, damping))
+    }
+
+    /// Sets whether contacts between the attached rigid-bodies are enabled.
+    #[must_use]
+    pub fn contacts_enabled(mut self, enabled: bool) -> Self {
+        self.0.set_contacts_enabled(enabled);
+        self
+    }
+
+    /// Sets the joint’s anchor, expressed in the local-space of the first rigid-body.
+    #[must_use]
+    pub fn local_anchor1(mut self, anchor1: Vect) -> Self {
+        self.0.set_local_anchor1(anchor1);
+        self
+    }
+
+    /// Sets the joint’s anchor, expressed in the local-space of the second rigid-body.
+    #[must_use]
+    pub fn local_anchor2(mut self, anchor2: Vect) -> Self {
+        self.0.set_local_anchor2(anchor2);
+        self
+    }
+
+    /// Set the spring used by this joint to reach the desired target velocity and position.
+    ///
+    /// Setting this to `MotorModel::ForceBased` (which is the default value for this joint) makes the spring constants
+    /// (stiffness and damping) parameter understood as in the regular spring-mass-damper system. With
+    /// `MotorModel::AccelerationBased`, the spring constants will be automatically scaled by the attached masses,
+    /// making the spring more mass-independent.
+    #[must_use]
+    pub fn spring_model(mut self, model: MotorModel) -> Self {
+        self.0.set_spring_model(model);
+        self
+    }
+
+    /// Builds the spring joint.
+    #[must_use]
+    pub fn build(self) -> SpringJoint {
+        self.0
+    }
+}
+
+impl Into<GenericJoint> for SpringJointBuilder {
+    fn into(self) -> GenericJoint {
+        self.0.into()
+    }
+}

--- a/src/pipeline/query_filter.rs
+++ b/src/pipeline/query_filter.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::Entity;
 
-pub use rapier::geometry::InteractionGroups;
 pub use rapier::pipeline::QueryFilterFlags;
 
 use crate::geometry::CollisionGroups;


### PR DESCRIPTION
This switches to [Rapier 0.18](https://github.com/dimforge/rapier/pull/583).
The main highlight of that new Rapier version is the implementation of a new non-linear velocity-based constraints solver that features significantly better convergence rate, resulting in improved contact and joints stability. See https://github.com/dimforge/rapier/pull/579 for technical details on that solver.