### PR TITLE
Interpret ExternalImpulse/ExternalForce torque in correct units

### DIFF
--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -456,7 +456,7 @@ pub fn apply_rigid_body_user_changes(
             rb.reset_torques(true);
             rb.add_force((forces.force / scale).into(), true);
             #[allow(clippy::useless_conversion)] // Need to convert if dim3 enabled
-            rb.add_torque(forces.torque.into(), true);
+            rb.add_torque((forces.torque / scale / scale).into(), true);
         }
     }
 
@@ -464,7 +464,7 @@ pub fn apply_rigid_body_user_changes(
         if let Some(rb) = context.bodies.get_mut(handle.0) {
             rb.apply_impulse((impulses.impulse / scale).into(), true);
             #[allow(clippy::useless_conversion)] // Need to convert if dim3 enabled
-            rb.apply_torque_impulse(impulses.torque_impulse.into(), true);
+            rb.apply_torque_impulse((impulses.torque_impulse / scale / scale).into(), true);
             impulses.reset();
         }
     }


### PR DESCRIPTION
force (kg m s⁻²) gets scaled down when passing to rapier
torque (kg m² s⁻²) should also be scaled down by a factor of scale²

without this change, there is AFAICT no combination of units that can be passed to `ExternalImpulse::at_point`/`ExternalForce::at_point` to give both correctly-acting force and torque with a non-1.0 scale; with this change, passing all values in scale units results in an impulse/force also in scale units, which is then correctly scaled before being passed to rapier.