### PR TITLE
chore: publish script edits readme path to current directory

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -10,6 +10,7 @@ cp -r LICENSE README.md "$tmp"/.
 
 ### Publish the 2D version.
 sed 's#\.\./src#src#g' bevy_rapier2d/Cargo.toml > "$tmp"/Cargo.toml
+gawk -i inplace '{ gsub("../README.md", "README.md") }; { print }' "$tmp"/Cargo.toml
 currdir=$(pwd)
 cd "$tmp" && cargo publish
 cd "$currdir" || exit
@@ -17,6 +18,7 @@ cd "$currdir" || exit
 
 ### Publish the 3D version.
 sed 's#\.\./src#src#g' bevy_rapier3d/Cargo.toml > "$tmp"/Cargo.toml
+gawk -i inplace '{ gsub("../README.md", "README.md") }; { print }' "$tmp"/Cargo.toml
 cp -r LICENSE README.md "$tmp"/.
 cd "$tmp" && cargo publish
 


### PR DESCRIPTION
solution shamelessly pumped from https://stackoverflow.com/questions/7573368/in-place-edits-with-sed-on-os-x ; I didn't go the `sed` route because the "-i" option is quite... finicky cross-platform wise.