### PR TITLE
update dependency to bevy 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Modified
 
 - Renamed `has_any_active_contacts` to `has_any_active_contact` for better consistency with rapier.
+- Update to bevy `0.13`.
+- `ColliderDebugColor`'s property is now a `bevy::color::Hsla`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Modified
 
 - Renamed `has_any_active_contacts` to `has_any_active_contact` for better consistency with rapier.
-- Update to bevy `0.13`.
+- Update to bevy `0.14`.
 - `ColliderDebugColor`'s property is now a `bevy::color::Hsla`.
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ opt-level = 1
 codegen-units = 1
 
 [patch.crates-io]
-#nalgebra = { path = "../nalgebra" }
-#parry2d = { path = "../parry/crates/parry2d" }
-#parry3d = { path = "../parry/crates/parry3d" }
+nalgebra = { path = "../nalgebra" }
+# parry2d = { path = "../parry/crates/parry2d" }
+# parry3d = { path = "../parry/crates/parry3d" }
 #rapier2d = { path = "../rapier/crates/rapier2d" }
 #rapier3d = { path = "../rapier/crates/rapier3d" }
 
@@ -21,3 +21,8 @@ codegen-units = 1
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #rapier2d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
+
+# nalgebra = { git = 'https://github.com/waywardmonkeys/nalgebra.git', branch = "support-glam-027", features = [
+#     "glam027",
+#     "approx",
+# ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ codegen-units = 1
 
 [patch.crates-io]
 nalgebra = { path = "../nalgebra" }
-# parry2d = { path = "../parry/crates/parry2d" }
-# parry3d = { path = "../parry/crates/parry3d" }
+#parry2d = { path = "../parry/crates/parry2d" }
+#parry3d = { path = "../parry/crates/parry3d" }
 #rapier2d = { path = "../rapier/crates/rapier2d" }
 #rapier3d = { path = "../rapier/crates/rapier3d" }
 
@@ -21,8 +21,3 @@ nalgebra = { path = "../nalgebra" }
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #rapier2d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
-
-# nalgebra = { git = 'https://github.com/waywardmonkeys/nalgebra.git', branch = "support-glam-027", features = [
-#     "glam027",
-#     "approx",
-# ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ opt-level = 1
 codegen-units = 1
 
 [patch.crates-io]
-nalgebra = { path = "../nalgebra" }
+#nalgebra = { path = "../nalgebra" }
 #parry2d = { path = "../parry/crates/parry2d" }
 #parry3d = { path = "../parry/crates/parry3d" }
 #rapier2d = { path = "../rapier/crates/rapier2d" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -20,8 +20,20 @@ required-features = ["dim2"]
 [features]
 default = ["dim2", "async-collider", "debug-render-2d"]
 dim2 = []
-debug-render-2d = ["bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_gizmos", "rapier2d/debug-render", "bevy/bevy_asset"]
-debug-render-3d = ["bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_gizmos", "rapier2d/debug-render", "bevy/bevy_asset"]
+debug-render-2d = [
+    "bevy/bevy_core_pipeline",
+    "bevy/bevy_sprite",
+    "bevy/bevy_gizmos",
+    "rapier2d/debug-render",
+    "bevy/bevy_asset",
+]
+debug-render-3d = [
+    "bevy/bevy_core_pipeline",
+    "bevy/bevy_pbr",
+    "bevy/bevy_gizmos",
+    "rapier2d/debug-render",
+    "bevy/bevy_asset",
+]
 parallel = ["rapier2d/parallel"]
 simd-stable = ["rapier2d/simd-stable"]
 simd-nightly = ["rapier2d/simd-nightly"]
@@ -32,18 +44,18 @@ headless = []
 async-collider = ["bevy/bevy_asset", "bevy/bevy_scene"]
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
-nalgebra = { version = "0.32.3", features = ["convert-glam025"] }
+bevy = { version = "0.14.0-rc.2", default-features = false }
+nalgebra = { version = "0.32.5", features = ["convert-glam027"] }
 rapier2d = "0.19.0"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = ["x11"] }
+bevy = { version = "0.14.0-rc.2", default-features = false, features = ["x11"] }
 oorandom = "11"
 approx = "0.5.1"
-glam = { version = "0.25", features = ["approx"] }
+glam = { version = "0.27", features = ["approx"] }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -52,7 +52,10 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.14.0-rc.2", default-features = false, features = ["x11"] }
+bevy = { version = "0.14.0-rc.2", default-features = false, features = [
+    "x11",
+    "bevy_state",
+] }
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.27", features = ["approx"] }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -45,7 +45,7 @@ async-collider = ["bevy/bevy_asset", "bevy/bevy_scene"]
 
 [dependencies]
 bevy = { version = "0.14.0-rc.2", default-features = false }
-nalgebra = { version = "0.32.5", features = ["convert-glam027"] }
+nalgebra = { version = "0.32.6", features = ["convert-glam027"] }
 rapier2d = "0.19.0"
 bitflags = "2.4"
 log = "0.4"

--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -30,7 +30,7 @@ impl BevyPhysicsHooks for SameUserDataFilter<'_, '_> {
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
@@ -80,7 +80,7 @@ pub fn setup_physics(mut commands: Commands) {
     let centery = shift / 2.0;
     let mut group_id = 0;
     let tags = [CustomFilterTag::GroupA, CustomFilterTag::GroupB];
-    let colors = [Color::hsl(220.0, 1.0, 0.3), Color::hsl(260.0, 1.0, 0.7)];
+    let colors = [Hsla::hsl(220.0, 1.0, 0.3), Hsla::hsl(260.0, 1.0, 0.7)];
 
     for i in 0..num {
         for j in 0usize..num * 5 {

--- a/bevy_rapier2d/examples/custom_system_setup2.rs
+++ b/bevy_rapier2d/examples/custom_system_setup2.rs
@@ -4,7 +4,7 @@ use bevy_rapier2d::prelude::*;
 fn main() {
     let mut app = App::new();
 
-    app.insert_resource(ClearColor(Color::rgb(
+    app.insert_resource(ClearColor(Color::srgb(
         0xF9 as f32 / 255.0,
         0xF9 as f32 / 255.0,
         0xFF as f32 / 255.0,

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -8,7 +8,7 @@ use bevy_rapier2d::prelude::*;
 fn main() {
     App::new()
         .init_resource::<Game>()
-        .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
+        .insert_resource(ClearColor(Color::srgb(0.0, 0.0, 0.0)))
         .add_plugins((
             DefaultPlugins,
             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
@@ -76,7 +76,7 @@ impl Default for Game {
 }
 
 fn byte_rgb(r: u8, g: u8, b: u8) -> Color {
-    Color::rgb(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
+    Color::srgb(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
 }
 
 pub fn setup_game(mut commands: Commands, mut game: ResMut<Game>) {
@@ -133,7 +133,7 @@ fn setup_board(commands: &mut Commands, game: &Game) {
     commands.spawn((
         SpriteBundle {
             sprite: Sprite {
-                color: Color::rgb(0.5, 0.5, 0.5),
+                color: Color::srgb(0.5, 0.5, 0.5),
                 custom_size: Some(Vec2::new(game.n_lanes as f32 * 30.0, 60.0)),
                 ..Default::default()
             },

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -18,7 +18,7 @@ pub struct ResizeResource {
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier2d/examples/joints_despawn2.rs
+++ b/bevy_rapier2d/examples/joints_despawn2.rs
@@ -11,7 +11,7 @@ pub struct DespawnResource {
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -35,7 +35,7 @@ pub fn spawn_player(mut commands: Commands, mut rapier_config: ResMut<RapierConf
     commands.spawn((
         SpriteBundle {
             sprite: Sprite {
-                color: Color::rgb(0.0, 0.0, 0.0),
+                color: Color::srgb(0.0, 0.0, 0.0),
                 custom_size: Some(Vec2::new(sprite_size, sprite_size)),
                 ..Default::default()
             },

--- a/bevy_rapier2d/examples/rope_joint2.rs
+++ b/bevy_rapier2d/examples/rope_joint2.rs
@@ -3,7 +3,7 @@ use bevy_rapier2d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -46,8 +46,7 @@ async-collider = ["bevy/bevy_asset", "bevy/bevy_scene"]
 
 [dependencies]
 bevy = { version = "0.14.0-rc.2", default-features = false }
-# nalgebra = { version = "0.32.5", features = ["convert-glam027"] }
-nalgebra = { path = "../../nalgebra", features = ["convert-glam027"] }
+nalgebra = { version = "0.32.6", features = ["convert-glam027"] }
 rapier3d = "0.19"
 bitflags = "2.4"
 log = "0.4"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -21,8 +21,20 @@ required-features = ["dim3"]
 default = ["dim3", "async-collider", "debug-render-3d"]
 dim3 = []
 debug-render = ["debug-render-3d"]
-debug-render-2d = ["bevy/bevy_core_pipeline", "bevy/bevy_sprite", "bevy/bevy_gizmos", "rapier3d/debug-render", "bevy/bevy_asset"]
-debug-render-3d = ["bevy/bevy_core_pipeline", "bevy/bevy_pbr", "bevy/bevy_gizmos", "rapier3d/debug-render", "bevy/bevy_asset"]
+debug-render-2d = [
+    "bevy/bevy_core_pipeline",
+    "bevy/bevy_sprite",
+    "bevy/bevy_gizmos",
+    "rapier3d/debug-render",
+    "bevy/bevy_asset",
+]
+debug-render-3d = [
+    "bevy/bevy_core_pipeline",
+    "bevy/bevy_pbr",
+    "bevy/bevy_gizmos",
+    "rapier3d/debug-render",
+    "bevy/bevy_asset",
+]
 parallel = ["rapier3d/parallel"]
 simd-stable = ["rapier3d/simd-stable"]
 simd-nightly = ["rapier3d/simd-nightly"]
@@ -33,17 +45,21 @@ headless = []
 async-collider = ["bevy/bevy_asset", "bevy/bevy_scene"]
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
-nalgebra = { version = "0.32.3", features = ["convert-glam025"] }
+bevy = { version = "0.14.0-rc.2", default-features = false }
+# nalgebra = { version = "0.32.5", features = ["convert-glam027"] }
+nalgebra = { path = "../../nalgebra", features = ["convert-glam027"] }
 rapier3d = "0.19"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = ["x11", "tonemapping_luts"] }
+bevy = { version = "0.14.0-rc.2", default-features = false, features = [
+    "x11",
+    "tonemapping_luts",
+] }
 approx = "0.5.1"
-glam = { version = "0.25", features = ["approx"] }
+glam = { version = "0.27", features = ["approx"] }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -57,6 +57,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 bevy = { version = "0.14.0-rc.2", default-features = false, features = [
     "x11",
     "tonemapping_luts",
+    "bevy_state",
 ] }
 approx = "0.5.1"
 glam = { version = "0.27", features = ["approx"] }

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -3,7 +3,7 @@ use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -51,9 +51,9 @@ pub fn setup_physics(mut commands: Commands) {
     let mut offset = -(num as f32) * (rad * 2.0 + rad) * 0.5;
     let mut color = 0;
     let colors = [
-        Color::hsl(220.0, 1.0, 0.3),
-        Color::hsl(180.0, 1.0, 0.3),
-        Color::hsl(260.0, 1.0, 0.7),
+        Hsla::hsl(220.0, 1.0, 0.3),
+        Hsla::hsl(180.0, 1.0, 0.3),
+        Hsla::hsl(260.0, 1.0, 0.7),
     ];
 
     for j in 0usize..20 {

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -30,7 +30,7 @@ impl BevyPhysicsHooks for SameUserDataFilter<'_, '_> {
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
@@ -81,7 +81,7 @@ pub fn setup_physics(mut commands: Commands) {
     let centery = shift / 2.0;
     let mut group_id = 0;
     let tags = [CustomFilterTag::GroupA, CustomFilterTag::GroupB];
-    let colors = [Color::hsl(220.0, 1.0, 0.3), Color::hsl(260.0, 1.0, 0.7)];
+    let colors = [Hsla::hsl(220.0, 1.0, 0.3), Hsla::hsl(260.0, 1.0, 0.7)];
 
     for i in 0..num {
         for j in 0usize..num * 5 {

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -4,7 +4,7 @@ use bevy_rapier3d::prelude::*;
 fn main() {
     let mut app = App::new();
 
-    app.insert_resource(ClearColor(Color::rgb(
+    app.insert_resource(ClearColor(Color::srgb(
         0xF9 as f32 / 255.0,
         0xF9 as f32 / 255.0,
         0xFF as f32 / 255.0,
@@ -94,9 +94,9 @@ pub fn setup_physics(mut commands: Commands) {
     let mut offset = -(num as f32) * (rad * 2.0 + rad) * 0.5;
     let mut color = 0;
     let colors = [
-        Color::hsl(220.0, 1.0, 0.3),
-        Color::hsl(180.0, 1.0, 0.3),
-        Color::hsl(260.0, 1.0, 0.7),
+        Hsla::hsl(220.0, 1.0, 0.3),
+        Hsla::hsl(180.0, 1.0, 0.3),
+        Hsla::hsl(260.0, 1.0, 0.7),
     ];
 
     for j in 0usize..20 {

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -11,7 +11,7 @@ pub struct DespawnResource {
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
@@ -64,9 +64,9 @@ pub fn setup_physics(mut commands: Commands) {
     let mut offset = -(num as f32) * (rad * 2.0 + rad) * 0.5;
     let mut color = 0;
     let colors = [
-        Color::hsl(220.0, 1.0, 0.3),
-        Color::hsl(180.0, 1.0, 0.3),
-        Color::hsl(260.0, 1.0, 0.7),
+        Hsla::hsl(220.0, 1.0, 0.3),
+        Hsla::hsl(180.0, 1.0, 0.3),
+        Hsla::hsl(260.0, 1.0, 0.7),
     ];
 
     for j in 0usize..20 {

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -3,7 +3,7 @@ use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -3,7 +3,7 @@ use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -11,7 +11,7 @@ pub struct DespawnResource {
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -3,7 +3,7 @@ use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/bevy_rapier3d/examples/multiple_colliders3.rs
+++ b/bevy_rapier3d/examples/multiple_colliders3.rs
@@ -3,7 +3,7 @@ use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
@@ -51,9 +51,9 @@ pub fn setup_physics(mut commands: Commands) {
     let mut offset = -(num as f32) * (rad * 2.0 + rad) * 0.5;
     let mut color = 0;
     let colors = [
-        Color::hsl(220.0, 1.0, 0.3),
-        Color::hsl(180.0, 1.0, 0.3),
-        Color::hsl(260.0, 1.0, 0.7),
+        Hsla::hsl(220.0, 1.0, 0.3),
+        Hsla::hsl(180.0, 1.0, 0.3),
+        Hsla::hsl(260.0, 1.0, 0.7),
     ];
 
     for j in 0usize..20 {

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -1,10 +1,11 @@
+use bevy::color::palettes::basic;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,
@@ -104,7 +105,7 @@ pub fn cast_ray(
             // Color in blue the entity we just hit.
             // Because of the query filter, only colliders attached to a dynamic body
             // will get an event.
-            let color = Color::BLUE;
+            let color = basic::BLUE.into();
             commands.entity(entity).insert(ColliderDebugColor(color));
         }
     }

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -5,7 +5,7 @@ use bevy_rapier3d::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb(
+        .insert_resource(ClearColor(Color::srgb(
             0xF9 as f32 / 255.0,
             0xF9 as f32 / 255.0,
             0xFF as f32 / 255.0,

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -3,7 +3,6 @@ use crate::plugin::configuration::SimulationToRenderTime;
 use crate::plugin::{systems, RapierConfiguration, RapierContext};
 use crate::prelude::*;
 use bevy::ecs::{
-    event::{event_update_system, Events},
     intern::Interned,
     schedule::{ScheduleLabel, SystemConfigs},
     system::SystemParamItem,
@@ -107,16 +106,11 @@ where
             )
                 .chain()
                 .into_configs(),
-            PhysicsSet::StepSimulation => (
-                systems::step_simulation::<PhysicsHooks>,
-                event_update_system.before(systems::step_simulation::<PhysicsHooks>),
-            )
-                .into_configs(),
+            PhysicsSet::StepSimulation => (systems::step_simulation::<PhysicsHooks>).into_configs(),
             PhysicsSet::Writeback => (
                 systems::update_colliding_entities,
                 systems::writeback_rigid_bodies,
                 systems::writeback_mass_properties,
-                event_update_system.after(systems::writeback_mass_properties),
             )
                 .into_configs(),
         }

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -2,13 +2,11 @@ use crate::pipeline::{CollisionEvent, ContactForceEvent};
 use crate::plugin::configuration::SimulationToRenderTime;
 use crate::plugin::{systems, RapierConfiguration, RapierContext};
 use crate::prelude::*;
-use bevy::{
-    ecs::{
-        event::{event_update_system, Events},
-        schedule::{ScheduleLabel, SystemConfigs},
-        system::SystemParamItem,
-    },
-    utils::intern::Interned,
+use bevy::ecs::{
+    event::{event_update_system, Events},
+    intern::Interned,
+    schedule::{ScheduleLabel, SystemConfigs},
+    system::SystemParamItem,
 };
 use bevy::{prelude::*, transform::TransformSystem};
 use rapier::dynamics::IntegrationParameters;
@@ -111,17 +109,14 @@ where
                 .into_configs(),
             PhysicsSet::StepSimulation => (
                 systems::step_simulation::<PhysicsHooks>,
-                event_update_system::<CollisionEvent>
-                    .before(systems::step_simulation::<PhysicsHooks>),
-                event_update_system::<ContactForceEvent>
-                    .before(systems::step_simulation::<PhysicsHooks>),
+                event_update_system.before(systems::step_simulation::<PhysicsHooks>),
             )
                 .into_configs(),
             PhysicsSet::Writeback => (
                 systems::update_colliding_entities,
                 systems::writeback_rigid_bodies,
                 systems::writeback_mass_properties,
-                event_update_system::<MassModifiedEvent>.after(systems::writeback_mass_properties),
+                event_update_system.after(systems::writeback_mass_properties),
             )
                 .into_configs(),
         }
@@ -241,7 +236,7 @@ where
 
             // Warn user if the timestep mode isn't in Fixed
             if self.schedule.as_dyn_eq().dyn_eq(FixedUpdate.as_dyn_eq()) {
-                let config = app.world.resource::<RapierConfiguration>();
+                let config = app.world_mut().resource::<RapierConfiguration>();
                 match config.timestep_mode {
                     TimestepMode::Fixed { .. } => {}
                     mode => {

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -549,18 +549,15 @@ pub mod test {
         app.update();
 
         assert!(
-            app.world_mut().entity(cube).get::<Collider>().is_some(),
+            app.world().entity(cube).get::<Collider>().is_some(),
             "Collider component should be added for cube"
         );
         assert!(
-            app.world_mut().entity(capsule).get::<Collider>().is_none(),
+            app.world().entity(capsule).get::<Collider>().is_none(),
             "Collider component shouldn't be added for capsule"
         );
         assert!(
-            app.world_mut()
-                .entity(parent)
-                .get::<AsyncCollider>()
-                .is_none(),
+            app.world().entity(parent).get::<AsyncCollider>().is_none(),
             "AsyncSceneCollider component should be removed after Collider components creation"
         );
     }

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -492,14 +492,14 @@ pub mod test {
         app.add_plugins(HeadlessRenderPlugin)
             .add_systems(Update, init_async_colliders);
 
-        let mut meshes = app.world.resource_mut::<Assets<Mesh>>();
+        let mut meshes = app.world_mut().resource_mut::<Assets<Mesh>>();
         let cube = meshes.add(Cuboid::default());
 
-        let entity = app.world.spawn((cube, AsyncCollider::default())).id();
+        let entity = app.world_mut().spawn((cube, AsyncCollider::default())).id();
 
         app.update();
 
-        let entity = app.world.entity(entity);
+        let entity = app.world().entity(entity);
         assert!(
             entity.get::<Collider>().is_some(),
             "Collider component should be added"
@@ -520,19 +520,22 @@ pub mod test {
         app.add_plugins(HeadlessRenderPlugin)
             .add_systems(PostUpdate, init_async_scene_colliders);
 
-        let mut meshes = app.world.resource_mut::<Assets<Mesh>>();
+        let mut meshes = app.world_mut().resource_mut::<Assets<Mesh>>();
         let cube_handle = meshes.add(Cuboid::default());
         let capsule_handle = meshes.add(Capsule3d::default());
-        let cube = app.world.spawn((Name::new("Cube"), cube_handle)).id();
-        let capsule = app.world.spawn((Name::new("Capsule"), capsule_handle)).id();
+        let cube = app.world_mut().spawn((Name::new("Cube"), cube_handle)).id();
+        let capsule = app
+            .world_mut()
+            .spawn((Name::new("Capsule"), capsule_handle))
+            .id();
 
-        let mut scenes = app.world.resource_mut::<Assets<Scene>>();
+        let mut scenes = app.world_mut().resource_mut::<Assets<Scene>>();
         let scene = scenes.add(Scene::new(World::new()));
 
         let mut named_shapes = bevy::utils::HashMap::new();
         named_shapes.insert("Capsule".to_string(), None);
         let parent = app
-            .world
+            .world_mut()
             .spawn((
                 scene,
                 AsyncSceneCollider {
@@ -546,15 +549,18 @@ pub mod test {
         app.update();
 
         assert!(
-            app.world.entity(cube).get::<Collider>().is_some(),
+            app.world_mut().entity(cube).get::<Collider>().is_some(),
             "Collider component should be added for cube"
         );
         assert!(
-            app.world.entity(capsule).get::<Collider>().is_none(),
+            app.world_mut().entity(capsule).get::<Collider>().is_none(),
             "Collider component shouldn't be added for capsule"
         );
         assert!(
-            app.world.entity(parent).get::<AsyncCollider>().is_none(),
+            app.world_mut()
+                .entity(parent)
+                .get::<AsyncCollider>()
+                .is_none(),
             "AsyncSceneCollider component should be removed after Collider components creation"
         );
     }

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -89,11 +89,11 @@ mod tests {
         app.add_event::<CollisionEvent>()
             .add_systems(Update, update_colliding_entities);
 
-        let entity1 = app.world.spawn(CollidingEntities::default()).id();
-        let entity2 = app.world.spawn(CollidingEntities::default()).id();
+        let entity1 = app.world_mut().spawn(CollidingEntities::default()).id();
+        let entity2 = app.world_mut().spawn(CollidingEntities::default()).id();
 
         let mut collision_events = app
-            .world
+            .world_mut()
             .get_resource_mut::<Events<CollisionEvent>>()
             .unwrap();
         collision_events.send(CollisionEvent::Started(
@@ -105,7 +105,7 @@ mod tests {
         app.update();
 
         let colliding_entities1 = app
-            .world
+            .world()
             .entity(entity1)
             .get::<CollidingEntities>()
             .unwrap();
@@ -121,7 +121,7 @@ mod tests {
         );
 
         let colliding_entities2 = app
-            .world
+            .world()
             .entity(entity2)
             .get::<CollidingEntities>()
             .unwrap();
@@ -137,7 +137,7 @@ mod tests {
         );
 
         let mut collision_events = app
-            .world
+            .world_mut()
             .get_resource_mut::<Events<CollisionEvent>>()
             .unwrap();
         collision_events.send(CollisionEvent::Stopped(
@@ -149,7 +149,7 @@ mod tests {
         app.update();
 
         let colliding_entities1 = app
-            .world
+            .world()
             .entity(entity1)
             .get::<CollidingEntities>()
             .unwrap();
@@ -159,7 +159,7 @@ mod tests {
         );
 
         let colliding_entities2 = app
-            .world
+            .world()
             .entity(entity2)
             .get::<CollidingEntities>()
             .unwrap();
@@ -198,7 +198,7 @@ mod tests {
 
         for (child_transform, parent_transform) in [zero, same, different] {
             let child = app
-                .world
+                .world_mut()
                 .spawn((
                     TransformBundle::from(child_transform),
                     RigidBody::Fixed,
@@ -206,14 +206,14 @@ mod tests {
                 ))
                 .id();
 
-            app.world
+            app.world_mut()
                 .spawn(TransformBundle::from(parent_transform))
                 .push_children(&[child]);
 
             app.update();
 
-            let child_transform = app.world.entity(child).get::<GlobalTransform>().unwrap();
-            let context = app.world.resource::<RapierContext>();
+            let child_transform = app.world().entity(child).get::<GlobalTransform>().unwrap();
+            let context = app.world().resource::<RapierContext>();
             let child_handle = context.entity2body[&child];
             let child_body = context.bodies.get(child_handle).unwrap();
             let body_transform = utils::iso_to_transform(child_body.position());
@@ -257,12 +257,12 @@ mod tests {
 
         for (child_transform, parent_transform) in [zero, same, different] {
             let child = app
-                .world
+                .world_mut()
                 .spawn((TransformBundle::from(child_transform), Collider::ball(1.0)))
                 .id();
 
             let parent = app
-                .world
+                .world_mut()
                 .spawn((TransformBundle::from(parent_transform), RigidBody::Fixed))
                 .push_children(&[child])
                 .id();
@@ -270,12 +270,12 @@ mod tests {
             app.update();
 
             let child_transform = app
-                .world
+                .world()
                 .entity(child)
                 .get::<GlobalTransform>()
                 .unwrap()
                 .compute_transform();
-            let context = app.world.resource::<RapierContext>();
+            let context = app.world().resource::<RapierContext>();
             let parent_handle = context.entity2body[&parent];
             let parent_body = context.bodies.get(parent_handle).unwrap();
             let child_collider_handle = parent_body.colliders()[0];

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -312,7 +312,7 @@ mod tests {
             app.add_plugins((
                 WindowPlugin::default(),
                 AssetPlugin::default(),
-                ScenePlugin::default(),
+                ScenePlugin,
                 RenderPlugin {
                     render_creation: RenderCreation::Automatic(WgpuSettings {
                         backends: None,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -112,7 +112,9 @@ impl<'world, 'state, 'a, 'b> BevyLinesRenderBackend<'world, 'state, 'a, 'b> {
             _ => None,
         };
 
-        color.map(|co| co.as_hsla_f32()).unwrap_or(default)
+        color
+            .map(|co: Color| co.linear().to_f32_array())
+            .unwrap_or(default)
     }
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 /// force to a specific value the color used to render the
 /// collider.
 #[derive(Copy, Clone, Component, PartialEq, Debug)]
-pub struct ColliderDebugColor(pub Color);
+pub struct ColliderDebugColor(pub Hsla);
 
 /// Plugin rensponsible for rendering (using lines) what Rapier "sees" when performing
 /// its physics simulation. This is typically useful to check proper
@@ -112,9 +112,7 @@ impl<'world, 'state, 'a, 'b> BevyLinesRenderBackend<'world, 'state, 'a, 'b> {
             _ => None,
         };
 
-        color
-            .map(|co: Color| co.linear().to_f32_array())
-            .unwrap_or(default)
+        color.map(|co: Hsla| co.to_f32_array()).unwrap_or(default)
     }
 }
 


### PR DESCRIPTION
We'd like to [update to rapier 0.20](https://github.com/dimforge/bevy_rapier/pull/525) before updating to bevy 0.14.