### PR TITLE
Release v0.27.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.27.0-rc.1 (17 June 2024)
+## v0.27.0-rc.1 (18 June 2024)
 
 **This is an update to Rapier 0.20 which includes several stability improvements
 and new features. Please have a look at the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.27.0-rc.1 (17 June 2024)
 
 **This is an update to Rapier 0.20 which includes several stability improvements
 and new features. Please have a look at the

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.26.0"
+version = "0.27.0-rc.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"
@@ -44,7 +44,7 @@ headless = []
 async-collider = ["bevy/bevy_asset", "bevy/bevy_scene"]
 
 [dependencies]
-bevy = { version = "0.14.0-rc.2", default-features = false }
+bevy = { version = "0.14.0-rc.3", default-features = false }
 nalgebra = { version = "0.32.6", features = ["convert-glam027"] }
 rapier2d = "0.20"
 bitflags = "2.4"
@@ -52,7 +52,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.14.0-rc.2", default-features = false, features = [
+bevy = { version = "0.14.0-rc.3", default-features = false, features = [
     "x11",
     "bevy_state",
 ] }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.26.0"
+version = "0.27.0-rc.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"
@@ -45,7 +45,7 @@ headless = []
 async-collider = ["bevy/bevy_asset", "bevy/bevy_scene"]
 
 [dependencies]
-bevy = { version = "0.14.0-rc.2", default-features = false }
+bevy = { version = "0.14.0-rc.3", default-features = false }
 nalgebra = { version = "0.32.6", features = ["convert-glam027"] }
 rapier3d = "0.20"
 bitflags = "2.4"
@@ -53,7 +53,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.14.0-rc.2", default-features = false, features = [
+bevy = { version = "0.14.0-rc.3", default-features = false, features = [
     "x11",
     "tonemapping_luts",
     "bevy_state",


### PR DESCRIPTION
Prepare release candidate for 0.27.

also bumps bevy version to rc.3.