### PR TITLE
Add `TriMeshFlags` to `ComputedColliderShape::TriMesh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added a `TriMeshFlags` parameter for `ComputedColliderShape`,
+its default value is `TriMeshFlags::MERGE_DUPLICATE_VERTICES`,
+which was its hardcoded behaviour.
+
 ## v0.27.0 (07 July 2024)
 
 **This is an update from rapier 0.19 to Rapier 0.21 which includes several stability improvements

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,7 +1,10 @@
 use std::fmt;
 
 #[cfg(all(feature = "dim3", feature = "async-collider"))]
-use {crate::geometry::VHACDParameters, bevy::utils::HashMap};
+use {
+    crate::geometry::{TriMeshFlags, VHACDParameters},
+    bevy::utils::HashMap,
+};
 
 use bevy::prelude::*;
 
@@ -37,7 +40,7 @@ pub struct AsyncSceneCollider {
 impl Default for AsyncSceneCollider {
     fn default() -> Self {
         Self {
-            shape: Some(ComputedColliderShape::TriMesh),
+            shape: Some(Default::default()),
             named_shapes: Default::default(),
         }
     }
@@ -45,15 +48,21 @@ impl Default for AsyncSceneCollider {
 
 /// Shape type based on a Bevy mesh asset.
 #[cfg(all(feature = "dim3", feature = "async-collider"))]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub enum ComputedColliderShape {
     /// Triangle-mesh.
-    #[default]
-    TriMesh,
+    TriMesh(TriMeshFlags),
     /// Convex hull.
     ConvexHull,
     /// Convex decomposition.
     ConvexDecomposition(VHACDParameters),
+}
+
+#[cfg(all(feature = "dim3", feature = "async-collider"))]
+impl Default for ComputedColliderShape {
+    fn default() -> Self {
+        Self::TriMesh(TriMeshFlags::MERGE_DUPLICATE_VERTICES)
+    }
 }
 
 /// A geometric entity that can be attached to a [`RigidBody`] so it can be affected by contacts

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -175,10 +175,9 @@ impl Collider {
         let (vtx, idx) = extract_mesh_vertices_indices(mesh)?;
 
         match collider_shape {
-            ComputedColliderShape::TriMesh => Some(
-                SharedShape::trimesh_with_flags(vtx, idx, TriMeshFlags::MERGE_DUPLICATE_VERTICES)
-                    .into(),
-            ),
+            ComputedColliderShape::TriMesh(flags) => {
+                Some(SharedShape::trimesh_with_flags(vtx, idx, *flags).into())
+            }
             ComputedColliderShape::ConvexHull => {
                 SharedShape::convex_hull(&vtx).map(|shape| shape.into())
             }


### PR DESCRIPTION
This adds `TriMeshFlags` to `ComputedColliderShape::TriMesh` so you don't have to use the `trimesh_with_flags()` method directly (since it takes vertices and indices vs a bevy mesh).