### PR TITLE
Add example to output a debugdump

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -64,6 +64,7 @@ approx = "0.5.1"
 glam = { version = "0.27", features = ["approx"] }
 bevy-inspector-egui = "0.25.1"
 bevy_egui = "0.28.0"
+bevy_mod_debugdump = "0.11"
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier2d/examples/debugdump2.rs
+++ b/bevy_rapier2d/examples/debugdump2.rs
@@ -14,7 +14,7 @@ fn main() {
         RapierDebugRenderPlugin::default(),
     ))
     .add_systems(Startup, (setup_graphics, setup_physics))
-    .add_systems(PostUpdate, display_events);
+    .add_systems(PostUpdate, display_events.after(PhysicsSet::StepSimulation));
 
     bevy_mod_debugdump::print_schedule_graph(&mut app, PostUpdate);
 }

--- a/bevy_rapier2d/examples/debugdump2.rs
+++ b/bevy_rapier2d/examples/debugdump2.rs
@@ -27,7 +27,7 @@ fn main() {
                 || system.name().starts_with("bevy_winit")
                 || system.name().starts_with("bevy_sprite")
             {
-                return dbg!(false);
+                return false;
             }
             true
         }));

--- a/bevy_rapier2d/examples/debugdump2.rs
+++ b/bevy_rapier2d/examples/debugdump2.rs
@@ -1,0 +1,61 @@
+use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
+fn main() {
+    let mut app = App::new();
+    app.insert_resource(ClearColor(Color::srgb(
+        0xF9 as f32 / 255.0,
+        0xF9 as f32 / 255.0,
+        0xFF as f32 / 255.0,
+    )))
+    .add_plugins((
+        DefaultPlugins,
+        RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
+        RapierDebugRenderPlugin::default(),
+    ))
+    .add_systems(Startup, (setup_graphics, setup_physics))
+    .add_systems(PostUpdate, display_events);
+
+    bevy_mod_debugdump::print_schedule_graph(&mut app, PostUpdate);
+}
+
+pub fn setup_graphics(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+}
+
+pub fn display_events(
+    mut collision_events: EventReader<CollisionEvent>,
+    mut contact_force_events: EventReader<ContactForceEvent>,
+) {
+    for collision_event in collision_events.read() {
+        println!("Received collision event: {collision_event:?}");
+    }
+
+    for contact_force_event in contact_force_events.read() {
+        println!("Received contact force event: {contact_force_event:?}");
+    }
+}
+
+pub fn setup_physics(mut commands: Commands) {
+    /*
+     * Ground
+     */
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, -24.0, 0.0)),
+        Collider::cuboid(80.0, 20.0),
+    ));
+
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 100.0, 0.0)),
+        Collider::cuboid(80.0, 30.0),
+        Sensor,
+    ));
+
+    commands.spawn((
+        TransformBundle::from(Transform::from_xyz(0.0, 260.0, 0.0)),
+        RigidBody::Dynamic,
+        Collider::cuboid(10.0, 10.0),
+        ActiveEvents::COLLISION_EVENTS,
+        ContactForceEventThreshold(10.0),
+    ));
+}

--- a/bevy_rapier2d/examples/debugdump2.rs
+++ b/bevy_rapier2d/examples/debugdump2.rs
@@ -1,21 +1,18 @@
+//! Example using bevy_mod_debugdump to output a graph of systems execution order.
+//! run with:
+//! `cargo run --example debugdump2 > dump.dot  && dot -Tsvg dump.dot > dump.svg`
+
 use bevy::prelude::*;
 use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
 use bevy_rapier2d::prelude::*;
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(ClearColor(Color::srgb(
-        0xF9 as f32 / 255.0,
-        0xF9 as f32 / 255.0,
-        0xFF as f32 / 255.0,
-    )))
-    .add_plugins((
+    app.add_plugins((
         DefaultPlugins,
         RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
         RapierDebugRenderPlugin::default(),
-    ))
-    .add_systems(Startup, (setup_graphics, setup_physics))
-    .add_systems(PostUpdate, display_events.after(PhysicsSet::StepSimulation));
+    ));
 
     let mut debugdump_settings = schedule_graph::Settings::default();
     // Filter out some less relevant systems.
@@ -33,45 +30,4 @@ fn main() {
         }));
     let dot = schedule_graph_dot(&mut app, PostUpdate, &debugdump_settings);
     println!("{dot}");
-}
-
-pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
-}
-
-pub fn display_events(
-    mut collision_events: EventReader<CollisionEvent>,
-    mut contact_force_events: EventReader<ContactForceEvent>,
-) {
-    for collision_event in collision_events.read() {
-        println!("Received collision event: {collision_event:?}");
-    }
-
-    for contact_force_event in contact_force_events.read() {
-        println!("Received contact force event: {contact_force_event:?}");
-    }
-}
-
-pub fn setup_physics(mut commands: Commands) {
-    /*
-     * Ground
-     */
-    commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -24.0, 0.0)),
-        Collider::cuboid(80.0, 20.0),
-    ));
-
-    commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 100.0, 0.0)),
-        Collider::cuboid(80.0, 30.0),
-        Sensor,
-    ));
-
-    commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 260.0, 0.0)),
-        RigidBody::Dynamic,
-        Collider::cuboid(10.0, 10.0),
-        ActiveEvents::COLLISION_EVENTS,
-        ContactForceEventThreshold(10.0),
-    ));
 }


### PR DESCRIPTION
This kind of example can be useful to both maintainers and users, to help understanding current state of the plugin, how things interact together.

Also there are some system ambiguities which are difficult to reason about in code, this visualization can help with that:

![post_update graph](https://github.com/user-attachments/assets/7225083e-4769-4c7b-b797-1a98e86b69e7)

- similar approach to https://github.com/Jondolf/avian/pull/383