### PR TITLE
Fix benchmark

### DIFF
--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -8,7 +8,20 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+visual = [
+    "bevy/x11",
+    "bevy/tonemapping_luts",
+    "bevy/bevy_asset",
+    "bevy/bevy_scene",
+    "bevy/bevy_core_pipeline",
+    "bevy/bevy_pbr",
+    "bevy/bevy_gizmos",
+    "rapier3d/debug-render",
+    "bevy/bevy_asset",
+]
+
 [dependencies]
-rapier3d = { features = ["profiler"], version = "0.22" }
-bevy_rapier3d = { version = "0.27", path = "../bevy_rapier3d" }
 bevy = { version = "0.14", default-features = false }
+rapier3d = { features = ["profiler"], version = "0.22" }
+bevy_rapier3d = { version = "0.27", path = "../bevy_rapier3d", default-features = false }

--- a/bevy_rapier_benches3d/src/bin/bench.rs
+++ b/bevy_rapier_benches3d/src/bin/bench.rs
@@ -5,7 +5,7 @@ fn pyramid_1_with_height_2() {
 }
 
 fn pyramid_2_with_height_20() {
-    custom_bencher(100, |app| setup_pyramids(app, 3, 20));
+    custom_bencher(100, |app| setup_pyramids(app, 40, 20));
 }
 
 fn main() {

--- a/bevy_rapier_benches3d/src/common.rs
+++ b/bevy_rapier_benches3d/src/common.rs
@@ -1,5 +1,6 @@
 use bevy::{
     app::PluginsState,
+    log::LogPlugin,
     prelude::*,
     render::{
         settings::{RenderCreation, WgpuSettings},
@@ -10,6 +11,7 @@ use bevy::{
 };
 use bevy_rapier3d::prelude::*;
 
+#[cfg(not(feature = "visual"))]
 pub fn default_app() -> App {
     let mut app = App::new();
 
@@ -18,6 +20,7 @@ pub fn default_app() -> App {
         MinimalPlugins,
         AssetPlugin::default(),
         ScenePlugin,
+        LogPlugin::default(),
         RenderPlugin {
             render_creation: RenderCreation::Automatic(WgpuSettings {
                 backends: None,
@@ -35,6 +38,34 @@ pub fn default_app() -> App {
     app.insert_resource(TimeUpdateStrategy::ManualDuration(
         std::time::Duration::from_secs_f32(1f32 / 60f32),
     ));
+    app
+}
+
+#[cfg(feature = "visual")]
+pub fn default_app() -> App {
+    use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
+
+    let mut app = App::new();
+    println!("visual mode!");
+    app.insert_resource(ClearColor(Color::srgb(
+        0xF9 as f32 / 255.0,
+        0xF9 as f32 / 255.0,
+        0xFF as f32 / 255.0,
+    )));
+    app.add_plugins((
+        DefaultPlugins,
+        RapierPhysicsPlugin::<()>::default(),
+        RapierDebugRenderPlugin::default(),
+        FrameTimeDiagnosticsPlugin::default(),
+        LogDiagnosticsPlugin::default(),
+    ));
+    app.add_systems(Startup, |mut commands: Commands| {
+        commands.spawn(Camera3dBundle {
+            transform: Transform::from_xyz(-30.0, 30.0, 100.0)
+                .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+            ..Default::default()
+        });
+    });
     app
 }
 

--- a/bevy_rapier_benches3d/src/lib.rs
+++ b/bevy_rapier_benches3d/src/lib.rs
@@ -14,6 +14,11 @@ use bevy_rapier3d::plugin::RapierContext;
 pub fn custom_bencher(steps: usize, setup: impl Fn(&mut App)) {
     let mut app = default_app();
     setup(&mut app);
+    #[cfg(feature = "visual")]
+    {
+        app.run();
+        return;
+    }
     wait_app_start(&mut app);
 
     let mut timer_total = rapier3d::counters::Timer::new();

--- a/bevy_rapier_benches3d/src/pyramids.rs
+++ b/bevy_rapier_benches3d/src/pyramids.rs
@@ -16,8 +16,10 @@ pub fn create_pyramid(commands: &mut Commands, offset: Vect, stack_height: usize
             // Build the rigid body.
             commands.spawn((
                 RigidBody::Dynamic,
-                Transform::from_translation(Vec3::new(x, y, 0.0) + offset),
-                Collider::cuboid(1.0, 1.0, 1.0),
+                SpatialBundle::from_transform(Transform::from_translation(
+                    Vec3::new(x, y, 0.0) + offset,
+                )),
+                Collider::cuboid(rad, rad, rad),
             ));
         }
     }
@@ -47,6 +49,7 @@ pub fn setup_pyramids(app: &mut App, pyramid_count: usize, stack_height: usize) 
         /*
          * Create the pyramids
          */
+
         for pyramid_index in 0..pyramid_count {
             let bottomy = rad;
             create_pyramid(


### PR DESCRIPTION
- Adding a simple `Transform` wasn't enough to place correctly the cubes, which made the scene having way too many exploding collisions, which was the main source of bad performance detected in https://github.com/dimforge/bevy_rapier/pull/551.

- I also added a feature "visual" to more easily see what the benchmark is doing. it's mostly meant to be used while working on the benchmarks, enabling only 1. We cannot run them sequentially because `bevy_winit` doesn´t support window recreaction.