### PR TITLE
add simpler reproduction + a 'fix' in userspace

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -57,6 +57,10 @@ oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.25", features = ["approx"] }
 
+#{ git = "https://github.com/vrixyz/bevy-inspector-egui.git", branch = "bevy_0.14" }
+bevy-inspector-egui = "*"
+bevy_tasks = "*"
+
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs
 features = ["debug-render-2d", "serde-serialize"]

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -1,4 +1,11 @@
-use bevy::prelude::*;
+use std::num::NonZeroUsize;
+
+use bevy::{
+    ecs::schedule::Stepping,
+    input::common_conditions::{input_just_pressed, input_pressed},
+    prelude::*,
+};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;
 
 fn main() {
@@ -13,11 +20,13 @@ fn main() {
             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
             RapierDebugRenderPlugin::default(),
         ))
+        .add_plugins(WorldInspectorPlugin::new())
         .add_systems(Startup, (setup_graphics, setup_physics))
         .run();
 }
 
-pub fn setup_graphics(mut commands: Commands) {
+pub fn setup_graphics(mut commands: Commands, mut rapier_context: ResMut<RapierContext>) {
+    rapier_context.integration_parameters.num_solver_iterations = NonZeroUsize::new(1).unwrap();
     commands.spawn(Camera2dBundle {
         transform: Transform::from_xyz(0.0, -200.0, 0.0),
         ..default()

--- a/bevy_rapier2d/examples/joints2_simple.rs
+++ b/bevy_rapier2d/examples/joints2_simple.rs
@@ -1,0 +1,92 @@
+use std::num::NonZeroUsize;
+
+use bevy::{
+    app::PluginsState, input::common_conditions::input_just_pressed, prelude::*, transform,
+};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_rapier2d::prelude::*;
+
+fn main() {
+    let mut app = App::new();
+    app.insert_resource(ClearColor(Color::rgb(
+        0xF9 as f32 / 255.0,
+        0xF9 as f32 / 255.0,
+        0xFF as f32 / 255.0,
+    )))
+    .add_plugins((
+        DefaultPlugins,
+        RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
+        RapierDebugRenderPlugin::default(),
+    ))
+    .add_plugins(WorldInspectorPlugin::new())
+    .add_systems(Startup, (setup_graphics))
+    .add_systems(
+        Update,
+        setup_physics.run_if(input_just_pressed(KeyCode::KeyS)),
+    );
+
+    /*
+    let check_positions_id = app.world.register_system(check_positions);
+    let setup_physics_id = app.world.register_system(setup_physics);
+    while app.plugins_state() == PluginsState::Adding {
+        #[cfg(not(target_arch = "wasm32"))]
+        bevy_tasks::tick_global_task_pools_on_main_thread();
+    }
+    app.finish();
+    app.cleanup();
+    app.update();
+    app.world.run_system(setup_physics_id).expect("error1");
+    app.world.run_system(check_positions_id).expect("error1");
+
+    app.update();
+    app.world.run_system(check_positions_id).expect("error2");
+    app.update();
+    app.world.run_system(check_positions_id).expect("error2");*/
+    app.run();
+}
+
+pub fn setup_graphics(mut commands: Commands, mut rapier_context: ResMut<RapierContext>) {
+    rapier_context.integration_parameters.num_solver_iterations = NonZeroUsize::new(1).unwrap();
+    commands.spawn(Camera2dBundle {
+        transform: Transform::from_xyz(0.0, -200.0, 0.0),
+        ..default()
+    });
+}
+
+#[derive(Component)]
+struct DynamicBodyMarker;
+
+pub fn setup_physics(mut commands: Commands) {
+    let rad = 4.0;
+    let shift = 10.0;
+    let parent_entity = commands
+        .spawn((
+            TransformBundle::from(Transform::from_xyz(-shift, 0.0, 0.0)),
+            RigidBody::Fixed,
+            Collider::cuboid(rad, rad),
+        ))
+        .id();
+    let child_entity = commands
+        .spawn((
+            TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
+            RigidBody::Dynamic,
+            Collider::cuboid(rad, rad),
+            DynamicBodyMarker,
+        ))
+        .id();
+    let joint = RevoluteJointBuilder::new().local_anchor2(Vec2::new(shift, 0.0));
+    commands.entity(child_entity).with_children(|cmd| {
+        // NOTE: we want to attach multiple impulse joints to this entity, so
+        //       we need to add the components to children of the entity. Otherwise
+        //       the second joint component would just overwrite the first one.
+        cmd.spawn(ImpulseJoint::new(parent_entity, joint));
+    });
+}
+
+fn check_positions(q: Query<(&Transform, &GlobalTransform), With<DynamicBodyMarker>>) {
+    for (t, gt) in q.iter() {
+        let gt = gt.compute_transform();
+        dbg!(&gt);
+        dbg!(&t);
+    }
+}


### PR DESCRIPTION
code for investigation on https://github.com/dimforge/bevy_rapier/issues/535.

What I did in this PR:

- reduced the reproduction to 2 rigidbodies (1 fixed, 1 dynamic) + 1 revolute joint
- run the app more slowly (through `app.update()`), code is in comments.
- I noticed that adding the physics setup after the first update resulted in a valid state.
  - it actually results in a valid state **most of the time**, which is characteristic of a system update ambiguity.

My hypotheses:
- rigidbodies are sleeping by default, so they are not moving, I'll test that by waking all entities continuously.
  - to be noted the rigidbodies are propagated the frame after (or probably somewhere in lateupdate)
  - 🔴 waking the rigidbodies continuously doesn't seem to help much.
- an event or component added is not detected. that would be suprising given the diff from #525 but 🤷 (I would be less surprised if that bug arose due to bevy update, which is not the case here.)
  - 🟠   as I can see them in rapierContext.bodies, I think that's not the case, but we shouldn't rule out an inconsistent RapierContext state.
  - 🔍 The investigation for an inconsistant RapierContext state led to realize the `NaN` translation/rotation arrive during the simulation, a call to rapier function. So either it's a bug from rapier, or the state calling of the rapier context is invalid somehow. Either way, debugging this is overwhelming and resolution for that would benefit including a debugging helper (error messages, CI, examples...).
  - 🟢 `delta_time` being `0` is the cause for `NaN` values 🎉 !
- a system order ambiguity seems a good place to look
  - 🟠 my investigation didn't lead to meaningful improvements when fixing system ordering, It might be part of the problem, but definitely not the only cause.

# investigation for inconsistent rapier state

the dynamic body is getting `NaN` translation/rotation after the first simulation run:

- [Serialized RapierContext before simulation](https://gist.github.com/Vrixyz/91c7f0e4da81b9658379e3847a12e886)
- [Diff of RapierContext after simulation](https://gist.github.com/Vrixyz/11db91938aec6e3588c66eda1d8e756a)

🟢 The deltatime of `integration_parameters` being `0` is causing the simulation to return the `NaN` values. If I force set it to `0.0000001` before the first simulation, the behaviour works as expected 🎉 ! 

Now for the proper fix, we have several options:
- do not step if delta time is 0 ? I'm not sure about the implications
- force a minimum deltatime ? This could lead to surprising simulations 👎 
- order the systems to make the first simulation once delta_time is updated. I'm doubtful it's even possible, or that might lead to similar problem if the timescale is 0 ?
- investigate why a delta_time of 0 leads to `NaN` values and fix that. 🔍 Currently investigating.

Opened https://github.com/dimforge/rapier/pull/660 to fix that within rapier.

# investigation on system order ambiguities

Helpful to get a feeling about current ambiguities: https://github.com/Vrixyz/bevy_rapier/pull/21

<details><summary>Current ambiguities reported by bevy detection:</summary>
<p>

```txt
2024-06-20T08:07:28.639475Z  WARN bevy_ecs::schedule::schedule: Schedule PostUpdate has ambiguities.
43 pairs of systems with conflicting data access have indeterminate execution order. Consider adding `before`, `after`, or `ambiguous_with` relationships between these:
 -- add_clusters (in set AddClusters) and camera_system<PerspectiveProjection> (in set CameraUpdateSystem)
    conflict on: ["bevy_render::camera::camera::Camera"]
 -- add_clusters (in set AddClusters) and camera_system<OrthographicProjection> (in set CameraUpdateSystem)
    conflict on: ["bevy_render::camera::camera::Camera"]
 -- add_clusters (in set AddClusters) and camera_system<Projection> (in set CameraUpdateSystem)
    conflict on: ["bevy_render::camera::camera::Camera"]
 -- no_automatic_morph_batching and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- no_automatic_skin_batching and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- compute_slices_on_sprite_change (in set ComputeSlices) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- compute_slices_on_asset_event (in set ComputeSlices) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- check_msaa and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- inherit_weights and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- reset_view_visibility (in set VisibilityPropagate) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- setup_physics and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- visibility_propagate_system (in set VisibilityPropagate) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- insert_deferred_lighting_pass_id_component and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- sync_removals and update_character_controls (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- sync_removals and init_rigid_bodies (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- sync_removals and init_colliders (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- sync_removals and init_joints (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- sync_removals and sync_removals (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext", "bevy_ecs::event::Events<bevy_rapier2d::dynamics::rigid_body::MassModifiedEvent>"]
 -- sync_removals and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- sync_removals and apply_collider_user_changes (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext", "bevy_ecs::event::Events<bevy_rapier2d::dynamics::rigid_body::MassModifiedEvent>"]
 -- sync_removals and apply_rigid_body_user_changes (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext", "bevy_ecs::event::Events<bevy_rapier2d::dynamics::rigid_body::MassModifiedEvent>"]
 -- sync_removals and apply_joint_user_changes (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- sync_removals and apply_initial_rigid_body_impulses (in set SyncBackend)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- sync_removals and step_simulation<()> (in set StepSimulation)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- sync_removals and writeback_rigid_bodies (in set Writeback)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- sync_removals and writeback_mass_properties (in set Writeback)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext", "bevy_ecs::event::Events<bevy_rapier2d::dynamics::rigid_body::MassModifiedEvent>"]
 -- sync_removals and event_update_system<MassModifiedEvent> (in set Writeback)
    conflict on: ["bevy_ecs::event::Events<bevy_rapier2d::dynamics::rigid_body::MassModifiedEvent>"]
 -- sync_removals and debug_render_scene
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
 -- camera_system<PerspectiveProjection> (in set CameraUpdateSystem) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- camera_system<PerspectiveProjection> (in set CameraUpdateSystem) and process_output_system (in set ProcessOutput)
    conflict on: ["bevy_window::window::Window"]
 -- camera_system<OrthographicProjection> (in set CameraUpdateSystem) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- camera_system<OrthographicProjection> (in set CameraUpdateSystem) and process_output_system (in set ProcessOutput)
    conflict on: ["bevy_window::window::Window"]
 -- camera_system<Projection> (in set CameraUpdateSystem) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- camera_system<Projection> (in set CameraUpdateSystem) and process_output_system (in set ProcessOutput)
    conflict on: ["bevy_window::window::Window"]
 -- window_closed (in set Update) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- update_accessibility_nodes (in set Update) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- update_accessibility_nodes (in set Update) and process_output_system (in set ProcessOutput)
    conflict on: ["bevy_window::window::Window"]
 -- poll_receivers (in set Update) and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- exit_on_all_closed and apply_deferred (in set SyncBackend)
    conflict on: bevy_ecs::world::World
 -- exit_on_all_closed and process_output_system (in set ProcessOutput)
    conflict on: ["bevy_window::window::Window"]
 -- apply_deferred (in set SyncBackend) and process_output_system (in set ProcessOutput)
    conflict on: bevy_ecs::world::World
 -- apply_deferred (in set SyncBackend) and update_egui_textures_system
    conflict on: bevy_ecs::world::World
 -- writeback_rigid_bodies (in set Writeback) and writeback_mass_properties (in set Writeback)
    conflict on: ["bevy_rapier2d::plugin::context::RapierContext"]
```

</p>
</details> 