### PR TITLE
 Fix a crash when removing colliders in `TimestepMode::Interpolated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fix
+
+- Fix a crash when using `TimestepMode::Interpolated` and removing colliders
+during a frame which would not run a simulation step.
+
 ### Added
 
 - Added a `TriMeshFlags` parameter for `ComputedColliderShape`,

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -125,7 +125,13 @@ impl<'a> EventHandler for EventQueue<'a> {
 
 #[cfg(test)]
 mod test {
-    use bevy::time::{TimePlugin, TimeUpdateStrategy};
+    use bevy::{
+        app::{App, Startup, Update},
+        prelude::{default, Commands, Component, Entity, Query, With},
+        time::{TimePlugin, TimeUpdateStrategy},
+        transform::{bundles::TransformBundle, components::Transform, TransformPlugin},
+        MinimalPlugins,
+    };
     use systems::tests::HeadlessRenderPlugin;
 
     use crate::{plugin::*, prelude::*};
@@ -229,6 +235,82 @@ mod test {
                 ActiveEvents::COLLISION_EVENTS | ActiveEvents::CONTACT_FORCE_EVENTS,
                 ContactForceEventThreshold(30.0),
             ));
+        }
+    }
+
+    #[test]
+    pub fn spam_remove_rapier_entity_interpolated() {
+        let mut app = App::new();
+        app.add_plugins((
+            HeadlessRenderPlugin,
+            MinimalPlugins,
+            TransformPlugin,
+            RapierPhysicsPlugin::<NoUserData>::default(),
+        ))
+        .insert_resource(RapierConfiguration {
+            timestep_mode: TimestepMode::Interpolated {
+                dt: 1.0 / 600.0,
+                time_scale: 1.0,
+                substeps: 2,
+            },
+            ..RapierConfiguration::new(1f32)
+        })
+        .add_systems(Startup, setup_physics)
+        .add_systems(Update, remove_collider);
+        // Simulates 60 updates per seconds
+        //app.insert_resource(TimeUpdateStrategy::ManualDuration(
+        //    std::time::Duration::from_secs_f32(1f32 / 60f32),
+        //));
+        // First update for setups, + creating default rapier context.
+
+        //app.run();
+        //return;
+
+        for i in 0..100 {
+            dbg!(i);
+            app.update();
+        }
+        return;
+
+        #[derive(Component)]
+        pub struct ToRemove;
+
+        #[cfg(feature = "dim3")]
+        fn cuboid(hx: Real, hy: Real, hz: Real) -> Collider {
+            Collider::cuboid(hx, hy, hz)
+        }
+        #[cfg(feature = "dim2")]
+        fn cuboid(hx: Real, hy: Real, _hz: Real) -> Collider {
+            Collider::cuboid(hx, hy)
+        }
+        pub fn setup_physics(mut commands: Commands) {
+            for i in 0..100 {
+                commands.spawn((
+                    TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
+                    RigidBody::Dynamic,
+                    cuboid(0.5, 0.5, 0.5),
+                    ActiveEvents::all(),
+                    ToRemove,
+                ));
+            }
+            /*
+             * Ground
+             */
+            let ground_size = 5.1;
+            let ground_height = 0.1;
+            let starting_y = -0.5 - ground_height;
+
+            commands.spawn((
+                TransformBundle::from(Transform::from_xyz(0.0, starting_y, 0.0)),
+                cuboid(ground_size, ground_height, ground_size),
+            ));
+        }
+
+        fn remove_collider(mut commands: Commands, query: Query<Entity, With<ToRemove>>) {
+            let Some(entity) = query.iter().next() else {
+                return;
+            };
+            commands.entity(entity).despawn();
         }
     }
 }

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -127,7 +127,7 @@ impl<'a> EventHandler for EventQueue<'a> {
 mod test {
     use bevy::{
         app::{App, Startup, Update},
-        prelude::{default, Commands, Component, Entity, Query, With},
+        prelude::{Commands, Component, Entity, Query, With},
         time::{TimePlugin, TimeUpdateStrategy},
         transform::{bundles::TransformBundle, components::Transform, TransformPlugin},
         MinimalPlugins,

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -249,7 +249,7 @@ mod test {
         ))
         .insert_resource(RapierConfiguration {
             timestep_mode: TimestepMode::Interpolated {
-                dt: 1.0 / 600.0,
+                dt: 1.0 / 30.0,
                 time_scale: 1.0,
                 substeps: 2,
             },
@@ -258,13 +258,9 @@ mod test {
         .add_systems(Startup, setup_physics)
         .add_systems(Update, remove_collider);
         // Simulates 60 updates per seconds
-        //app.insert_resource(TimeUpdateStrategy::ManualDuration(
-        //    std::time::Duration::from_secs_f32(1f32 / 60f32),
-        //));
-        // First update for setups, + creating default rapier context.
-
-        //app.run();
-        //return;
+        app.insert_resource(TimeUpdateStrategy::ManualDuration(
+            std::time::Duration::from_secs_f32(1f32 / 60f32),
+        ));
 
         for i in 0..100 {
             dbg!(i);
@@ -284,7 +280,7 @@ mod test {
             Collider::cuboid(hx, hy)
         }
         pub fn setup_physics(mut commands: Commands) {
-            for i in 0..100 {
+            for _i in 0..100 {
                 commands.spawn((
                     TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
                     RigidBody::Dynamic,

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -333,6 +333,7 @@ impl RapierContext {
                 }
             }
         }
+
         if executed_steps > 0 {
             self.deleted_colliders.clear();
         }

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -225,6 +225,7 @@ impl RapierContext {
             .or_else(|| event_queue.as_ref().map(|q| q as &dyn EventHandler))
             .unwrap_or(&() as &dyn EventHandler);
 
+        let mut executed_steps = 0;
         match timestep_mode {
             TimestepMode::Interpolated {
                 dt,
@@ -271,6 +272,7 @@ impl RapierContext {
                             hooks,
                             events,
                         );
+                        executed_steps += 1;
                     }
 
                     sim_to_render_time.diff -= dt;
@@ -302,6 +304,7 @@ impl RapierContext {
                         hooks,
                         events,
                     );
+                    executed_steps += 1;
                 }
             }
             TimestepMode::Fixed { dt, substeps } => {
@@ -326,8 +329,12 @@ impl RapierContext {
                         hooks,
                         events,
                     );
+                    executed_steps += 1;
                 }
             }
+        }
+        if executed_steps > 0 {
+            self.deleted_colliders.clear();
         }
     }
 

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -50,7 +50,6 @@ pub fn step_simulation<Hooks>(
             &mut sim_to_render_time,
             Some(interpolation_query),
         );
-        context.deleted_colliders.clear();
     } else {
         context.propagate_modified_body_positions_to_colliders();
     }


### PR DESCRIPTION
Fix #285

`context.deleted_colliders`  should only be cleared when we actually execute the physics steps. because with interpolated timestep, some frames can bypass the physics step, So if we clear that list, the events firing next frame won't have access to those through [collider2entity](https://github.com/Vrixyz/bevy_rapier/blob/4d36ae2d174cb8858e36d8041ac4f62ecff8e96c/src/pipeline/events.rs#L70).