### PR TITLE
Add custom-debug-render feature

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -37,7 +37,7 @@ debug-render-3d = [
     "rapier2d/debug-render",
     "bevy/bevy_asset",
 ]
-custom-debug-render = ["rapier2d/debug-render"]
+rapier-debug-render = ["rapier2d/debug-render"]
 
 parallel = ["rapier2d/parallel"]
 simd-stable = ["rapier2d/simd-stable"]

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -37,6 +37,8 @@ debug-render-3d = [
     "rapier2d/debug-render",
     "bevy/bevy_asset",
 ]
+custom-debug-render = ["rapier2d/debug-render"]
+
 parallel = ["rapier2d/parallel"]
 simd-stable = ["rapier2d/simd-stable"]
 simd-nightly = ["rapier2d/simd-nightly"]

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -38,7 +38,7 @@ debug-render-3d = [
     "rapier3d/debug-render",
     "bevy/bevy_asset",
 ]
-custom-debug-render = ["rapier3d/debug-render"]
+rapier-debug-render = ["rapier3d/debug-render"]
 
 parallel = ["rapier3d/parallel"]
 simd-stable = ["rapier3d/simd-stable"]

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -38,6 +38,8 @@ debug-render-3d = [
     "rapier3d/debug-render",
     "bevy/bevy_asset",
 ]
+custom-debug-render = ["rapier3d/debug-render"]
+
 parallel = ["rapier3d/parallel"]
 simd-stable = ["rapier3d/simd-stable"]
 simd-nightly = ["rapier3d/simd-nightly"]


### PR DESCRIPTION
Provide features to enable `rapier/debug-render` when implementing custom debug render instead of bevy's