### PR TITLE
Release v0.26.0 + update to Rapier 0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,43 @@
 # Changelog
 
+## v0.26.0 (05 May 2024)
+
+**This is an update to Rapier 0.19 which includes several stability improvements
+and character-controller fix. Please have a look at the
+[0.19 changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md) of Rapier.**
+
+### Modified
+
+- Renamed `Toi/ToiDetails` to `ShapeCastHit/ShapeCastHitDetails`.
+- Switch to rapier’s built-in `length_unit` instead of explicitly scaling shapes with `physics_scale`.
+- Linear shape-casting functions now take a `ShapeCastOptions` parameter that describes how the shape-cast should
+  behave on special-cases (like toi == 0).
+- Internal edge correction is now opt-in with the `TriMeshFlags::FIX_INTERNAL_EDGES` and
+  `HeightFieldFlags::FIX_INTERNAL_EDGES` flags.
+- Rename `RayIntersection::toi` to `RayIntersection::time_of_impact`.
+
+### Fix
+
+- Fix character controller occasionally getting stuck against vertical walls.
+
+### Added
+
+- Add the `SoftCcd` (for rigid-bodies) and `ContactSkin` (for colliders) components. See
+  [rapier#625](https://github.com/dimforge/rapier/pull/625) for details on the features they enable.
+
 ## v0.25.0 (19 Feb. 2024)
 
 ### Modified
+
 - Update to bevy `0.13`.
 
 ## v0.24.0 (27 Jan. 2024)
+
 The main highlight of this release is the implementation of a new non-linear constraints solver for better stability
 and increased convergence rates. See [#579](https://github.com/dimforge/rapier/pull/579) for additional information.
 
-In order to adjust the number of iterations of the new solver, simply adjust `IntegrationParameters::num_solver_iterations`.
+In order to adjust the number of iterations of the new solver, simply
+adjust `IntegrationParameters::num_solver_iterations`.
 If recovering the old solver behavior is useful to you, call `IntegrationParameters::switch_to_standard_pgs_solver()`.
 
 It is now possible to specify some additional solver iteration for specific rigid-bodies (and everything interacting
@@ -18,26 +46,34 @@ same entity as the rigid-body. This allows for higher-accuracy on subsets of the
 performance of the other parts of the simulation.
 
 ### Fix
-- Fix bug causing angular joint limits and motor to sometimes only take into account half of the angles specified by the user.
+
+- Fix bug causing angular joint limits and motor to sometimes only take into account half of the angles specified by the
+  user.
 - Fix bug where collisions would not be re-computed after a collider was re-enabled.
 
 ### Added
-- Add a `SpringJoint` and `SpringJointBuilder` for simulating springs with customizable stiffness and damping coefficients.
+
+- Add a `SpringJoint` and `SpringJointBuilder` for simulating springs with customizable stiffness and damping
+  coefficients.
 - Fix incorrect update of angular degrees-of-freedoms on spherical multibody joints.
 - Fix debug-renderer showing moved kinematic rigid-bodies only at their initial position.
 
 ### Modified
+
 - Rename `RapierContext::contacts_with` to `RapierContext::contact_pairs_with`.
 - Rename `RapierContext::intersections_with` to `RapierContext::intersection_pairs_with`.
 - Collisions between the character controller and sensors are now disabled by default.
 
 ## 0.23.0
+
 ### Modified
+
 - Update to Bevy 0.12
 
 ### Added
+
 - `ColliderView::as_typed_shape` and `::to_shared_shape` to convert a `ColliderView` to a parry’s
-    `TypedShape` or `SharedShape`. The `From` trait has also been implemented accordingly.
+  `TypedShape` or `SharedShape`. The `From` trait has also been implemented accordingly.
 - Implement `Copy` for `ColliderView` and all the other non-mut shape views.
 - Add `RapierContext::rigid_body_colliders` to retrieve all collider entities attached to this rigid-body.
 - Add `RapierPhysicsPlugin::in_fixed_schedule`/`::in_schedude` to add rapier’s systems to a fixed/custom
@@ -48,24 +84,29 @@ performance of the other parts of the simulation.
   of the shape.
 
 ### Fix
+
 - Fix `RapierContext::integration_parameters::dt` not being updated on non-fixed timestep modes.
 - Fix debug-renderer lagging one frame behind.
 - Fix Collider `Transform` rotation change not being taken into account by the physics engine.
 - Fix automatic update of `ReadMassProperties`.
 
 ## 0.22.0 (10 July 2023)
+
 ### Modified
+
 - Update to Bevy 0.11.
 - Disabled rigid-bodies are no longer synchronized with the rapier backend.
 - Switch to bevy’s gizmo system for the debug-renderer. This removes the vendored debug lines plugin.
 
 ### Added
+
 - Add a joint for simulating ropes: the `RopeJoint`.
 - Add `Velocity::linear_velocity_at_point` to calculate the linear velocity at the given world-space point.
 - Add the `ComputedColliderShape::ConvexHull` variant to automatcially calculate the convex-hull of an imported mesh.
 - Implement `Reflect` for the debug-renderer.
 
 ### Fix
+
 - Fix broken interpolation for rigid-bodies with the `TransformInterpolation` component.
 - Fix compilation when `bevy_rapier` is being used with headless bevy.
 - Improved performance of the writeback system by not iterting on non-rigid-body entities.
@@ -73,7 +114,9 @@ performance of the other parts of the simulation.
 - Properly scale parented collider’s offset based on changes on its `ColliderScale`.
 
 ## 0.21.0  (07 March 2023)
+
 ### Modified
+
 - Update to Bevy 0.10.
 - The `PhysicsHooksWithQuery` trait has been renamed to by the `BevyPhysicsHooks`.
 - Bevy resources and queries accessed by the physics hook are now specified by the implementor of `BevyPhysicsHooks`
@@ -83,32 +126,43 @@ performance of the other parts of the simulation.
 - Rename `PhysicsStages` to `PhysicsSet`.
 
 ## 0.20.0 (15 Jan. 2023)
+
 ### Added
+
 - Add the `RigidBodyDisabled` and `ColliderDisabled` component that can be inserted to disable a rigid-body
   or collider without removing it from the scene.
 
 ### Fix
+
 - Fix spawn position of colliders without rigid bodies.
 - Fix overriding enabled flag in debug render.
 
 ### Modified
-- Make debug-rendering enabled by default when inserting the `RapierDebugRenderPlugin` plugin with its default configuration.
-- The `debug-render` feature has been replaced by two features: `debug-render-2d` and `debug-render-3d`. For example, 
-  using `debug-render-2d` with `bevy_rapier3d`, the debug-render will work with 2D cameras (useful, e.g., for top-down games
+
+- Make debug-rendering enabled by default when inserting the `RapierDebugRenderPlugin` plugin with its default
+  configuration.
+- The `debug-render` feature has been replaced by two features: `debug-render-2d` and `debug-render-3d`. For example,
+  using `debug-render-2d` with `bevy_rapier3d`, the debug-render will work with 2D cameras (useful, e.g., for top-down
+  games
   with 3D graphics).
 - In order to facilitate the use of `bevy_rapier` in headless mode, the `AsyncCollider` and `AsyncSceneCollider`
   components were moved behind the `async-collider` feature (enabled by default). Disabling that feature will
   make `bevy_rapier` work even with the `MinimalPlugins` inserted instead of the `DefaultPlugins`.
-- Corrected an API inconsistency where `bevy_rapier` components would sometimes require an `InteracitonGroup` type defined in
+- Corrected an API inconsistency where `bevy_rapier` components would sometimes require an `InteracitonGroup` type
+  defined in
   `rapier`. It has been replaced by the `CollisionGroup` type (defined in `bevy_rapier`).
 - `Velocity::zero,linear,angular` are now const-fn.
 
 ## 0.19.0 (18 Nov. 2022)
+
 ### Modified
+
 - Update to Bevy 0.9
 
 ## 0.18.0 (30 Oct. 2022)
+
 ### Added
+
 - Add the accessor `RapierContext::physics_scale()` to read the physics scale
   that was set when initializing the plugin.
 - Add `RapierConfiguration::force_update_from_transform_changes` to force the transform
@@ -118,8 +172,9 @@ performance of the other parts of the simulation.
   flags.
 
 ### Fix
+
 - Reset the `ExternalImpulse` component after each step automatically.
-- Fix `transform_to_iso` to preserve identical rotations instead of 
+- Fix `transform_to_iso` to preserve identical rotations instead of
   converting to an intermediate axis-angle representation.
 - Fix **internal edges** of 3D triangle meshes or 3D heightfields generating invalid contacts
   preventing balls from moving straight. Be sure to set the triangle mesh flag
@@ -127,47 +182,59 @@ performance of the other parts of the simulation.
   vertices.
 
 ### Modified
+
 - Rename `AABB` to `Aabb` to comply with Rust’s style guide.
 
 ## 0.17.0 (02 Oct. 2022)
+
 ### Added
+
 - Add a **kinematic character controller** implementation. This feature is accessible in two different ways:
-  1. The first approach is to insert the `KinematicCharacterController` component to an entity. If the
-  `KinematicCharacterController::custom_shape` field is set, then this shape is used for the character control.
-  If this field is `None` then the `Collider` attached to the same entity as the character controller is used.
-  The character controller will be automatically updated when the `KinematicCharacterController::movement` is set.
-  The result position is written to the `Transform` of the character controller’s entity.
-  2. The second, lower level, approach, is to call `RapierContext::move_shape` to compute the possible movement
-  of a shape, taking obstacle and sliding into account.
+    1. The first approach is to insert the `KinematicCharacterController` component to an entity. If the
+       `KinematicCharacterController::custom_shape` field is set, then this shape is used for the character control.
+       If this field is `None` then the `Collider` attached to the same entity as the character controller is used.
+       The character controller will be automatically updated when the `KinematicCharacterController::movement` is set.
+       The result position is written to the `Transform` of the character controller’s entity.
+    2. The second, lower level, approach, is to call `RapierContext::move_shape` to compute the possible movement
+       of a shape, taking obstacle and sliding into account.
 - Add implementations of `Add`, `AddAssign`, `Sub`, `SubAssign` to `ExternalForce` and `ExternalImpulse`.
 - Add `ExternalForce::at_point` and `ExternalImpulse::at_point` to apply a force/impulse at a specific point
   of a rigid-body.
 
 ### Fix
+
 - Fix shapes quickly switching between scaled and non-scaled versions due to rounding errors in the scaling extraction
   from bevy’s global affine transform.
 
 ## 0.16.2 (23 August 2022)
+
 ### Added
+
 - Implement `Debug` for `Collider` and `ColliderView`.
 - Add the missing `ActiveEvent::CONTACT_FORCE_EVENTS` to enable contact force events on a collider.
 
 ## 0.16.1 (19 August 2022)
+
 ### Fixed
+
 - Fix crash of the 2D debug-render on certain platforms (including Metal/MacOS).
 - Fix bug where collision events and contact force events were not cleared automatically.
 - Implement `Reflect` for `AsyncCollider`.
 
 ## 0.16.0 (31 July 2022)
+
 ### Modified
+
 - Switch to Bevy 0.8.
 
 ## 0.15.0 (10 July 2022)
+
 ### Fixed
+
 - Fix unpredictable broad-phase panic when using small colliders in the simulation.
 - Fix collision events being incorrectly generated for any shape that produces multiple
   contact manifolds (like triangle meshes).
-- Fix transform hierarchies not being properly taken into account for colliders with a 
+- Fix transform hierarchies not being properly taken into account for colliders with a
   parent rigid-body.
 - Fix force and impulse application when the `ExternalImpulse` or `ExternalForce` components were added
   at the same time as the rigid-body creation.
@@ -175,21 +242,24 @@ performance of the other parts of the simulation.
   creation.
 
 ### Added
-- Add the `ColliderMassProperties::Mass` variant to let the user specify a collider’s mass directly (instead of its density).
+
+- Add the `ColliderMassProperties::Mass` variant to let the user specify a collider’s mass directly (instead of its
+  density).
   As a result the collider’s angular inertia tensor will be automatically be computed based on this mass and its shape.
 - Add the `ContactForceEvent` event. It can be read by a bevy system with the `EventReader<ContactForceEvent>`. This
   event is useful to read contact forces. A `ContactForceEvent` is generated whenever the sum of the magnitudes of the
   forces applied by contacts between two colliders exceeds the value specified by the `ContactForceEventThreshold`
   component.
 - Add the `QueryFilter` struct that is now used by all the scene queries instead of the `CollisionGroups` and
- `Fn(Entity) -> bool` closure. This `QueryFilter` provides easy access to most common filtering strategies
- (e.g. dynamic bodies only, excluding one particular entity, etc.) for scene queries.
+  `Fn(Entity) -> bool` closure. This `QueryFilter` provides easy access to most common filtering strategies
+  (e.g. dynamic bodies only, excluding one particular entity, etc.) for scene queries.
 - Added some missing serialization of joints.
 - Implement `Default` for `Collider`. It defaults to a `Ball` with radius 0.5.
-- Added a `contacts_enabled` flag to all the joints. If this flag is set to `false` for a joint, no contact will be 
+- Added a `contacts_enabled` flag to all the joints. If this flag is set to `false` for a joint, no contact will be
   computed between two colliders attached to rigid-bodies liked by that joint.
 
 ### Modified
+
 - The `MassProperties` struct is no longer a `Component`. A common mistake was to assume that `MassProperties` could
   be used to initialize the mass/angular inertia tensor of a rigid-body. It is not the case. Instead, the user should
   use the `AdditionalMassProperties` component. The `ReadMassProperties` component has been added to read the mass
@@ -198,41 +268,54 @@ performance of the other parts of the simulation.
   a solid collider.
 
 ## 0.14.1 (01 June 2022)
+
 ### Fixed
+
 - Add the missing `init_async_scene_colliders` to the list of the plugin systems.
 
 ## 0.14.0 (31 May 2022)
+
 ### Added
+
 - Add the `AsyncSceneCollider` component to generate collision for scene meshes similar to `AsyncCollider`.
 - Add calls to `App::register_type` for the types implementing `Reflect`.
 
 ### Modified
-- `Collider::bevy_mesh`, `Collider::bevy_mesh_convex_decomposition` and `Collider::bevy_mesh_convex_decomposition_with_params` was replaced with single `Collider::from_bevy_mesh` function which accepts `ComputedColliderShape`.
+
+- `Collider::bevy_mesh`, `Collider::bevy_mesh_convex_decomposition`
+  and `Collider::bevy_mesh_convex_decomposition_with_params` was replaced with single `Collider::from_bevy_mesh`
+  function which accepts `ComputedColliderShape`.
 - `AsyncCollider` is now a struct which contains a mesh handle and `ComputedColliderShape`.
 - The physics systems are now running after `CoreStage::Update` but before `CoreStage::PostUpdate`.
-- The collider and rigid-body positions are read from the `GlobalTransform` instead of `Transform` (the 
+- The collider and rigid-body positions are read from the `GlobalTransform` instead of `Transform` (the
   transforms modified by Rapier are written back to the `Transform` component). It is therefore important
   to insert both a `Transform` and `GlobalTransform` component (or the `TransformBundle` bundle).
-- It is now possible to prevent the plugin from registering its system thanks to `RapierPhysicsPlugin::with_default_system_setup(false)`.
+- It is now possible to prevent the plugin from registering its system thanks
+  to `RapierPhysicsPlugin::with_default_system_setup(false)`.
   If that’s the case, the `RapierPhysicsPlugin::get_systems` method can be called to retrieve the relevant `SystemSet`
   that can be added to your own stages in order to apply your own scheduling.
 
 ### Fixed
+
 - Fixed issues where contact regularization (using compliance) would result in tunnelling despite tunnelling
   being enabled.
 - Don’t overwrite the user’s `RapierConfiguration` if one already exists before initializing the plugin.
 
 ## 0.13.2 (5 May 2022)
+
 ### Modified
+
 - The `TimestepMode` and `SimulationToRenderTime` structures are now public.
 
 ### Fixed
+
 - Fixed colors rendered by the debug-renderer.
 - Fix issue where the debug-renderer would sometimes render lines behind the user’s meshes/sprites.
 
-
 ## 0.13.1 (1 May 2022)
+
 ### Added
+
 - Add the `CollidingEntities` components which tracks the set of entities colliding
   with a given entity.
 - Add constructors `Velocity::linear`, `Velocity::angular`, `Ccd::enabled()`, `Ccd::disabled()`,
@@ -242,11 +325,12 @@ performance of the other parts of the simulation.
   of a collider.
 
 ### Modified
+
 - Switched to linear ordering to order our systems.
 - Make the `plugin::systems` module public.
 
-
 ## 0.13.0 (30 Apr. 2022)
+
 This is a **complete rewrite of the plugin** (mostly likely the last large redesign this plugin
 will be subject to). It switches to `rapier` 0.12 and `bevy` 0.7. The focus of this rewrite was
 to significantly improve ergonomics while simplifying the codebase and adding new features.
@@ -256,7 +340,9 @@ on this change. See the folders `bevy_rapier2d/examples` and `bevy_rapier3d/exam
 for some examples.
 
 ## 0.12.0
+
 ### Modified
+
 - Switch to `rapier` 0.12.0-alpha.0 and `nalgebra` 0.30.
 - Switch to `bevy` 0.6.
 - All the Rapier components have been wrapped into wrapper types (for example `ColliderPosition`
@@ -266,25 +352,33 @@ for some examples.
   for details.
 
 ## 0.11.0
+
 ### Modified
+
 - Switch to `Rapier` 0.11 and `nalgebra` 0.29.
 - Add labels to each system from `bevy-rapier`.
 
 ### Fixed
+
 - Fix panics when despawning joints or colliders.
 - Fix a panic where adding a collider.
-- Don’t let the plugin overwrite the user’s `PhysicsHooksWithQueryObject` if it was already 
+- Don’t let the plugin overwrite the user’s `PhysicsHooksWithQueryObject` if it was already
   present before inserting the plugin.
 
 ## 0.10.2
+
 ### Fixed
+
 - Fix build when targeting WASM.
 
 ## 0.10.1
+
 ### Fixed
+
 - Fix joint removal when despawning its entity.
 
 ## 0.10.0
+
 A new, exhaustive, user-guide for bevy_rapier has been uploaded to rapier.rs.
 
 This version is a complete rewrite of the plugin. Rigid-bodies and
@@ -296,17 +390,21 @@ converted directly using `entity.handle()` or `handle.entity()`.
 
 Finally, there is now a prelude: `use bevy_rapier2d::prelude::*`.
 
-
 ## 0.9.0
+
 ### Added
+
 - The `ColliderDebugRender` component must be added to an entity
   containing a collider shape in order to render it.
-  
+
 ## 0.8.0
+
 ### Changed
+
 - Use the version 0.5.0 of Rapier.
 
 ### Added
+
 - The debug rendering of 3D trimesh now work.
 - The debug rendering won't crash any more if a not-yet-supported shape
   is used. It will silently ignore the shape instead.
@@ -315,58 +413,75 @@ Finally, there is now a prelude: `use bevy_rapier2d::prelude::*`.
   targetting WASM).
 
 ## 0.7.0
+
 ### Changed
+
 - Use the version 0.4.0 of Bevy.
 
 ## 0.6.2
+
 ### Changed
+
 - Fix the rendering of colliders attached to an entity children of another
   entity containing the rigid-body it is attached to.
 
 ## 0.6.1
+
 ### Changed
+
 - The adaptive change of number of timesteps executed during each render loop
   (introduced in the version 0.4.0 with position interpolation) is
   now disabled by default. It needs to be enabled explicitly by setting
   `RapierConfiguration.time_dependent_number_of_timesteps` to `true`.
 
 ## 0.6.0
+
 ### Added
+
 - It is now possible to attach multiple colliders to a single
   rigid-body by using Bevy hierarchy: an entity contains
-  the `RigidBodyBuider` whereas its children contain the `ColliderBuilder`. 
+  the `RigidBodyBuider` whereas its children contain the `ColliderBuilder`.
 
 ### Changed
+
 - We now use the latest version of Rapier: 0.4.0. See the
   [Rapier changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md#v040)
   for details. In particular, this includes the ability to lock the rotations of a rigid-body.
 
 ## 0.5.0
+
 ### Changed
+
 - We now use the latest version of Bevy: 0.3.0
 
 ### Added
+
 - Rigid-bodies, colliders, and joints, will automatically removed from the Rapier
   sets when their corresponding Bevy components are removed.
 
 ## 0.4.0
+
 This release update the plugin to the latest version of Rapier, which itself
 includes lots of new features. Refer to the Rapier changelogs for details.
 
 ### Added
+
 - A `InteractionPairFilters` resource where you can your own filters for contact pair
-and proximity pair filtering. Before considering the use of a custom filter, consider
-using collision groups instead (as it is faster, but less versatile).
+  and proximity pair filtering. Before considering the use of a custom filter, consider
+  using collision groups instead (as it is faster, but less versatile).
 
 ### Changed
+
 - The stepping system now applies interpolation between two physics state at render time.
   Refer to [that issue](https://github.com/dimforge/bevy_rapier/pull/19) and the following
   blog post article for details: https://www.gafferongames.com/post/fix_your_timestep/
 
 ## 0.3.1
+
 ### Changed
+
 - Rapier configuration
-  - Replaced `Gravity` and `RapierPhysicsScale` resources with a unique `RapierConfiguration` resource.
-  - Added an `physics_pipeline_active` attribute to `RapierConfiguration` allowing to pause the physic simulation.
-  - Added a `query_pipeline_active` attribute to `RapierConfiguration` allowing to pause the query pipeline update.
+    - Replaced `Gravity` and `RapierPhysicsScale` resources with a unique `RapierConfiguration` resource.
+    - Added an `physics_pipeline_active` attribute to `RapierConfiguration` allowing to pause the physic simulation.
+    - Added a `query_pipeline_active` attribute to `RapierConfiguration` allowing to pause the query pipeline update.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ codegen-units = 1
 
 [patch.crates-io]
 #nalgebra = { path = "../nalgebra" }
-parry2d = { path = "../parry/crates/parry2d" }
-parry3d = { path = "../parry/crates/parry3d" }
-rapier2d = { path = "../rapier/crates/rapier2d" }
-rapier3d = { path = "../rapier/crates/rapier3d" }
+#parry2d = { path = "../parry/crates/parry2d" }
+#parry3d = { path = "../parry/crates/parry3d" }
+#rapier2d = { path = "../rapier/crates/rapier2d" }
+#rapier3d = { path = "../rapier/crates/rapier3d" }
 
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
 #parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bevy_rapier2d", "bevy_rapier3d"]
 resolver = "2"
 
 [profile.dev]
- # Use slightly better optimization by default, as examples otherwise seem laggy.
+# Use slightly better optimization by default, as examples otherwise seem laggy.
 opt-level = 1
 
 [profile.release]
@@ -11,10 +11,10 @@ codegen-units = 1
 
 [patch.crates-io]
 #nalgebra = { path = "../nalgebra" }
-#parry2d = { path = "../parry/crates/parry2d" }
-#parry3d = { path = "../parry/crates/parry3d" }
-#rapier2d = { path = "../rapier/crates/rapier2d" }
-#rapier3d = { path = "../rapier/crates/rapier3d" }
+parry2d = { path = "../parry/crates/parry2d" }
+parry3d = { path = "../parry/crates/parry3d" }
+rapier2d = { path = "../rapier/crates/rapier2d" }
+rapier3d = { path = "../rapier/crates/rapier3d" }
 
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
 #parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
 homepage = "http://rapier.rs"
 repository = "https://github.com/dimforge/bevy_rapier"
 readme = "../README.md"
-keywords = [ "physics", "dynamics", "rigid", "real-time", "joints" ]
+keywords = ["physics", "dynamics", "rigid", "real-time", "joints"]
 license = "Apache-2.0"
 edition = "2021"
 
@@ -15,36 +15,36 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 path = "../src/lib.rs"
-required-features = [ "dim2" ]
+required-features = ["dim2"]
 
 [features]
-default = [ "dim2", "async-collider", "debug-render-2d" ]
+default = ["dim2", "async-collider", "debug-render-2d"]
 dim2 = []
-debug-render-2d = [ "bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_gizmos", "rapier2d/debug-render", "bevy/bevy_asset" ]
-debug-render-3d = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_gizmos", "rapier2d/debug-render", "bevy/bevy_asset" ]
-parallel = [ "rapier2d/parallel" ]
-simd-stable = [ "rapier2d/simd-stable" ]
-simd-nightly = [ "rapier2d/simd-nightly" ]
-wasm-bindgen = [ "rapier2d/wasm-bindgen" ]
-serde-serialize = [ "rapier2d/serde-serialize", "bevy/serialize", "serde" ]
-enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
+debug-render-2d = ["bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_gizmos", "rapier2d/debug-render", "bevy/bevy_asset"]
+debug-render-3d = ["bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_gizmos", "rapier2d/debug-render", "bevy/bevy_asset"]
+parallel = ["rapier2d/parallel"]
+simd-stable = ["rapier2d/simd-stable"]
+simd-nightly = ["rapier2d/simd-nightly"]
+wasm-bindgen = ["rapier2d/wasm-bindgen"]
+serde-serialize = ["rapier2d/serde-serialize", "bevy/serialize", "serde"]
+enhanced-determinism = ["rapier2d/enhanced-determinism"]
 headless = []
-async-collider = [ "bevy/bevy_asset", "bevy/bevy_scene" ]
+async-collider = ["bevy/bevy_asset", "bevy/bevy_scene"]
 
 [dependencies]
 bevy = { version = "0.13", default-features = false }
-nalgebra = { version = "0.32.3", features = [ "convert-glam025" ] }
-rapier2d = "0.18.0"
+nalgebra = { version = "0.32.3", features = ["convert-glam025"] }
+rapier2d = "0.19.0"
 bitflags = "2.4"
 log = "0.4"
-serde = { version = "1", features = [ "derive" ], optional = true}
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.13", default-features = false, features = ["x11"] }
 oorandom = "11"
 approx = "0.5.1"
-glam = { version = "0.25", features = [ "approx" ] }
+glam = { version = "0.25", features = ["approx"] }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs
-features = [ "debug-render-2d", "serde-serialize" ]
+features = ["debug-render-2d", "serde-serialize"]

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -41,7 +41,7 @@ fn main() {
         .init_resource::<ExamplesRes>()
         .add_plugins((
             DefaultPlugins,
-            RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
+            RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
             RapierDebugRenderPlugin::default(),
         ))
         //
@@ -145,9 +145,13 @@ fn main() {
         )
         .add_systems(
             OnExit(Examples::PlayerMovement2),
-            (cleanup, |mut rapier_config: ResMut<RapierConfiguration>| {
-                rapier_config.gravity = RapierConfiguration::default().gravity;
-            }),
+            (
+                cleanup,
+                |mut rapier_config: ResMut<RapierConfiguration>, ctxt: Res<RapierContext>| {
+                    rapier_config.gravity =
+                        RapierConfiguration::new(ctxt.integration_parameters.length_unit).gravity;
+                },
+            ),
         )
         //
         //testbed

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
 homepage = "http://rapier.rs"
 repository = "https://github.com/dimforge/bevy_rapier"
 readme = "../README.md"
-keywords = [ "physics", "dynamics", "rigid", "real-time", "joints" ]
+keywords = ["physics", "dynamics", "rigid", "real-time", "joints"]
 license = "Apache-2.0"
 edition = "2021"
 
@@ -15,36 +15,36 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 path = "../src/lib.rs"
-required-features = [ "dim3" ]
+required-features = ["dim3"]
 
 [features]
-default = [ "dim3", "async-collider", "debug-render-3d" ]
+default = ["dim3", "async-collider", "debug-render-3d"]
 dim3 = []
-debug-render = [ "debug-render-3d" ]
-debug-render-2d = [ "bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_gizmos", "rapier3d/debug-render", "bevy/bevy_asset" ]
-debug-render-3d = [ "bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_gizmos", "rapier3d/debug-render", "bevy/bevy_asset" ]
-parallel = [ "rapier3d/parallel" ]
-simd-stable = [ "rapier3d/simd-stable" ]
-simd-nightly = [ "rapier3d/simd-nightly" ]
-wasm-bindgen = [ "rapier3d/wasm-bindgen" ]
-serde-serialize = [ "rapier3d/serde-serialize", "bevy/serialize", "serde" ]
-enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
-headless = [ ]
-async-collider = [ "bevy/bevy_asset", "bevy/bevy_scene" ]
+debug-render = ["debug-render-3d"]
+debug-render-2d = ["bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_gizmos", "rapier3d/debug-render", "bevy/bevy_asset"]
+debug-render-3d = ["bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_gizmos", "rapier3d/debug-render", "bevy/bevy_asset"]
+parallel = ["rapier3d/parallel"]
+simd-stable = ["rapier3d/simd-stable"]
+simd-nightly = ["rapier3d/simd-nightly"]
+wasm-bindgen = ["rapier3d/wasm-bindgen"]
+serde-serialize = ["rapier3d/serde-serialize", "bevy/serialize", "serde"]
+enhanced-determinism = ["rapier3d/enhanced-determinism"]
+headless = []
+async-collider = ["bevy/bevy_asset", "bevy/bevy_scene"]
 
 [dependencies]
 bevy = { version = "0.13", default-features = false }
-nalgebra = { version = "0.32.3", features = [ "convert-glam025" ] }
-rapier3d = "0.18"
+nalgebra = { version = "0.32.3", features = ["convert-glam025"] }
+rapier3d = "0.19"
 bitflags = "2.4"
 log = "0.4"
-serde = { version = "1", features = [ "derive" ], optional = true}
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = ["x11", "tonemapping_luts"]}
+bevy = { version = "0.13", default-features = false, features = ["x11", "tonemapping_luts"] }
 approx = "0.5.1"
-glam = { version = "0.25", features = [ "approx" ] }
+glam = { version = "0.25", features = ["approx"] }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs
-features = [ "debug-render-3d", "serde-serialize" ]
+features = ["debug-render-3d", "serde-serialize"]

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -1,4 +1,4 @@
-use crate::geometry::{Collider, CollisionGroups, Toi};
+use crate::geometry::{Collider, CollisionGroups, ShapeCastHit};
 use crate::math::{Real, Rot, Vect};
 use bevy::prelude::*;
 
@@ -21,7 +21,7 @@ pub struct CharacterCollision {
     /// The translations that was still waiting to be applied to the character when the hit happens.
     pub translation_remaining: Vect,
     /// Geometric information about the hit.
-    pub toi: Toi,
+    pub hit: ShapeCastHit,
 }
 
 impl CharacterCollision {
@@ -29,12 +29,13 @@ impl CharacterCollision {
         ctxt: &RapierContext,
         c: &rapier::control::CharacterCollision,
     ) -> Option<Self> {
-        Self::from_raw_with_set(&ctxt.colliders, c)
+        Self::from_raw_with_set(&ctxt.colliders, c, true)
     }
 
     pub(crate) fn from_raw_with_set(
         colliders: &ColliderSet,
         c: &rapier::control::CharacterCollision,
+        details_always_computed: bool,
     ) -> Option<Self> {
         RapierContext::collider_entity_with_set(colliders, c.handle).map(|entity| {
             CharacterCollision {
@@ -46,7 +47,7 @@ impl CharacterCollision {
                 character_rotation: c.character_pos.rotation.into(),
                 translation_applied: c.translation_applied.into(),
                 translation_remaining: c.translation_remaining.into(),
-                toi: Toi::from_rapier(c.toi),
+                hit: ShapeCastHit::from_rapier(c.hit, details_always_computed),
             }
         })
     }

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -29,25 +29,24 @@ impl CharacterCollision {
         ctxt: &RapierContext,
         c: &rapier::control::CharacterCollision,
     ) -> Option<Self> {
-        Self::from_raw_with_set(ctxt.physics_scale, &ctxt.colliders, c)
+        Self::from_raw_with_set(&ctxt.colliders, c)
     }
 
     pub(crate) fn from_raw_with_set(
-        physics_scale: Real,
         colliders: &ColliderSet,
         c: &rapier::control::CharacterCollision,
     ) -> Option<Self> {
         RapierContext::collider_entity_with_set(colliders, c.handle).map(|entity| {
             CharacterCollision {
                 entity,
-                character_translation: (c.character_pos.translation.vector * physics_scale).into(),
+                character_translation: c.character_pos.translation.vector.into(),
                 #[cfg(feature = "dim2")]
                 character_rotation: c.character_pos.rotation.angle(),
                 #[cfg(feature = "dim3")]
                 character_rotation: c.character_pos.rotation.into(),
-                translation_applied: (c.translation_applied * physics_scale).into(),
-                translation_remaining: (c.translation_remaining * physics_scale).into(),
-                toi: Toi::from_rapier(physics_scale, c.toi),
+                translation_applied: c.translation_applied.into(),
+                translation_remaining: c.translation_remaining.into(),
+                toi: Toi::from_rapier(c.toi),
             }
         })
     }
@@ -160,26 +159,21 @@ pub struct KinematicCharacterController {
 }
 
 impl KinematicCharacterController {
-    pub(crate) fn to_raw(
-        &self,
-        physics_scale: Real,
-    ) -> Option<rapier::control::KinematicCharacterController> {
+    pub(crate) fn to_raw(&self) -> Option<rapier::control::KinematicCharacterController> {
         let autostep = self.autostep.map(|autostep| CharacterAutostep {
-            max_height: autostep.max_height.map_absolute(|x| x / physics_scale),
-            min_width: autostep.min_width.map_absolute(|x| x / physics_scale),
+            max_height: autostep.max_height,
+            min_width: autostep.min_width,
             include_dynamic_bodies: autostep.include_dynamic_bodies,
         });
 
         Some(rapier::control::KinematicCharacterController {
             up: self.up.try_into().ok()?,
-            offset: self.offset.map_absolute(|x| x / physics_scale),
+            offset: self.offset,
             slide: self.slide,
             autostep,
             max_slope_climb_angle: self.max_slope_climb_angle,
             min_slope_slide_angle: self.min_slope_slide_angle,
-            snap_to_ground: self
-                .snap_to_ground
-                .map(|x| x.map_absolute(|x| x / physics_scale)),
+            snap_to_ground: self.snap_to_ground,
             normal_nudge_factor: self.normal_nudge_factor,
         })
     }

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -78,6 +78,15 @@ pub struct MoveShapeOptions {
     /// Should the character be automatically snapped to the ground if the distance between
     /// the ground and its feet are smaller than the specified threshold?
     pub snap_to_ground: Option<CharacterLength>,
+    /// Increase this number if your character appears to get stuck when sliding against surfaces.
+    ///
+    /// This is a small distance applied to the movement toward the contact normals of shapes hit
+    /// by the character controller. This helps shape-casting not getting stuck in an alway-penetrating
+    /// state during the sliding calculation.
+    ///
+    /// This value should remain fairly small since it can introduce artificial "bumps" when sliding
+    /// along a flat surface.
+    pub normal_nudge_factor: Real,
 }
 
 impl Default for MoveShapeOptions {
@@ -92,6 +101,7 @@ impl Default for MoveShapeOptions {
             min_slope_slide_angle: def.min_slope_slide_angle,
             apply_impulse_to_dynamic_bodies: true,
             snap_to_ground: def.snap_to_ground,
+            normal_nudge_factor: def.normal_nudge_factor,
         }
     }
 }
@@ -138,6 +148,15 @@ pub struct KinematicCharacterController {
     /// Groups for filtering-out some colliders from the environment seen by the character
     /// controller.
     pub filter_groups: Option<CollisionGroups>,
+    /// Increase this number if your character appears to get stuck when sliding against surfaces.
+    ///
+    /// This is a small distance applied to the movement toward the contact normals of shapes hit
+    /// by the character controller. This helps shape-casting not getting stuck in an alway-penetrating
+    /// state during the sliding calculation.
+    ///
+    /// This value should remain fairly small since it can introduce artificial "bumps" when sliding
+    /// along a flat surface.
+    pub normal_nudge_factor: Real,
 }
 
 impl KinematicCharacterController {
@@ -161,6 +180,7 @@ impl KinematicCharacterController {
             snap_to_ground: self
                 .snap_to_ground
                 .map(|x| x.map_absolute(|x| x / physics_scale)),
+            normal_nudge_factor: self.normal_nudge_factor,
         })
     }
 }
@@ -182,6 +202,7 @@ impl Default for KinematicCharacterController {
             snap_to_ground: def.snap_to_ground,
             filter_flags: QueryFilterFlags::default() | QueryFilterFlags::EXCLUDE_SENSORS,
             filter_groups: None,
+            normal_nudge_factor: def.normal_nudge_factor,
         }
     }
 }

--- a/src/dynamics/generic_joint.rs
+++ b/src/dynamics/generic_joint.rs
@@ -20,22 +20,7 @@ pub struct GenericJoint {
 
 impl GenericJoint {
     /// Converts this joint into a Rapier joint.
-    pub fn into_rapier(mut self, physics_scale: Real) -> RapierGenericJoint {
-        self.raw.local_frame1.translation.vector /= physics_scale;
-        self.raw.local_frame2.translation.vector /= physics_scale;
-
-        // NOTE: we don’t apply the physics scale to angular limits.
-        for limit in &mut self.raw.limits[0..DIM] {
-            limit.min /= physics_scale;
-            limit.max /= physics_scale;
-        }
-
-        // NOTE: we don’t apply the physics scale to angular motors.
-        for motor in &mut self.raw.motors[0..DIM] {
-            motor.target_vel /= physics_scale;
-            motor.target_pos /= physics_scale;
-        }
-
+    pub fn into_rapier(self) -> RapierGenericJoint {
         self.raw
     }
 }

--- a/src/dynamics/generic_joint.rs
+++ b/src/dynamics/generic_joint.rs
@@ -4,7 +4,6 @@ use rapier::dynamics::{
     GenericJoint as RapierGenericJoint, JointAxesMask, JointAxis, JointLimits, JointMotor,
     MotorModel,
 };
-use rapier::math::DIM;
 
 #[cfg(feature = "dim3")]
 use crate::dynamics::SphericalJoint;

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -233,34 +233,33 @@ pub struct MassProperties {
 impl MassProperties {
     /// Converts these mass-properties to Rapier’s `MassProperties` structure.
     #[cfg(feature = "dim2")]
-    pub fn into_rapier(self, physics_scale: f32) -> rapier::dynamics::MassProperties {
+    pub fn into_rapier(self) -> rapier::dynamics::MassProperties {
         rapier::dynamics::MassProperties::new(
-            (self.local_center_of_mass / physics_scale).into(),
+            self.local_center_of_mass.into(),
             self.mass,
             #[allow(clippy::useless_conversion)] // Need to convert if dim3 enabled
-            (self.principal_inertia / (physics_scale * physics_scale)).into(),
+            self.principal_inertia.into(),
         )
     }
 
     /// Converts these mass-properties to Rapier’s `MassProperties` structure.
     #[cfg(feature = "dim3")]
-    pub fn into_rapier(self, physics_scale: f32) -> rapier::dynamics::MassProperties {
+    pub fn into_rapier(self) -> rapier::dynamics::MassProperties {
         rapier::dynamics::MassProperties::with_principal_inertia_frame(
-            (self.local_center_of_mass / physics_scale).into(),
+            self.local_center_of_mass.into(),
             self.mass,
-            (self.principal_inertia / (physics_scale * physics_scale)).into(),
+            self.principal_inertia.into(),
             self.principal_inertia_local_frame.into(),
         )
     }
 
     /// Converts Rapier’s `MassProperties` structure to `Self`.
-    pub fn from_rapier(mprops: rapier::dynamics::MassProperties, physics_scale: f32) -> Self {
+    pub fn from_rapier(mprops: rapier::dynamics::MassProperties) -> Self {
         #[allow(clippy::useless_conversion)] // Need to convert if dim3 enabled
         Self {
             mass: mprops.mass(),
-            local_center_of_mass: (mprops.local_com * physics_scale).into(),
-            principal_inertia: (mprops.principal_inertia() * (physics_scale * physics_scale))
-                .into(),
+            local_center_of_mass: mprops.local_com.into(),
+            principal_inertia: mprops.principal_inertia().into(),
             #[cfg(feature = "dim3")]
             principal_inertia_local_frame: mprops.principal_inertia_local_frame.into(),
         }

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -481,6 +481,23 @@ impl Ccd {
     }
 }
 
+/// Sets the maximum prediction distance Soft Continuous Collision-Detection.
+///
+/// When set to 0, soft-CCD is disabled. Soft-CCD helps prevent tunneling especially of
+/// slow-but-thin to moderately fast objects. The soft CCD prediction distance indicates how
+/// far in the object’s path the CCD algorithm is allowed to inspect. Large values can impact
+/// performance badly by increasing the work needed from the broad-phase.
+///
+/// It is a generally cheaper variant of regular CCD (that can be enabled with
+/// [`rapier::dynamics::RigidBody::enable_ccd`] since it relies on predictive constraints instead of
+/// shape-cast and substeps.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Component, Reflect)]
+#[reflect(Component, PartialEq)]
+pub struct SoftCcd {
+    /// The soft CCD prediction distance.
+    pub prediction: f32,
+}
+
 /// The dominance groups of a [`RigidBody`].
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Component, Reflect)]
 #[reflect(Component, PartialEq)]

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -506,7 +506,10 @@ impl Dominance {
 #[reflect(Component, PartialEq)]
 pub struct Sleeping {
     /// The linear velocity below which the body can fall asleep.
-    pub linear_threshold: f32,
+    ///
+    /// The effictive threshold is obtained by multpilying this value by the
+    /// [`IntegrationParameters::length_unit`].
+    pub normalized_linear_threshold: f32,
     /// The angular velocity below which the body can fall asleep.
     pub angular_threshold: f32,
     /// Is this body sleeping?
@@ -517,7 +520,7 @@ impl Sleeping {
     /// Creates a components that disables sleeping for the associated [`RigidBody`].
     pub fn disabled() -> Self {
         Self {
-            linear_threshold: -1.0,
+            normalized_linear_threshold: -1.0,
             angular_threshold: -1.0,
             sleeping: false,
         }
@@ -527,7 +530,7 @@ impl Sleeping {
 impl Default for Sleeping {
     fn default() -> Self {
         Self {
-            linear_threshold: RigidBodyActivation::default_linear_threshold(),
+            normalized_linear_threshold: RigidBodyActivation::default_normalized_linear_threshold(),
             angular_threshold: RigidBodyActivation::default_angular_threshold(),
             sleeping: false,
         }

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -490,6 +490,19 @@ impl Default for ContactForceEventThreshold {
     }
 }
 
+/// Sets the contact skin of the collider.
+///
+/// The contact skin acts as if the collider was enlarged with a skin of width `skin_thickness`
+/// around it, keeping objects further apart when colliding.
+///
+/// A non-zero contact skin can increase performance, and in some cases, stability. However
+/// it creates a small gap between colliding object (equal to the sum of their skin). If the
+/// skin is sufficiently small, this might not be visually significant or can be hidden by the
+/// rendering assets.
+#[derive(Copy, Clone, PartialEq, Default, Component, Reflect)]
+#[reflect(Component)]
+pub struct ContactSkin(pub f32);
+
 /// Component which will be filled (if present) with a list of entities with which the current
 /// entity is currently in contact.
 ///

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -172,9 +172,8 @@ impl Collider {
     /// Returns `None` if the index buffer or vertex buffer of the mesh are in an incompatible format.
     #[cfg(all(feature = "dim3", feature = "async-collider"))]
     pub fn from_bevy_mesh(mesh: &Mesh, collider_shape: &ComputedColliderShape) -> Option<Self> {
-        let Some((vtx, idx)) = extract_mesh_vertices_indices(mesh) else {
-            return None;
-        };
+        let (vtx, idx) = extract_mesh_vertices_indices(mesh)?;
+
         match collider_shape {
             ComputedColliderShape::TriMesh => Some(
                 SharedShape::trimesh_with_flags(vtx, idx, TriMeshFlags::MERGE_DUPLICATE_VERTICES)

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -43,9 +43,9 @@ impl From<rapier::parry::query::PointProjection> for PointProjection {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct RayIntersection {
     /// The time of impact of the ray with the object.  The exact contact point can be computed
-    /// with `origin + dir * toi` where `origin` is the origin of the ray;
-    /// `dir` is its direction and `toi` is the value of this field.
-    pub toi: Real,
+    /// with `origin + dir * time_of_impact` where `origin` is the origin of the ray;
+    /// `dir` is its direction and `time_of_impact` is the value of this field.
+    pub time_of_impact: Real,
 
     /// The intersection point between the ray and the object.
     pub point: Vect,
@@ -66,7 +66,7 @@ impl RayIntersection {
         unscaled_dir: Vect,
     ) -> Self {
         Self {
-            toi: inter.time_of_impact,
+            time_of_impact: inter.time_of_impact,
             point: unscaled_origin + unscaled_dir * inter.time_of_impact,
             normal: inter.normal.into(),
             feature: inter.feature,

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -23,13 +23,10 @@ pub struct PointProjection {
 }
 
 impl PointProjection {
-    pub(crate) fn from_rapier(
-        physics_scale: Real,
-        raw: rapier::parry::query::PointProjection,
-    ) -> Self {
+    pub(crate) fn from_rapier(raw: rapier::parry::query::PointProjection) -> Self {
         Self {
             is_inside: raw.is_inside,
-            point: (raw.point * physics_scale).into(),
+            point: raw.point.into(),
         }
     }
 }
@@ -105,11 +102,11 @@ pub struct ToiDetails {
 
 impl Toi {
     /// Convert from internal `rapier::Toi`.
-    pub fn from_rapier(physics_scale: Real, toi: rapier::parry::query::ShapeCastHit) -> Self {
+    pub fn from_rapier(toi: rapier::parry::query::ShapeCastHit) -> Self {
         let details = if toi.status != ShapeCastStatus::PenetratingOrWithinTargetDist {
             Some(ToiDetails {
-                witness1: (toi.witness1 * physics_scale).into(),
-                witness2: (toi.witness2 * physics_scale).into(),
+                witness1: toi.witness1.into(),
+                witness2: toi.witness2.into(),
                 normal1: toi.normal1.into(),
                 normal2: toi.normal2.into(),
             })

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -1,7 +1,7 @@
 pub use self::collider::*;
 pub use self::shape_views::ColliderView;
 pub use rapier::geometry::SolverFlags;
-pub use rapier::parry::query::TOIStatus;
+pub use rapier::parry::query::{ShapeCastOptions, ShapeCastStatus};
 pub use rapier::parry::shape::TriMeshFlags;
 pub use rapier::parry::transformation::{vhacd::VHACDParameters, voxelization::FillMode};
 
@@ -69,8 +69,8 @@ impl RayIntersection {
         unscaled_dir: Vect,
     ) -> Self {
         Self {
-            toi: inter.toi,
-            point: unscaled_origin + unscaled_dir * inter.toi,
+            toi: inter.time_of_impact,
+            point: unscaled_origin + unscaled_dir * inter.time_of_impact,
             normal: inter.normal.into(),
             feature: inter.feature,
         }
@@ -87,7 +87,7 @@ pub struct Toi {
     /// `None` if `status` is `Penetrating`.
     pub details: Option<ToiDetails>,
     /// The way the time-of-impact computation algorithm terminated.
-    pub status: TOIStatus,
+    pub status: ShapeCastStatus,
 }
 
 /// In depth information about a time-of-impact (TOI) computation.
@@ -105,8 +105,8 @@ pub struct ToiDetails {
 
 impl Toi {
     /// Convert from internal `rapier::Toi`.
-    pub fn from_rapier(physics_scale: Real, toi: rapier::parry::query::TOI) -> Self {
-        let details = if toi.status != TOIStatus::Penetrating {
+    pub fn from_rapier(physics_scale: Real, toi: rapier::parry::query::ShapeCastHit) -> Self {
+        let details = if toi.status != ShapeCastStatus::PenetratingOrWithinTargetDist {
             Some(ToiDetails {
                 witness1: (toi.witness1 * physics_scale).into(),
                 witness2: (toi.witness2 * physics_scale).into(),
@@ -117,7 +117,7 @@ impl Toi {
             None
         };
         Self {
-            toi: toi.toi,
+            toi: toi.time_of_impact,
             status: toi.status,
             details,
         }

--- a/src/plugin/configuration.rs
+++ b/src/plugin/configuration.rs
@@ -79,15 +79,18 @@ impl FromWorld for RapierConfiguration {
             .get_resource::<RapierContext>()
             .map(|ctxt| ctxt.integration_parameters.length_unit)
             .unwrap_or(1.0);
-        println!("Heree: {}", length_unit);
-
         Self::new(length_unit)
     }
 }
 
 impl RapierConfiguration {
+    /// Configures rapier with the specified length unit.
+    ///
+    /// See the documentation of [`IntegrationParameters::length_unit`] for additional details
+    /// on that argument.
+    ///
+    /// The default gravity is automatically scaled by that length unit.
     pub fn new(length_unit: Real) -> Self {
-        println!("Here: {}", length_unit);
         Self {
             gravity: Vect::Y * -9.81 * length_unit,
             physics_pipeline_active: true,

--- a/src/plugin/configuration.rs
+++ b/src/plugin/configuration.rs
@@ -1,6 +1,7 @@
-use bevy::prelude::Resource;
+use bevy::prelude::{FromWorld, Resource, World};
 
-use crate::math::Vect;
+use crate::math::{Real, Vect};
+use crate::plugin::RapierContext;
 
 /// Difference between simulation and rendering time
 #[derive(Resource, Default)]
@@ -68,17 +69,27 @@ pub struct RapierConfiguration {
     /// discretized into a convex polyhedron, using `scaled_shape_subdivision` as the number of subdivisions
     /// along each spherical coordinates angle.
     pub scaled_shape_subdivision: u32,
-    /// Specifies if backend sync should always accept tranform changes, which may be from the writeback stage.
+    /// Specifies if backend sync should always accept transform changes, which may be from the writeback stage.
     pub force_update_from_transform_changes: bool,
 }
 
-impl Default for RapierConfiguration {
-    fn default() -> Self {
+impl FromWorld for RapierConfiguration {
+    fn from_world(world: &mut World) -> Self {
+        let length_unit = world
+            .get_resource::<RapierContext>()
+            .map(|ctxt| ctxt.integration_parameters.length_unit)
+            .unwrap_or(1.0);
+        println!("Heree: {}", length_unit);
+
+        Self::new(length_unit)
+    }
+}
+
+impl RapierConfiguration {
+    pub fn new(length_unit: Real) -> Self {
+        println!("Here: {}", length_unit);
         Self {
-            #[cfg(feature = "dim2")]
-            gravity: Vect::Y * -9.81 * 10.0,
-            #[cfg(feature = "dim3")]
-            gravity: Vect::Y * -9.81,
+            gravity: Vect::Y * -9.81 * length_unit,
             physics_pipeline_active: true,
             query_pipeline_active: true,
             timestep_mode: TimestepMode::Variable {

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use rapier::prelude::{
-    BroadPhase, CCDSolver, ColliderHandle, ColliderSet, EventHandler, FeatureId,
-    ImpulseJointHandle, ImpulseJointSet, IntegrationParameters, IslandManager,
-    MultibodyJointHandle, MultibodyJointSet, NarrowPhase, PhysicsHooks, PhysicsPipeline,
-    QueryFilter as RapierQueryFilter, QueryPipeline, Ray, Real, RigidBodyHandle, RigidBodySet,
+    CCDSolver, ColliderHandle, ColliderSet, EventHandler, FeatureId, ImpulseJointHandle,
+    ImpulseJointSet, IntegrationParameters, IslandManager, MultibodyJointHandle, MultibodyJointSet,
+    NarrowPhase, PhysicsHooks, PhysicsPipeline, QueryFilter as RapierQueryFilter, QueryPipeline,
+    Ray, Real, RigidBodyHandle, RigidBodySet,
 };
 
 use crate::geometry::{Collider, PointProjection, RayIntersection, ShapeCastHit};
@@ -30,7 +30,7 @@ pub struct RapierContext {
     /// (not moving much) to reduce computations.
     pub islands: IslandManager,
     /// The broad-phase, which detects potential contact pairs.
-    pub broad_phase: Box<dyn BroadPhase>,
+    pub broad_phase: DefaultBroadPhase,
     /// The narrow-phase, which computes contact points, tests intersections,
     /// and maintain the contact and intersection graphs.
     pub narrow_phase: NarrowPhase,
@@ -77,7 +77,7 @@ impl Default for RapierContext {
     fn default() -> Self {
         Self {
             islands: IslandManager::new(),
-            broad_phase: Box::new(DefaultBroadPhase::new()),
+            broad_phase: DefaultBroadPhase::new(),
             narrow_phase: NarrowPhase::new(),
             bodies: RigidBodySet::new(),
             colliders: ColliderSet::new(),
@@ -257,7 +257,7 @@ impl RapierContext {
                             &gravity.into(),
                             &substep_integration_parameters,
                             &mut self.islands,
-                            &mut *self.broad_phase,
+                            &mut self.broad_phase,
                             &mut self.narrow_phase,
                             &mut self.bodies,
                             &mut self.colliders,
@@ -288,7 +288,7 @@ impl RapierContext {
                         &gravity.into(),
                         &substep_integration_parameters,
                         &mut self.islands,
-                        &mut *self.broad_phase,
+                        &mut self.broad_phase,
                         &mut self.narrow_phase,
                         &mut self.bodies,
                         &mut self.colliders,
@@ -312,7 +312,7 @@ impl RapierContext {
                         &gravity.into(),
                         &substep_integration_parameters,
                         &mut self.islands,
-                        &mut *self.broad_phase,
+                        &mut self.broad_phase,
                         &mut self.narrow_phase,
                         &mut self.bodies,
                         &mut self.colliders,

--- a/src/plugin/narrow_phase.rs
+++ b/src/plugin/narrow_phase.rs
@@ -249,7 +249,7 @@ impl<'a> ContactView<'a> {
     /// collider's rigid-body.
     #[cfg(feature = "dim2")]
     pub fn tangent_impulse(&self) -> Real {
-        self.raw.data.tangent_impulse
+        self.raw.data.tangent_impulse.x
     }
 
     /// The friction impulse along the vector orthonormal to the contact normal, applied to the first

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -11,6 +11,7 @@ use bevy::{
     utils::intern::Interned,
 };
 use bevy::{prelude::*, transform::TransformSystem};
+use rapier::dynamics::IntegrationParameters;
 use std::marker::PhantomData;
 
 /// No specific user-data is associated to the hooks.
@@ -22,7 +23,7 @@ pub type NoUserData = ();
 /// Rapier physics engine.
 pub struct RapierPhysicsPlugin<PhysicsHooks = ()> {
     schedule: Interned<dyn ScheduleLabel>,
-    physics_scale: f32,
+    length_unit: f32,
     default_system_setup: bool,
     _phantom: PhantomData<PhysicsHooks>,
 }
@@ -35,11 +36,11 @@ where
     /// Specifies a scale ratio between the physics world and the bevy transforms.
     ///
     /// This affects the size of every elements in the physics engine, by multiplying
-    /// all the length-related quantities by the `physics_scale` factor. This should
+    /// all the length-related quantities by the `length_unit` factor. This should
     /// likely always be 1.0 in 3D. In 2D, this is useful to specify a "pixels-per-meter"
     /// conversion ratio.
-    pub fn with_physics_scale(mut self, physics_scale: f32) -> Self {
-        self.physics_scale = physics_scale;
+    pub fn with_length_unit(mut self, length_unit: f32) -> Self {
+        self.length_unit = length_unit;
         self
     }
 
@@ -58,7 +59,7 @@ where
     #[cfg(feature = "dim2")]
     pub fn pixels_per_meter(pixels_per_meter: f32) -> Self {
         Self {
-            physics_scale: pixels_per_meter,
+            length_unit: pixels_per_meter,
             default_system_setup: true,
             ..default()
         }
@@ -137,7 +138,7 @@ impl<PhysicsHooksSystemParam> Default for RapierPhysicsPlugin<PhysicsHooksSystem
     fn default() -> Self {
         Self {
             schedule: PostUpdate.intern(),
-            physics_scale: 1.0,
+            length_unit: 1.0,
             default_system_setup: true,
             _phantom: PhantomData,
         }
@@ -191,18 +192,24 @@ where
             .register_type::<ContactForceEventThreshold>()
             .register_type::<Group>();
 
-        // Insert all of our required resources. Don’t overwrite
-        // the `RapierConfiguration` if it already exists.
-        app.init_resource::<RapierConfiguration>();
-
         app.insert_resource(SimulationToRenderTime::default())
             .insert_resource(RapierContext {
-                physics_scale: self.physics_scale,
+                integration_parameters: IntegrationParameters {
+                    length_unit: self.length_unit,
+                    ..Default::default()
+                },
                 ..Default::default()
             })
             .insert_resource(Events::<CollisionEvent>::default())
             .insert_resource(Events::<ContactForceEvent>::default())
             .insert_resource(Events::<MassModifiedEvent>::default());
+
+        // Insert all of our required resources. Don’t overwrite
+        // the `RapierConfiguration` if it already exists.
+        //
+        // NOTE: be sure to call this after the `.insert_resource(RapierContext)` so we can
+        //       access the length_unit when initializing the RapierConfiguration.
+        app.init_resource::<RapierConfiguration>();
 
         // Add each set as necessary
         if self.default_system_setup {

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -182,6 +182,7 @@ where
             .register_type::<Damping>()
             .register_type::<Dominance>()
             .register_type::<Ccd>()
+            .register_type::<SoftCcd>()
             .register_type::<GravityScale>()
             .register_type::<CollidingEntities>()
             .register_type::<Sensor>()
@@ -190,6 +191,7 @@ where
             .register_type::<CollisionGroups>()
             .register_type::<SolverGroups>()
             .register_type::<ContactForceEventThreshold>()
+            .register_type::<ContactSkin>()
             .register_type::<Group>();
 
         app.insert_resource(SimulationToRenderTime::default())

--- a/src/plugin/systems.rs
+++ b/src/plugin/systems.rs
@@ -318,7 +318,7 @@ pub fn apply_rigid_body_user_changes(
     for (handle, sleeping) in changed_sleeping.iter() {
         if let Some(rb) = context.bodies.get_mut(handle.0) {
             let activation = rb.activation_mut();
-            activation.linear_threshold = sleeping.linear_threshold;
+            activation.normalized_linear_threshold = sleeping.normalized_linear_threshold;
             activation.angular_threshold = sleeping.angular_threshold;
 
             if !sleeping.sleeping && activation.sleeping {
@@ -1068,7 +1068,7 @@ pub fn init_rigid_bodies(
 
         if let Some(sleep) = sleep {
             let activation = rb.activation_mut();
-            activation.linear_threshold = sleep.linear_threshold;
+            activation.normalized_linear_threshold = sleep.normalized_linear_threshold;
             activation.angular_threshold = sleep.angular_threshold;
         }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -95,7 +95,6 @@ impl Plugin for RapierDebugRenderPlugin {
 }
 
 struct BevyLinesRenderBackend<'world, 'state, 'a, 'b> {
-    physics_scale: f32,
     custom_colors: Query<'world, 'state, &'a ColliderDebugColor>,
     context: &'b RapierContext,
     gizmos: Gizmos<'world, 'state>,
@@ -126,11 +125,10 @@ impl<'world, 'state, 'a, 'b> DebugRenderBackend for BevyLinesRenderBackend<'worl
         b: Point<Real>,
         color: [f32; 4],
     ) {
-        let scale = self.physics_scale;
         let color = self.object_color(object, color);
         self.gizmos.line(
-            [a.x * scale, a.y * scale, 0.0].into(),
-            [b.x * scale, b.y * scale, 0.0].into(),
+            [a.x, a.y, 0.0].into(),
+            [b.x, b.y, 0.0].into(),
             Color::hsla(color[0], color[1], color[2], color[3]),
         )
     }
@@ -143,11 +141,10 @@ impl<'world, 'state, 'a, 'b> DebugRenderBackend for BevyLinesRenderBackend<'worl
         b: Point<Real>,
         color: [f32; 4],
     ) {
-        let scale = self.physics_scale;
         let color = self.object_color(object, color);
         self.gizmos.line(
-            [a.x * scale, a.y * scale, a.z * scale].into(),
-            [b.x * scale, b.y * scale, b.z * scale].into(),
+            [a.x, a.y, a.z].into(),
+            [b.x, b.y, b.z].into(),
             Color::hsla(color[0], color[1], color[2], color[3]),
         )
     }
@@ -164,14 +161,12 @@ fn debug_render_scene(
     }
 
     let mut backend = BevyLinesRenderBackend {
-        physics_scale: rapier_context.physics_scale,
         custom_colors,
         context: &rapier_context,
         gizmos,
     };
 
     let unscaled_style = render_context.pipeline.style;
-    render_context.pipeline.style.rigid_body_axes_length /= rapier_context.physics_scale;
     render_context.pipeline.render(
         &mut backend,
         &rapier_context.bodies,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,8 +2,6 @@ use bevy::prelude::Transform;
 use rapier::math::{Isometry, Real};
 
 /// Converts a Rapier isometry to a Bevy transform.
-///
-/// The translation is multiplied by the `physics_scale`.
 #[cfg(feature = "dim2")]
 pub fn iso_to_transform(iso: &Isometry<Real>) -> Transform {
     Transform {
@@ -14,8 +12,6 @@ pub fn iso_to_transform(iso: &Isometry<Real>) -> Transform {
 }
 
 /// Converts a Rapier isometry to a Bevy transform.
-///
-/// The translation is multiplied by the `physics_scale`.
 #[cfg(feature = "dim3")]
 pub fn iso_to_transform(iso: &Isometry<Real>) -> Transform {
     Transform {
@@ -26,8 +22,6 @@ pub fn iso_to_transform(iso: &Isometry<Real>) -> Transform {
 }
 
 /// Converts a Bevy transform to a Rapier isometry.
-///
-/// The translation is divided by the `physics_scale`.
 #[cfg(feature = "dim2")]
 pub(crate) fn transform_to_iso(transform: &Transform) -> Isometry<Real> {
     use bevy::math::Vec3Swizzles;
@@ -38,8 +32,6 @@ pub(crate) fn transform_to_iso(transform: &Transform) -> Isometry<Real> {
 }
 
 /// Converts a Bevy transform to a Rapier isometry.
-///
-/// The translation is divided by the `physics_scale`.
 #[cfg(feature = "dim3")]
 pub(crate) fn transform_to_iso(transform: &Transform) -> Isometry<Real> {
     Isometry::from_parts(transform.translation.into(), transform.rotation.into())

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -51,7 +51,7 @@ mod tests {
                 .normalize(),
             ..Default::default()
         };
-        let converted_transform = iso_to_transform(&transform_to_iso(&transform, 1.0), 1.0);
+        let converted_transform = iso_to_transform(&transform_to_iso(&transform));
         assert_eq!(converted_transform, transform);
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,9 +5,9 @@ use rapier::math::{Isometry, Real};
 ///
 /// The translation is multiplied by the `physics_scale`.
 #[cfg(feature = "dim2")]
-pub fn iso_to_transform(iso: &Isometry<Real>, physics_scale: Real) -> Transform {
+pub fn iso_to_transform(iso: &Isometry<Real>) -> Transform {
     Transform {
-        translation: (iso.translation.vector.push(0.0) * physics_scale).into(),
+        translation: iso.translation.vector.push(0.0).into(),
         rotation: bevy::prelude::Quat::from_rotation_z(iso.rotation.angle()),
         ..Default::default()
     }
@@ -17,9 +17,9 @@ pub fn iso_to_transform(iso: &Isometry<Real>, physics_scale: Real) -> Transform 
 ///
 /// The translation is multiplied by the `physics_scale`.
 #[cfg(feature = "dim3")]
-pub fn iso_to_transform(iso: &Isometry<Real>, physics_scale: Real) -> Transform {
+pub fn iso_to_transform(iso: &Isometry<Real>) -> Transform {
     Transform {
-        translation: (iso.translation.vector * physics_scale).into(),
+        translation: iso.translation.vector.into(),
         rotation: iso.rotation.into(),
         ..Default::default()
     }
@@ -29,10 +29,10 @@ pub fn iso_to_transform(iso: &Isometry<Real>, physics_scale: Real) -> Transform 
 ///
 /// The translation is divided by the `physics_scale`.
 #[cfg(feature = "dim2")]
-pub(crate) fn transform_to_iso(transform: &Transform, physics_scale: Real) -> Isometry<Real> {
+pub(crate) fn transform_to_iso(transform: &Transform) -> Isometry<Real> {
     use bevy::math::Vec3Swizzles;
     Isometry::new(
-        (transform.translation / physics_scale).xy().into(),
+        transform.translation.xy().into(),
         transform.rotation.to_scaled_axis().z,
     )
 }
@@ -41,11 +41,8 @@ pub(crate) fn transform_to_iso(transform: &Transform, physics_scale: Real) -> Is
 ///
 /// The translation is divided by the `physics_scale`.
 #[cfg(feature = "dim3")]
-pub(crate) fn transform_to_iso(transform: &Transform, physics_scale: Real) -> Isometry<Real> {
-    Isometry::from_parts(
-        (transform.translation / physics_scale).into(),
-        transform.rotation.into(),
-    )
+pub(crate) fn transform_to_iso(transform: &Transform) -> Isometry<Real> {
+    Isometry::from_parts(transform.translation.into(), transform.rotation.into())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**This is an update to Rapier 0.19 which includes several stability improvements
and character-controller fix. Please have a look at the
[0.19 changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md) of Rapier.**

### Modified

- Renamed `Toi/ToiDetails` to `ShapeCastHit/ShapeCastHitDetails`.
- Switch to rapier’s built-in `length_unit` instead of explicitly scaling shapes with `physics_scale`.
- Linear shape-casting functions now take a `ShapeCastOptions` parameter that describes how the shape-cast should
  behave on special-cases (like toi == 0).
- Internal edge correction is now opt-in with the `TriMeshFlags::FIX_INTERNAL_EDGES` and
  `HeightFieldFlags::FIX_INTERNAL_EDGES` flags.
- Rename `RayIntersection::toi` to `RayIntersection::time_of_impact`.

### Fix

- Fix character controller occasionally getting stuck against vertical walls.

### Added

- Add the `SoftCcd` (for rigid-bodies) and `ContactSkin` (for colliders) components. See
  [rapier#625](https://github.com/dimforge/rapier/pull/625) for details on the features they enable.
