### PR TITLE
Update bevy to 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Update from rapier `0.21` to rapier `0.22`,
   see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
-- update bevy to 0.15
+- Update bevy to 0.15.
 - `RapierContext`, `RapierConfiguration` and `RenderToSimulationTime` are now a `Component` instead of resources.
   - Rapier now supports multiple independent physics worlds, see example `multi_world3` for usage details.
   - Migration guide:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 - Update from rapier `0.21` to rapier `0.22`,
   see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
 - update bevy to 0.15
+- `RapierContext`, `RapierConfiguration` and `RenderToSimulationTime` are now a `Component` instead of resources.
+  - Rapier now supports multiple independent physics worlds, see example `multi_world3` for usage details.
+  - Migration guide:
+    - `ResMut<mut RapierContext>` -> `WriteDefaultRapierContext`
+    - `Res<RapierContext>` -> `ReadDefaultRapierContext`
+    - Access to `RapierConfiguration` and `RenderToSimulationTime` should query for it
+on the responsible entity owning the `RenderContext`.
+  - If you are building a library on top of `bevy_rapier` and would want to support multiple independent physics worlds too,
+you can check out the details of [#545](https://github.com/dimforge/bevy_rapier/pull/545)
+to get more context and information.
+- `colliders_with_aabb_intersecting_aabb` now takes `bevy::math::bounding::Aabb3d` (or `[..]::Aabb2d` in 2D) as parameter.
+  - it is now accessible with `headless` feature enabled.
 
 ### Fix
 
@@ -21,21 +33,6 @@ which was its hardcoded behaviour.
 - Added a way to configure which colliders should be debug rendered: `global` parameter for both 
   `RapierDebugColliderPlugin` and `DebugRenderContext`, as well as individual collider setup via
   a `ColliderDebug` component.
-
-### Modified
-
-- `RapierContext`, `RapierConfiguration` and `RenderToSimulationTime` are now a `Component` instead of resources.
-  - Rapier now supports multiple independent physics worlds, see example `multi_world3` for usage details.
-  - Migration guide:
-    - `ResMut<mut RapierContext>` -> `WriteDefaultRapierContext`
-    - `Res<RapierContext>` -> `ReadDefaultRapierContext`
-    - Access to `RapierConfiguration` and `RenderToSimulationTime` should query for it
-on the responsible entity owning the `RenderContext`.
-  - If you are building a library on top of `bevy_rapier` and would want to support multiple independent physics worlds too,
-you can check out the details of [#545](https://github.com/dimforge/bevy_rapier/pull/545)
-to get more context and information.
-- `colliders_with_aabb_intersecting_aabb` now takes `bevy::math::bounding::Aabb3d` (or `[..]::Aabb2d` in 2D) as parameter.
-  - it is now accessible with `headless` feature enabled.
 
 ## v0.27.0 (07 July 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update from rapier `0.21` to rapier `0.22`,
   see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
+- update bevy to 0.15
 
 ### Fix
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,10 @@ codegen-units = 1
 #parry3d = { path = "../parry/crates/parry3d" }
 #rapier2d = { path = "../rapier/crates/rapier2d" }
 #rapier3d = { path = "../rapier/crates/rapier3d" }
-
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
 #parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #rapier2d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
+bevy_egui = { git = "https://github.com/Vrixyz/bevy_egui", branch = "bevy_main" }
+bevy-inspector-egui = { git = "https://github.com/Vrixyz/bevy-inspector-egui", branch = "bevy_0.15" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,3 @@ codegen-units = 1
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #rapier2d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
-bevy_egui = { git = "https://github.com/Vrixyz/bevy_egui", branch = "bevy_main" }
-bevy-inspector-egui = { git = "https://github.com/Vrixyz/bevy-inspector-egui", branch = "bevy_0.15" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -68,8 +68,7 @@ approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.28.0"
 bevy_egui = "0.31"
-# bevy_mod_debugdump = "0.11"
-bevy_mod_debugdump = { git = "https://github.com/andriyDev/bevy_mod_debugdump.git", branch = "bevy-0.15" }
+bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump.git", branch = "main" }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -65,8 +65,8 @@ bevy = { version = "0.15.0-rc.2", default-features = false, features = [
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
-# bevy-inspector-egui = "0.25.1"
-# bevy_egui = "0.28.0"
+bevy-inspector-egui = "0.28.0"
+bevy_egui = "0.30.0"
 # bevy_mod_debugdump = "0.11"
 bevy_mod_debugdump = { git = "https://github.com/andriyDev/bevy_mod_debugdump.git", branch = "bevy-0.15" }
 

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -49,7 +49,7 @@ headless = []
 async-collider = ["bevy/bevy_asset", "bevy/bevy_scene", "bevy/bevy_render"]
 
 [dependencies]
-bevy = { version = "0.15.0-rc.2", default-features = false }
+bevy = { version = "0.15", default-features = false }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
 rapier2d = "0.22"
 bitflags = "2.4"
@@ -57,16 +57,17 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc.2", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "x11",
     "bevy_state",
+    "bevy_window",
     "bevy_debug_stepping",
 ] }
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.28.0"
-bevy_egui = "0.30.0"
+bevy_egui = "0.31"
 # bevy_mod_debugdump = "0.11"
 bevy_mod_debugdump = { git = "https://github.com/andriyDev/bevy_mod_debugdump.git", branch = "bevy-0.15" }
 

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -68,7 +68,7 @@ approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.28.0"
 bevy_egui = "0.31"
-bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump.git", branch = "main" }
+bevy_mod_debugdump = "0.12"
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -49,25 +49,26 @@ headless = []
 async-collider = ["bevy/bevy_asset", "bevy/bevy_scene", "bevy/bevy_render"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false }
-nalgebra = { version = "0.33", features = ["convert-glam027"] }
+bevy = { version = "0.15.0-rc.2", default-features = false }
+nalgebra = { version = "0.33", features = ["convert-glam029"] }
 rapier2d = "0.22"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15.0-rc.2", default-features = false, features = [
     "x11",
     "bevy_state",
     "bevy_debug_stepping",
 ] }
 oorandom = "11"
 approx = "0.5.1"
-glam = { version = "0.27", features = ["approx"] }
-bevy-inspector-egui = "0.25.1"
-bevy_egui = "0.28.0"
-bevy_mod_debugdump = "0.11"
+glam = { version = "0.29", features = ["approx"] }
+# bevy-inspector-egui = "0.25.1"
+# bevy_egui = "0.28.0"
+# bevy_mod_debugdump = "0.11"
+bevy_mod_debugdump = { git = "https://github.com/andriyDev/bevy_mod_debugdump.git", branch = "bevy-0.15" }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier2d/examples/boxes2.rs
+++ b/bevy_rapier2d/examples/boxes2.rs
@@ -18,10 +18,7 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0.0, 20.0, 0.0),
-        ..default()
-    });
+    commands.spawn((Camera2d::default(), Transform::from_xyz(0.0, 20.0, 0.0)));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -32,7 +29,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 10.0;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 0.0 * -ground_height, 0.0)),
+        Transform::from_xyz(0.0, 0.0 * -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height),
     ));
 
@@ -54,7 +51,7 @@ pub fn setup_physics(mut commands: Commands) {
             let y = j as f32 * shift + centery + 30.0;
 
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                Transform::from_xyz(x, y, 0.0),
                 RigidBody::Dynamic,
                 Collider::cuboid(rad, rad),
             ));

--- a/bevy_rapier2d/examples/contact_filter2.rs
+++ b/bevy_rapier2d/examples/contact_filter2.rs
@@ -45,10 +45,7 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0.0, 20.0, 0.0),
-        ..default()
-    });
+    commands.spawn((Camera2d::default(), Transform::from_xyz(0.0, 20.0, 0.0)));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -58,13 +55,13 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 100.0;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -100.0, 0.0)),
+        Transform::from_xyz(0.0, -100.0, 0.0),
         Collider::cuboid(ground_size, 12.0),
         CustomFilterTag::GroupA,
     ));
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
+        Transform::from_xyz(0.0, 0.0, 0.0),
         Collider::cuboid(ground_size, 12.0),
         CustomFilterTag::GroupB,
     ));
@@ -89,7 +86,7 @@ pub fn setup_physics(mut commands: Commands) {
             group_id += 1;
 
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                Transform::from_xyz(x, y, 0.0),
                 RigidBody::Dynamic,
                 Collider::cuboid(rad, rad),
                 ActiveHooks::FILTER_CONTACT_PAIRS,

--- a/bevy_rapier2d/examples/custom_system_setup2.rs
+++ b/bevy_rapier2d/examples/custom_system_setup2.rs
@@ -61,10 +61,7 @@ fn despawn_one_box(
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0.0, 20.0, 0.0),
-        ..default()
-    });
+    commands.spawn((Camera2d::default(), Transform::from_xyz(0.0, 20.0, 0.0)));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -75,7 +72,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 10.0;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 0.0 * -ground_height, 0.0)),
+        Transform::from_xyz(0.0, 0.0 * -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height),
     ));
 
@@ -97,7 +94,7 @@ pub fn setup_physics(mut commands: Commands) {
             let y = j as f32 * shift + centery + 30.0;
 
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                Transform::from_xyz(x, y, 0.0),
                 RigidBody::Dynamic,
                 Collider::cuboid(rad, rad),
             ));

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -92,7 +92,7 @@ pub fn setup_game(mut commands: Commands, mut game: ResMut<Game>) {
         byte_rgb(255, 0, 0),
     ];
 
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
 
     setup_board(&mut commands, &game);
 
@@ -131,15 +131,12 @@ fn setup_board(commands: &mut Commands, game: &Game) {
 
     // Add floor
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.5, 0.5, 0.5),
-                custom_size: Some(Vec2::new(game.n_lanes as f32 * 30.0, 60.0)),
-                ..Default::default()
-            },
-            transform: Transform::from_xyz(0.0, floor_y - 30.0 * 0.5, 0.0),
+        Sprite {
+            color: Color::srgb(0.5, 0.5, 0.5),
+            custom_size: Some(Vec2::new(game.n_lanes as f32 * 30.0, 60.0)),
             ..Default::default()
         },
+        Transform::from_xyz(0.0, floor_y - 30.0 * 0.5, 0.0),
         RigidBody::Fixed,
         Collider::cuboid(game.n_lanes as f32 * 30.0 / 2.0, 60.0 / 2.0),
     ));
@@ -200,15 +197,12 @@ fn spawn_block(
 
     commands
         .spawn((
-            SpriteBundle {
-                sprite: Sprite {
-                    color: game.cube_colors[kind as usize],
-                    custom_size: Some(Vec2::new(30.0, 30.0)),
-                    ..Default::default()
-                },
-                transform: Transform::from_xyz(x, y, 0.0),
+            Sprite {
+                color: game.cube_colors[kind as usize],
+                custom_size: Some(Vec2::new(30.0, 30.0)),
                 ..Default::default()
             },
+            Transform::from_xyz(x, y, 0.0),
             RigidBody::Dynamic,
             Damping {
                 linear_damping,

--- a/bevy_rapier2d/examples/debug_toggle2.rs
+++ b/bevy_rapier2d/examples/debug_toggle2.rs
@@ -31,11 +31,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-30.0, 30.0, 100.0)
-            .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
+    ));
 }
 
 #[derive(Component)]
@@ -49,7 +48,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height),
     ));
 
@@ -81,12 +80,10 @@ pub fn setup_physics(mut commands: Commands) {
                 color += 1;
 
                 commands
-                    .spawn(TransformBundle::from(Transform::from_rotation(
-                        Quat::from_rotation_x(0.2),
-                    )))
+                    .spawn(Transform::from_rotation(Quat::from_rotation_x(0.2)))
                     .with_children(|child| {
                         child.spawn((
-                            TransformBundle::from(Transform::from_xyz(x, y, z)),
+                            Transform::from_xyz(x, y, z),
                             RigidBody::Dynamic,
                             Collider::cuboid(rad, rad),
                             ColliderDebugColor(colors[color % 3]),

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -43,10 +43,7 @@ pub fn setup_graphics(
     resize.timer = Timer::from_seconds(6.0, TimerMode::Once);
     despawn.timer = Timer::from_seconds(5.0, TimerMode::Once);
 
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0.0, 20.0, 0.0),
-        ..default()
-    });
+    commands.spawn((Camera2d::default(), Transform::from_xyz(0.0, 20.0, 0.0)));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -58,12 +55,12 @@ pub fn setup_physics(mut commands: Commands) {
     commands.spawn((Collider::cuboid(ground_size, 12.0), Despawn));
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(ground_size, ground_size * 2.0, 0.0)),
+        Transform::from_xyz(ground_size, ground_size * 2.0, 0.0),
         Collider::cuboid(12.0, ground_size * 2.0),
     ));
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(-ground_size, ground_size * 2.0, 0.0)),
+        Transform::from_xyz(-ground_size, ground_size * 2.0, 0.0),
         Collider::cuboid(12.0, ground_size * 2.0),
     ));
 
@@ -83,7 +80,7 @@ pub fn setup_physics(mut commands: Commands) {
             let y = j as f32 * shift + centery + 2.0;
 
             let mut entity = commands.spawn((
-                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                Transform::from_xyz(x, y, 0.0),
                 RigidBody::Dynamic,
                 Collider::cuboid(rad, rad),
             ));

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -19,7 +19,7 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
 }
 
 pub fn display_events(
@@ -40,18 +40,18 @@ pub fn setup_physics(mut commands: Commands) {
      * Ground
      */
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -24.0, 0.0)),
+        Transform::from_xyz(0.0, -24.0, 0.0),
         Collider::cuboid(80.0, 20.0),
     ));
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 100.0, 0.0)),
+        Transform::from_xyz(0.0, 100.0, 0.0),
         Collider::cuboid(80.0, 30.0),
         Sensor,
     ));
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 260.0, 0.0)),
+        Transform::from_xyz(0.0, 260.0, 0.0),
         RigidBody::Dynamic,
         Collider::cuboid(10.0, 10.0),
         ActiveEvents::COLLISION_EVENTS,

--- a/bevy_rapier2d/examples/joints2.rs
+++ b/bevy_rapier2d/examples/joints2.rs
@@ -18,10 +18,7 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0.0, -200.0, 0.0),
-        ..default()
-    });
+    commands.spawn((Camera2d::default(), Transform::from_xyz(0.0, -200.0, 0.0)));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -46,7 +43,7 @@ pub fn setup_physics(mut commands: Commands) {
 
             let child_entity = commands
                 .spawn((
-                    TransformBundle::from(Transform::from_xyz(fk * shift, -fi * shift, 0.0)),
+                    Transform::from_xyz(fk * shift, -fi * shift, 0.0),
                     rigid_body,
                     Collider::cuboid(rad, rad),
                 ))

--- a/bevy_rapier2d/examples/joints_despawn2.rs
+++ b/bevy_rapier2d/examples/joints_despawn2.rs
@@ -28,10 +28,7 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0.0, -200.0, 0.0),
-        ..default()
-    });
+    commands.spawn((Camera2d::default(), Transform::from_xyz(0.0, -200.0, 0.0)));
 }
 
 pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource>) {
@@ -58,7 +55,7 @@ pub fn setup_physics(mut commands: Commands, mut despawn: ResMut<DespawnResource
 
             let child_entity = commands
                 .spawn((
-                    TransformBundle::from(Transform::from_xyz(fk * shift, -fi * shift, 0.0)),
+                    Transform::from_xyz(fk * shift, -fi * shift, 0.0),
                     rigid_body,
                     Collider::cuboid(rad, rad),
                 ))

--- a/bevy_rapier2d/examples/locked_rotations2.rs
+++ b/bevy_rapier2d/examples/locked_rotations2.rs
@@ -18,10 +18,7 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0.0, 200.0, 0.0),
-        ..default()
-    });
+    commands.spawn((Camera2d::default(), Transform::from_xyz(0.0, 200.0, 0.0)));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -32,7 +29,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 10.0;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height),
     ));
 
@@ -40,7 +37,7 @@ pub fn setup_physics(mut commands: Commands) {
      * A rectangle that only rotate.
      */
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 300.0, 0.0)),
+        Transform::from_xyz(0.0, 300.0, 0.0),
         RigidBody::Dynamic,
         LockedAxes::TRANSLATION_LOCKED,
         Collider::cuboid(200.0, 60.0),
@@ -50,9 +47,7 @@ pub fn setup_physics(mut commands: Commands) {
      * A tilted cuboid that cannot rotate.
      */
     commands.spawn((
-        TransformBundle::from(
-            Transform::from_xyz(50.0, 500.0, 0.0).with_rotation(Quat::from_rotation_z(1.0)),
-        ),
+        Transform::from_xyz(50.0, 500.0, 0.0).with_rotation(Quat::from_rotation_z(1.0)),
         RigidBody::Dynamic,
         LockedAxes::ROTATION_LOCKED,
         Collider::cuboid(60.0, 40.0),

--- a/bevy_rapier2d/examples/multiple_colliders2.rs
+++ b/bevy_rapier2d/examples/multiple_colliders2.rs
@@ -18,7 +18,7 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -29,7 +29,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 1.0;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height),
     ));
 
@@ -51,18 +51,15 @@ pub fn setup_physics(mut commands: Commands) {
             let y = j as f32 * (shift * 5.0) + centery + 3.0;
 
             commands
-                .spawn((
-                    TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
-                    RigidBody::Dynamic,
-                ))
+                .spawn((Transform::from_xyz(x, y, 0.0), RigidBody::Dynamic))
                 .with_children(|children| {
                     children.spawn(Collider::cuboid(rad * 10.0, rad));
                     children.spawn((
-                        TransformBundle::from(Transform::from_xyz(rad * 10.0, rad * 10.0, 0.0)),
+                        Transform::from_xyz(rad * 10.0, rad * 10.0, 0.0),
                         Collider::cuboid(rad, rad * 10.0),
                     ));
                     children.spawn((
-                        TransformBundle::from(Transform::from_xyz(-rad * 10.0, rad * 10.0, 0.0)),
+                        Transform::from_xyz(-rad * 10.0, rad * 10.0, 0.0),
                         Collider::cuboid(rad, rad * 10.0),
                     ));
                 });

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -28,18 +28,15 @@ pub fn spawn_player(mut commands: Commands, mut rapier_config: Query<&mut Rapier
     let mut rapier_config = rapier_config.single_mut();
     // Set gravity to 0.0 and spawn camera.
     rapier_config.gravity = Vec2::ZERO;
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
 
     let sprite_size = 100.0;
 
     // Spawn entity with `Player` struct as a component for access in movement query.
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.0, 0.0, 0.0),
-                custom_size: Some(Vec2::new(sprite_size, sprite_size)),
-                ..Default::default()
-            },
+        Sprite {
+            color: Color::srgb(0.0, 0.0, 0.0),
+            custom_size: Some(Vec2::new(sprite_size, sprite_size)),
             ..Default::default()
         },
         RigidBody::Dynamic,

--- a/bevy_rapier2d/examples/rope_joint2.rs
+++ b/bevy_rapier2d/examples/rope_joint2.rs
@@ -18,10 +18,7 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera2dBundle {
-        transform: Transform::from_xyz(0.0, -200.0, 0.0),
-        ..default()
-    });
+    commands.spawn((Camera2d::default(), Transform::from_xyz(0.0, -200.0, 0.0)));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -30,7 +27,7 @@ pub fn setup_physics(mut commands: Commands) {
 
     let parent = commands
         .spawn((
-            TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
+            Transform::from_xyz(0.0, 0.0, 0.0),
             RigidBody::Fixed,
             Collider::cuboid(rad, rad),
         ))
@@ -40,7 +37,7 @@ pub fn setup_physics(mut commands: Commands) {
 
     commands
         .spawn((
-            TransformBundle::from(Transform::from_xyz(-rad * 2.0, 0.0, 0.0)),
+            Transform::from_xyz(-rad * 2.0, 0.0, 0.0),
             RigidBody::Dynamic,
             Collider::cuboid(rad, rad),
         ))

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -108,6 +108,7 @@ fn main() {
             )
                 .run_if(in_state(Examples::DebugToggle2)),
         )
+        .add_systems(OnExit(Examples::DebugToggle2), cleanup)
         //
         // rope joint
         .add_systems(

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -13,7 +13,7 @@ mod player_movement2;
 mod rope_joint2;
 
 use bevy::prelude::*;
-use bevy_egui::EguiPlugin;
+use bevy_egui::{egui, EguiContexts, EguiPlugin};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;
 
@@ -224,7 +224,7 @@ fn main() {
         .add_systems(
             Update,
             (
-                //ui_example_system,
+                ui_example_system,
                 change_example.run_if(resource_changed::<ExampleSelected>),
             )
                 .chain(),
@@ -260,7 +260,7 @@ fn change_example(
 ) {
     next_state.set(examples_available.0[example_selected.0].state);
 }
-/*
+
 fn ui_example_system(
     mut contexts: EguiContexts,
     mut current_example: ResMut<ExampleSelected>,
@@ -284,4 +284,3 @@ fn ui_example_system(
         }
     });
 }
-*/

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -13,8 +13,8 @@ mod player_movement2;
 mod rope_joint2;
 
 use bevy::prelude::*;
-// use bevy_egui::{egui, EguiContexts, EguiPlugin};
-//use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;
 
 #[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
@@ -62,10 +62,10 @@ fn main() {
     app.init_resource::<ExamplesRes>()
         .add_plugins((
             DefaultPlugins,
-            //EguiPlugin,
+            EguiPlugin,
             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
             RapierDebugRenderPlugin::default(),
-            //WorldInspectorPlugin::new(),
+            WorldInspectorPlugin::new(),
         ))
         .register_type::<Examples>()
         .register_type::<ExamplesRes>()

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -13,8 +13,8 @@ mod player_movement2;
 mod rope_joint2;
 
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+// use bevy_egui::{egui, EguiContexts, EguiPlugin};
+//use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;
 
 #[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
@@ -62,10 +62,10 @@ fn main() {
     app.init_resource::<ExamplesRes>()
         .add_plugins((
             DefaultPlugins,
-            EguiPlugin,
+            //EguiPlugin,
             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
             RapierDebugRenderPlugin::default(),
-            WorldInspectorPlugin::new(),
+            //WorldInspectorPlugin::new(),
         ))
         .register_type::<Examples>()
         .register_type::<ExamplesRes>()
@@ -224,7 +224,7 @@ fn main() {
         .add_systems(
             Update,
             (
-                ui_example_system,
+                //ui_example_system,
                 change_example.run_if(resource_changed::<ExampleSelected>),
             )
                 .chain(),
@@ -260,7 +260,7 @@ fn change_example(
 ) {
     next_state.set(examples_available.0[example_selected.0].state);
 }
-
+/*
 fn ui_example_system(
     mut contexts: EguiContexts,
     mut current_example: ResMut<ExampleSelected>,
@@ -284,3 +284,4 @@ fn ui_example_system(
         }
     });
 }
+*/

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -13,7 +13,7 @@ mod player_movement2;
 mod rope_joint2;
 
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_egui::EguiPlugin;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;
 

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -50,7 +50,7 @@ headless = []
 async-collider = ["bevy/bevy_asset", "bevy/bevy_scene", "bevy/bevy_render"]
 
 [dependencies]
-bevy = { version = "0.15.0-rc.2", default-features = false }
+bevy = { version = "0.15", default-features = false }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
 rapier3d = "0.22"
 bitflags = "2.4"
@@ -58,7 +58,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc.3", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "x11",
     "tonemapping_luts",
     "bevy_state",
@@ -67,7 +67,7 @@ bevy = { version = "0.15.0-rc.3", default-features = false, features = [
 approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.28"
-bevy_egui = "0.30.0"
+bevy_egui = "0.31"
 divan = "0.1"
 bevy_rapier_benches3d = { version = "0.1", path = "../bevy_rapier_benches3d" }
 

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -50,24 +50,24 @@ headless = []
 async-collider = ["bevy/bevy_asset", "bevy/bevy_scene", "bevy/bevy_render"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false }
-nalgebra = { version = "0.33", features = ["convert-glam027"] }
+bevy = { version = "0.15.0-rc.2", default-features = false }
+nalgebra = { version = "0.33", features = ["convert-glam029"] }
 rapier3d = "0.22"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15.0-rc.2", default-features = false, features = [
     "x11",
     "tonemapping_luts",
     "bevy_state",
     "bevy_debug_stepping",
 ] }
 approx = "0.5.1"
-glam = { version = "0.27", features = ["approx"] }
-bevy-inspector-egui = "0.25.1"
-bevy_egui = "0.28.0"
+glam = { version = "0.29", features = ["approx"] }
+# bevy-inspector-egui = "0.25.1"
+# bevy_egui = "0.28.0"
 divan = "0.1"
 bevy_rapier_benches3d = { version = "0.1", path = "../bevy_rapier_benches3d" }
 

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -59,6 +59,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.15", default-features = false, features = [
+    "bevy_window",
     "x11",
     "tonemapping_luts",
     "bevy_state",

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -58,7 +58,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc.2", default-features = false, features = [
+bevy = { version = "0.15.0-rc.3", default-features = false, features = [
     "x11",
     "tonemapping_luts",
     "bevy_state",
@@ -66,8 +66,8 @@ bevy = { version = "0.15.0-rc.2", default-features = false, features = [
 ] }
 approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
-# bevy-inspector-egui = "0.25.1"
-# bevy_egui = "0.28.0"
+bevy-inspector-egui = "0.28"
+bevy_egui = "0.30.0"
 divan = "0.1"
 bevy_rapier_benches3d = { version = "0.1", path = "../bevy_rapier_benches3d" }
 

--- a/bevy_rapier3d/examples/boxes3.rs
+++ b/bevy_rapier3d/examples/boxes3.rs
@@ -18,11 +18,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-30.0, 30.0, 100.0)
-            .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
+    ));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -33,7 +32,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height, ground_size),
     ));
 
@@ -65,12 +64,10 @@ pub fn setup_physics(mut commands: Commands) {
                 color += 1;
 
                 commands
-                    .spawn(TransformBundle::from(Transform::from_rotation(
-                        Quat::from_rotation_x(0.2),
-                    )))
+                    .spawn(Transform::from_rotation(Quat::from_rotation_x(0.2)))
                     .with_children(|child| {
                         child.spawn((
-                            TransformBundle::from(Transform::from_xyz(x, y, z)),
+                            Transform::from_xyz(x, y, z),
                             RigidBody::Dynamic,
                             Collider::cuboid(rad, rad, rad),
                             ColliderDebugColor(colors[color % 3]),

--- a/bevy_rapier3d/examples/character_controller3.rs
+++ b/bevy_rapier3d/examples/character_controller3.rs
@@ -34,10 +34,8 @@ fn main() {
 pub fn setup_player(mut commands: Commands) {
     commands
         .spawn((
-            SpatialBundle {
-                transform: Transform::from_xyz(0.0, 5.0, 0.0),
-                ..default()
-            },
+            Transform::from_xyz(0.0, 5.0, 0.0),
+            Visibility::default(),
             Collider::round_cylinder(0.9, 0.3, 0.2),
             KinematicCharacterController {
                 custom_mass: Some(5.0),
@@ -60,10 +58,7 @@ pub fn setup_player(mut commands: Commands) {
         ))
         .with_children(|b| {
             // FPS Camera
-            b.spawn(Camera3dBundle {
-                transform: Transform::from_xyz(0.0, 0.2, -0.1),
-                ..Default::default()
-            });
+            b.spawn((Camera3d::default(), Transform::from_xyz(0.0, 0.2, -0.1)));
         });
 }
 
@@ -75,7 +70,7 @@ fn setup_map(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height, ground_size),
     ));
     /*
@@ -87,35 +82,19 @@ fn setup_map(mut commands: Commands) {
         let step = i as f32;
         let collider = Collider::cuboid(1.0, step * stair_step, 1.0);
         commands.spawn((
-            TransformBundle::from(Transform::from_xyz(
-                40.0,
-                step * stair_step,
-                step * 2.0 - 20.0,
-            )),
+            Transform::from_xyz(40.0, step * stair_step, step * 2.0 - 20.0),
             collider.clone(),
         ));
         commands.spawn((
-            TransformBundle::from(Transform::from_xyz(
-                -40.0,
-                step * stair_step,
-                step * -2.0 + 20.0,
-            )),
+            Transform::from_xyz(-40.0, step * stair_step, step * -2.0 + 20.0),
             collider.clone(),
         ));
         commands.spawn((
-            TransformBundle::from(Transform::from_xyz(
-                step * 2.0 - 20.0,
-                step * stair_step,
-                40.0,
-            )),
+            Transform::from_xyz(step * 2.0 - 20.0, step * stair_step, 40.0),
             collider.clone(),
         ));
         commands.spawn((
-            TransformBundle::from(Transform::from_xyz(
-                step * -2.0 + 20.0,
-                step * stair_step,
-                -40.0,
-            )),
+            Transform::from_xyz(step * -2.0 + 20.0, step * stair_step, -40.0),
             collider.clone(),
         ));
     }
@@ -176,7 +155,7 @@ fn player_movement(
     let Ok((transform, mut controller, output)) = player.get_single_mut() else {
         return;
     };
-    let delta_time = time.delta_seconds();
+    let delta_time = time.delta_secs();
     // Retrieve input
     let mut movement = Vec3::new(input.x, 0.0, input.z) * MOVEMENT_SPEED;
     let jump_speed = input.y * JUMP_SPEED;

--- a/bevy_rapier3d/examples/contact_filter3.rs
+++ b/bevy_rapier3d/examples/contact_filter3.rs
@@ -45,11 +45,10 @@ fn main() {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-30.0, 30.0, 100.0)
-            .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
+    ));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -59,13 +58,13 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_size = 10.0;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -10.0, 0.0)),
+        Transform::from_xyz(0.0, -10.0, 0.0),
         Collider::cuboid(ground_size, 1.2, ground_size),
         CustomFilterTag::GroupA,
     ));
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
+        Transform::from_xyz(0.0, 0.0, 0.0),
         Collider::cuboid(ground_size, 1.2, ground_size),
         CustomFilterTag::GroupB,
     ));
@@ -90,7 +89,7 @@ pub fn setup_physics(mut commands: Commands) {
             group_id += 1;
 
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(x, y, 0.0)),
+                Transform::from_xyz(x, y, 0.0),
                 RigidBody::Dynamic,
                 Collider::cuboid(rad, rad, rad),
                 ActiveHooks::FILTER_CONTACT_PAIRS,

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -61,11 +61,10 @@ fn despawn_one_box(
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-30.0, 30.0, 100.0)
-            .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
+    ));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -76,7 +75,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height, ground_size),
     ));
 
@@ -108,7 +107,7 @@ pub fn setup_physics(mut commands: Commands) {
                 color += 1;
 
                 commands.spawn((
-                    TransformBundle::from(Transform::from_xyz(x, y, z)),
+                    Transform::from_xyz(x, y, z),
                     RigidBody::Dynamic,
                     Collider::cuboid(rad, rad, rad),
                     ColliderDebugColor(colors[color % 3]),

--- a/bevy_rapier3d/examples/debug_toggle3.rs
+++ b/bevy_rapier3d/examples/debug_toggle3.rs
@@ -31,11 +31,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-30.0, 30.0, 100.0)
-            .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
+    ));
 }
 
 #[derive(Component)]
@@ -49,7 +48,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height, ground_size),
     ));
 
@@ -81,12 +80,10 @@ pub fn setup_physics(mut commands: Commands) {
                 color += 1;
 
                 commands
-                    .spawn(TransformBundle::from(Transform::from_rotation(
-                        Quat::from_rotation_x(0.2),
-                    )))
+                    .spawn(Transform::from_rotation(Quat::from_rotation_x(0.2)))
                     .with_children(|child| {
                         child.spawn((
-                            TransformBundle::from(Transform::from_xyz(x, y, z)),
+                            Transform::from_xyz(x, y, z),
                             RigidBody::Dynamic,
                             Collider::cuboid(rad, rad, rad),
                             ColliderDebugColor(colors[color % 3]),

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -30,11 +30,10 @@ fn main() {
 pub fn setup_graphics(mut commands: Commands, mut res: ResMut<DespawnResource>) {
     res.timer = Timer::from_seconds(5.0, TimerMode::Once);
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-30.0, 30.0, 100.0)
-            .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
+    ));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -45,7 +44,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height, ground_size),
         Despawn,
     ));
@@ -78,7 +77,7 @@ pub fn setup_physics(mut commands: Commands) {
                 color += 1;
 
                 commands.spawn((
-                    TransformBundle::from(Transform::from_xyz(x, y, z)),
+                    Transform::from_xyz(x, y, z),
                     RigidBody::Dynamic,
                     Collider::cuboid(rad, rad, rad),
                     ColliderDebugColor(colors[color % 3]),

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -19,10 +19,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 25.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 0.0, 25.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }
 
 pub fn display_events(
@@ -43,18 +43,18 @@ pub fn setup_physics(mut commands: Commands) {
      * Ground
      */
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -1.2, 0.0)),
+        Transform::from_xyz(0.0, -1.2, 0.0),
         Collider::cuboid(4.0, 1.0, 1.0),
     ));
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)),
+        Transform::from_xyz(0.0, 5.0, 0.0),
         Collider::cuboid(4.0, 1.5, 1.0),
         Sensor,
     ));
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 13.0, 0.0)),
+        Transform::from_xyz(0.0, 13.0, 0.0),
         RigidBody::Dynamic,
         Collider::cuboid(0.5, 0.5, 0.5),
         ActiveEvents::COLLISION_EVENTS,

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -25,11 +25,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(15.0, 5.0, 42.0)
-            .looking_at(Vec3::new(13.0, 1.0, 1.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(15.0, 5.0, 42.0).looking_at(Vec3::new(13.0, 1.0, 1.0), Vec3::Y),
+    ));
 }
 
 fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
@@ -38,7 +37,7 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
 
     let mut curr_parent = commands
         .spawn((
-            TransformBundle::from(Transform::from_xyz(origin.x, origin.y, origin.z)),
+            Transform::from_xyz(origin.x, origin.y, origin.z),
             RigidBody::Fixed,
             Collider::cuboid(rad, rad, rad),
         ))
@@ -60,7 +59,7 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
 
         curr_parent = commands
             .spawn((
-                TransformBundle::from(Transform::from_xyz(origin.x, origin.y, origin.z + dz)),
+                Transform::from_xyz(origin.x, origin.y, origin.z + dz),
                 RigidBody::Dynamic,
                 Collider::cuboid(rad, rad, rad),
                 joint,
@@ -75,7 +74,7 @@ fn create_rope_joints(commands: &mut Commands, origin: Vect, num: usize) {
 
     let mut curr_parent = commands
         .spawn((
-            TransformBundle::from(Transform::from_xyz(origin.x, origin.y, origin.z)),
+            Transform::from_xyz(origin.x, origin.y, origin.z),
             RigidBody::Fixed,
             Collider::cuboid(rad, rad, rad),
         ))
@@ -89,7 +88,7 @@ fn create_rope_joints(commands: &mut Commands, origin: Vect, num: usize) {
 
         curr_parent = commands
             .spawn((
-                TransformBundle::from(Transform::from_xyz(origin.x, origin.y, origin.z + dz)),
+                Transform::from_xyz(origin.x, origin.y, origin.z + dz),
                 RigidBody::Dynamic,
                 Collider::cuboid(rad, rad, rad),
                 joint,
@@ -104,7 +103,7 @@ fn create_revolute_joints(commands: &mut Commands, origin: Vec3, num: usize) {
 
     let mut curr_parent = commands
         .spawn((
-            TransformBundle::from(Transform::from_xyz(origin.x, origin.y, 0.0)),
+            Transform::from_xyz(origin.x, origin.y, 0.0),
             RigidBody::Fixed,
             Collider::cuboid(rad, rad, rad),
         ))
@@ -124,7 +123,7 @@ fn create_revolute_joints(commands: &mut Commands, origin: Vec3, num: usize) {
         for k in 0..4 {
             handles[k] = commands
                 .spawn((
-                    TransformBundle::from(Transform::from_translation(positions[k])),
+                    Transform::from_translation(positions[k]),
                     RigidBody::Dynamic,
                     Collider::cuboid(rad, rad, rad),
                 ))
@@ -180,11 +179,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Vec3, num: usize) {
 
             let child_entity = commands
                 .spawn((
-                    TransformBundle::from(Transform::from_xyz(
-                        origin.x + fk * shift,
-                        origin.y,
-                        origin.z + fi * shift,
-                    )),
+                    Transform::from_xyz(origin.x + fk * shift, origin.y, origin.z + fi * shift),
                     rigid_body,
                     Collider::ball(rad),
                 ))
@@ -239,7 +234,7 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
 
             let child_entity = commands
                 .spawn((
-                    TransformBundle::from(Transform::from_xyz(fk * shift, 0.0, fi * shift)),
+                    Transform::from_xyz(fk * shift, 0.0, fi * shift),
                     rigid_body,
                     Collider::ball(rad),
                 ))

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -30,11 +30,10 @@ fn main() {
 pub fn setup_graphics(mut commands: Commands, mut res: ResMut<DespawnResource>) {
     res.timer = Timer::from_seconds(5.0, TimerMode::Once);
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(15.0, 5.0, 42.0)
-            .looking_at(Vec3::new(13.0, 1.0, 1.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(15.0, 5.0, 42.0).looking_at(Vec3::new(13.0, 1.0, 1.0), Vec3::Y),
+    ));
 }
 
 fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
@@ -43,7 +42,7 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
 
     let mut curr_parent = commands
         .spawn((
-            TransformBundle::from(Transform::from_xyz(origin.x, origin.y, origin.z)),
+            Transform::from_xyz(origin.x, origin.y, origin.z),
             RigidBody::Fixed,
             Collider::cuboid(rad, rad, rad),
         ))
@@ -64,7 +63,7 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
         let joint = ImpulseJoint::new(curr_parent, prism);
 
         let mut entity = commands.spawn((
-            TransformBundle::from(Transform::from_xyz(origin.x, origin.y, origin.z + dz)),
+            Transform::from_xyz(origin.x, origin.y, origin.z + dz),
             RigidBody::Dynamic,
             Collider::cuboid(rad, rad, rad),
             joint,
@@ -84,7 +83,7 @@ fn create_revolute_joints(commands: &mut Commands, origin: Vec3, num: usize) {
 
     let mut curr_parent = commands
         .spawn((
-            TransformBundle::from(Transform::from_xyz(origin.x, origin.y, 0.0)),
+            Transform::from_xyz(origin.x, origin.y, 0.0),
             RigidBody::Fixed,
             Collider::cuboid(rad, rad, rad),
         ))
@@ -104,7 +103,7 @@ fn create_revolute_joints(commands: &mut Commands, origin: Vec3, num: usize) {
         for k in 0..4 {
             handles[k] = commands
                 .spawn((
-                    TransformBundle::from(Transform::from_translation(positions[k])),
+                    Transform::from_translation(positions[k]),
                     RigidBody::Dynamic,
                     Collider::cuboid(rad, rad, rad),
                 ))
@@ -167,11 +166,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Vec3, num: usize) {
 
             let child_entity = commands
                 .spawn((
-                    TransformBundle::from(Transform::from_xyz(
-                        origin.x + fk * shift,
-                        origin.y,
-                        origin.z + fi * shift,
-                    )),
+                    Transform::from_xyz(origin.x + fk * shift, origin.y, origin.z + fi * shift),
                     rigid_body,
                     Collider::ball(rad),
                 ))
@@ -226,7 +221,7 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
 
             let child_entity = commands
                 .spawn((
-                    TransformBundle::from(Transform::from_xyz(fk * shift, 0.0, fi * shift)),
+                    Transform::from_xyz(fk * shift, 0.0, fi * shift),
                     rigid_body,
                     Collider::ball(rad),
                 ))

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -18,11 +18,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(10.0, 3.0, 0.0)
-            .looking_at(Vec3::new(0.0, 3.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(10.0, 3.0, 0.0).looking_at(Vec3::new(0.0, 3.0, 0.0), Vec3::Y),
+    ));
 }
 
 pub fn setup_physics(mut commands: Commands) {

--- a/bevy_rapier3d/examples/locked_rotations3.rs
+++ b/bevy_rapier3d/examples/locked_rotations3.rs
@@ -32,7 +32,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height, ground_size),
     ));
 
@@ -40,7 +40,7 @@ pub fn setup_physics(mut commands: Commands) {
      * A rectangle that only rotates along the `x` axis.
      */
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, 3.0, 0.0)),
+        Transform::from_xyz(0.0, 3.0, 0.0),
         RigidBody::Dynamic,
         LockedAxes::TRANSLATION_LOCKED
             | LockedAxes::ROTATION_LOCKED_Y
@@ -52,9 +52,7 @@ pub fn setup_physics(mut commands: Commands) {
      * A tilted cuboid that cannot rotate.
      */
     commands.spawn((
-        TransformBundle::from(
-            Transform::from_xyz(0.0, 5.0, 0.0).with_rotation(Quat::from_rotation_x(1.0)),
-        ),
+        Transform::from_xyz(0.0, 5.0, 0.0).with_rotation(Quat::from_rotation_x(1.0)),
         RigidBody::Dynamic,
         LockedAxes::ROTATION_LOCKED,
         Collider::cuboid(0.6, 0.4, 0.4),

--- a/bevy_rapier3d/examples/multi_world3.rs
+++ b/bevy_rapier3d/examples/multi_world3.rs
@@ -38,11 +38,10 @@ fn create_worlds(mut commands: Commands) {
 }
 
 fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 3.0, -10.0)
-            .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 3.0, -10.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+    ));
 }
 
 #[derive(Component)]
@@ -55,7 +54,7 @@ struct Platform {
 
 fn move_platforms(time: Res<Time>, mut query: Query<(&mut Transform, &Platform)>) {
     for (mut transform, platform) in query.iter_mut() {
-        transform.translation.y = platform.starting_y + -time.elapsed_seconds().sin();
+        transform.translation.y = platform.starting_y + -time.elapsed_secs().sin();
     }
 }
 
@@ -96,7 +95,7 @@ pub fn setup_physics(
         let starting_y = (id as f32) * -0.5 - ground_height;
 
         let mut platforms = commands.spawn((
-            TransformBundle::from(Transform::from_xyz(0.0, starting_y, 0.0)),
+            Transform::from_xyz(0.0, starting_y, 0.0),
             Collider::cuboid(ground_size, ground_height, ground_size),
             ColliderDebugColor(color),
             RapierContextEntityLink(context_entity),
@@ -110,7 +109,7 @@ pub fn setup_physics(
          */
 
         commands.spawn((
-            TransformBundle::from(Transform::from_xyz(0.0, 1.0 + id as f32 * 5.0, 0.0)),
+            Transform::from_xyz(0.0, 1.0 + id as f32 * 5.0, 0.0),
             RigidBody::Dynamic,
             Collider::cuboid(0.5, 0.5, 0.5),
             ColliderDebugColor(color),

--- a/bevy_rapier3d/examples/multiple_colliders3.rs
+++ b/bevy_rapier3d/examples/multiple_colliders3.rs
@@ -18,11 +18,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-30.0, 30.0, 100.0)
-            .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
+    ));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -33,7 +32,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height, ground_size),
     ));
 
@@ -66,26 +65,19 @@ pub fn setup_physics(mut commands: Commands) {
 
                 // Crate a rigid-body with multiple colliders attached, using Bevy hierarchy.
                 commands
-                    .spawn((
-                        TransformBundle::from(Transform::from_xyz(x, y, z)),
-                        RigidBody::Dynamic,
-                    ))
+                    .spawn((Transform::from_xyz(x, y, z), RigidBody::Dynamic))
                     .with_children(|children| {
                         children.spawn((
                             Collider::cuboid(rad * 10.0, rad, rad),
                             ColliderDebugColor(colors[color % 3]),
                         ));
                         children.spawn((
-                            TransformBundle::from(Transform::from_xyz(rad * 10.0, rad * 10.0, 0.0)),
+                            Transform::from_xyz(rad * 10.0, rad * 10.0, 0.0),
                             Collider::cuboid(rad, rad * 10.0, rad),
                             ColliderDebugColor(colors[color % 3]),
                         ));
                         children.spawn((
-                            TransformBundle::from(Transform::from_xyz(
-                                -rad * 10.0,
-                                rad * 10.0,
-                                0.0,
-                            )),
+                            Transform::from_xyz(-rad * 10.0, rad * 10.0, 0.0),
                             Collider::cuboid(rad, rad * 10.0, rad),
                             ColliderDebugColor(colors[color % 3]),
                         ));

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -21,11 +21,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-30.0, 30.0, 100.0)
-            .looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-30.0, 30.0, 100.0).looking_at(Vec3::new(0.0, 10.0, 0.0), Vec3::Y),
+    ));
 }
 
 pub fn setup_physics(mut commands: Commands) {
@@ -36,7 +35,7 @@ pub fn setup_physics(mut commands: Commands) {
     let ground_height = 0.1;
 
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(0.0, -ground_height, 0.0)),
+        Transform::from_xyz(0.0, -ground_height, 0.0),
         Collider::cuboid(ground_size, ground_height, ground_size),
     ));
 
@@ -62,7 +61,7 @@ pub fn setup_physics(mut commands: Commands) {
 
                 // Build the rigid body.
                 commands.spawn((
-                    TransformBundle::from(Transform::from_xyz(x, y, z)),
+                    Transform::from_xyz(x, y, z),
                     RigidBody::Dynamic,
                     Collider::cuboid(rad, rad, rad),
                 ));
@@ -88,7 +87,10 @@ pub fn cast_ray(
     // We will color in read the colliders hovered by the mouse.
     for (camera, camera_transform) in &cameras {
         // First, compute a ray from the mouse position.
-        let Some(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
+        let Some(ray) = camera
+            .viewport_to_world(camera_transform, cursor_position)
+            .ok()
+        else {
             return;
         };
 

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -87,10 +87,7 @@ pub fn cast_ray(
     // We will color in read the colliders hovered by the mouse.
     for (camera, camera_transform) in &cameras {
         // First, compute a ray from the mouse position.
-        let Some(ray) = camera
-            .viewport_to_world(camera_transform, cursor_position)
-            .ok()
-        else {
+        let Ok(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
             return;
         };
 

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -22,11 +22,10 @@ fn main() {
 }
 
 pub fn setup_graphics(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-15.0, 8.0, 15.0)
-            .looking_at(Vec3::new(-5.0, 0.0, 5.0), Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-15.0, 8.0, 15.0).looking_at(Vec3::new(-5.0, 0.0, 5.0), Vec3::Y),
+    ));
 }
 
 fn ramp_size() -> Vec3 {
@@ -93,11 +92,11 @@ pub fn setup_physics(mut commands: Commands, mut ball_state: ResMut<BallState>) 
     // Position so ramp connects smoothly
     // to one edge of the lip of the bowl.
     commands.spawn((
-        TransformBundle::from(Transform::from_xyz(
+        Transform::from_xyz(
             -bowl_size.x / 2.0,
             -bowl_size.y / 2.0,
             bowl_size.z / 2.0 - ramp_size.z / 2.0,
-        )),
+        ),
         Collider::trimesh(vertices, indices),
     ));
 }
@@ -130,11 +129,7 @@ pub fn ball_spawner(mut commands: Commands, time: Res<Time>, mut ball_state: Res
         let rad = 0.3;
 
         commands.spawn((
-            TransformBundle::from(Transform::from_xyz(
-                ramp_size.x * 0.9,
-                ramp_size.y / 2.0 + rad * 3.0,
-                0.0,
-            )),
+            Transform::from_xyz(ramp_size.x * 0.9, ramp_size.y / 2.0 + rad * 3.0, 0.0),
             RigidBody::Dynamic,
             Collider::ball(rad),
             Restitution::new(0.5),

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -12,7 +12,7 @@ mod ray_casting3;
 mod static_trimesh3;
 
 use bevy::prelude::*;
-use bevy_egui::EguiPlugin;
+use bevy_egui::{egui, EguiContexts, EguiPlugin};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
 
@@ -209,7 +209,7 @@ fn main() {
         .add_systems(
             Update,
             (
-                //ui_example_system,
+                ui_example_system,
                 change_example.run_if(resource_changed::<ExampleSelected>),
             )
                 .chain(),
@@ -245,7 +245,7 @@ fn change_example(
 ) {
     next_state.set(examples_available.0[example_selected.0].state);
 }
-/*
+
 fn ui_example_system(
     mut contexts: EguiContexts,
     mut current_example: ResMut<ExampleSelected>,
@@ -269,4 +269,3 @@ fn ui_example_system(
         }
     });
 }
-  */

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -12,7 +12,7 @@ mod ray_casting3;
 mod static_trimesh3;
 
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_egui::EguiPlugin;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
 

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -106,6 +106,7 @@ fn main() {
             )
                 .run_if(in_state(Examples::DebugToggle3)),
         )
+        .add_systems(OnExit(Examples::DebugToggle3), cleanup)
         //
         // despawn
         .init_resource::<despawn3::DespawnResource>()

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -12,8 +12,8 @@ mod ray_casting3;
 mod static_trimesh3;
 
 use bevy::prelude::*;
-// use bevy_egui::{egui, EguiContexts, EguiPlugin};
-// use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
 
 #[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
@@ -60,10 +60,10 @@ fn main() {
     app.init_resource::<ExamplesRes>()
         .add_plugins((
             DefaultPlugins,
-            //EguiPlugin,
+            EguiPlugin,
             RapierPhysicsPlugin::<NoUserData>::default(),
             RapierDebugRenderPlugin::default(),
-            //WorldInspectorPlugin::new(),
+            WorldInspectorPlugin::new(),
         ))
         .register_type::<Examples>()
         .register_type::<ExamplesRes>()

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -12,8 +12,8 @@ mod ray_casting3;
 mod static_trimesh3;
 
 use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+// use bevy_egui::{egui, EguiContexts, EguiPlugin};
+// use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
 
 #[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
@@ -60,10 +60,10 @@ fn main() {
     app.init_resource::<ExamplesRes>()
         .add_plugins((
             DefaultPlugins,
-            EguiPlugin,
+            //EguiPlugin,
             RapierPhysicsPlugin::<NoUserData>::default(),
             RapierDebugRenderPlugin::default(),
-            WorldInspectorPlugin::new(),
+            //WorldInspectorPlugin::new(),
         ))
         .register_type::<Examples>()
         .register_type::<ExamplesRes>()
@@ -209,7 +209,7 @@ fn main() {
         .add_systems(
             Update,
             (
-                ui_example_system,
+                //ui_example_system,
                 change_example.run_if(resource_changed::<ExampleSelected>),
             )
                 .chain(),
@@ -245,7 +245,7 @@ fn change_example(
 ) {
     next_state.set(examples_available.0[example_selected.0].state);
 }
-
+/*
 fn ui_example_system(
     mut contexts: EguiContexts,
     mut current_example: ResMut<ExampleSelected>,
@@ -269,3 +269,4 @@ fn ui_example_system(
         }
     });
 }
+  */

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2021"
 [dependencies]
 rapier3d = { features = ["profiler"], version = "0.22" }
 bevy_rapier3d = { version = "0.27", path = "../bevy_rapier3d" }
-bevy = { version = "0.14", default-features = false }
+bevy = { version = "0.15.0-rc.2", default-features = false }

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2021"
 [dependencies]
 rapier3d = { features = ["profiler"], version = "0.22" }
 bevy_rapier3d = { version = "0.27", path = "../bevy_rapier3d" }
-bevy = { version = "0.15.0-rc.2", default-features = false }
+bevy = { version = "0.15", default-features = false }

--- a/bevy_rapier_benches3d/src/common.rs
+++ b/bevy_rapier_benches3d/src/common.rs
@@ -1,31 +1,11 @@
-use bevy::{
-    app::PluginsState,
-    prelude::*,
-    render::{
-        settings::{RenderCreation, WgpuSettings},
-        RenderPlugin,
-    },
-    scene::ScenePlugin,
-    time::TimeUpdateStrategy,
-};
+use bevy::{app::PluginsState, prelude::*, time::TimeUpdateStrategy};
 use bevy_rapier3d::prelude::*;
 
 pub fn default_app() -> App {
     let mut app = App::new();
 
     app.add_plugins((
-        WindowPlugin::default(),
         MinimalPlugins,
-        AssetPlugin::default(),
-        ScenePlugin,
-        RenderPlugin {
-            render_creation: RenderCreation::Automatic(WgpuSettings {
-                backends: None,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        ImagePlugin::default(),
         HierarchyPlugin,
         TransformPlugin,
         RapierPhysicsPlugin::<()>::default(),

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,8 @@
 [advisories]
 yanked = "deny"
+ignore = [
+    { id = "RUSTSEC-2024-0384", reason = "this is about instant crate, which is only used for benchmarks + an upstream fix is in the works." },
+]
 
 [licenses]
 allow = [

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -271,7 +271,8 @@ mod test {
         }
         pub fn setup_physics(mut commands: Commands) {
             for _i in 0..100 {
-                commands.spawn((Transform::from_xyz(0.0, 0.0, 0.0),
+                commands.spawn((
+                    Transform::from_xyz(0.0, 0.0, 0.0),
                     RigidBody::Dynamic,
                     cuboid(0.5, 0.5, 0.5),
                     ActiveEvents::all(),
@@ -285,7 +286,8 @@ mod test {
             let ground_height = 0.1;
             let starting_y = -0.5 - ground_height;
 
-            commands.spawn((Transform::from_xyz(0.0, starting_y, 0.0),
+            commands.spawn((
+                Transform::from_xyz(0.0, starting_y, 0.0),
                 cuboid(ground_size, ground_height, ground_size),
             ));
         }

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -129,7 +129,7 @@ mod test {
         app::{App, Startup, Update},
         prelude::{Commands, Component, Entity, Query, With},
         time::{TimePlugin, TimeUpdateStrategy},
-        transform::{bundles::TransformBundle, components::Transform, TransformPlugin},
+        transform::{components::Transform, TransformPlugin},
         MinimalPlugins,
     };
     use systems::tests::HeadlessRenderPlugin;
@@ -214,19 +214,16 @@ mod test {
             /*
              * Ground
              */
-            commands.spawn((
-                TransformBundle::from(Transform::from_xyz(0.0, -1.2, 0.0)),
-                cuboid(4.0, 1.0, 1.0),
-            ));
+            commands.spawn((Transform::from_xyz(0.0, -1.2, 0.0), cuboid(4.0, 1.0, 1.0)));
 
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)),
+                Transform::from_xyz(0.0, 5.0, 0.0),
                 cuboid(4.0, 1.5, 1.0),
                 Sensor,
             ));
 
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(0.0, 13.0, 0.0)),
+                Transform::from_xyz(0.0, 13.0, 0.0),
                 RigidBody::Dynamic,
                 cuboid(0.5, 0.5, 0.5),
                 ActiveEvents::COLLISION_EVENTS,
@@ -274,8 +271,7 @@ mod test {
         }
         pub fn setup_physics(mut commands: Commands) {
             for _i in 0..100 {
-                commands.spawn((
-                    TransformBundle::from(Transform::from_xyz(0.0, 0.0, 0.0)),
+                commands.spawn((Transform::from_xyz(0.0, 0.0, 0.0),
                     RigidBody::Dynamic,
                     cuboid(0.5, 0.5, 0.5),
                     ActiveEvents::all(),
@@ -289,8 +285,7 @@ mod test {
             let ground_height = 0.1;
             let starting_y = -0.5 - ground_height;
 
-            commands.spawn((
-                TransformBundle::from(Transform::from_xyz(0.0, starting_y, 0.0)),
+            commands.spawn((Transform::from_xyz(0.0, starting_y, 0.0),
                 cuboid(ground_size, ground_height, ground_size),
             ));
         }

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -266,7 +266,7 @@ impl RapierContext {
             } => {
                 self.integration_parameters.dt = dt;
 
-                sim_to_render_time.diff += time.delta_seconds();
+                sim_to_render_time.diff += time.delta_secs();
 
                 while sim_to_render_time.diff > 0.0 {
                     // NOTE: in this comparison we do the same computations we
@@ -315,7 +315,7 @@ impl RapierContext {
                 time_scale,
                 substeps,
             } => {
-                self.integration_parameters.dt = (time.delta_seconds() * time_scale).min(max_dt);
+                self.integration_parameters.dt = (time.delta_secs() * time_scale).min(max_dt);
 
                 let mut substep_integration_parameters = self.integration_parameters;
                 substep_integration_parameters.dt /= substeps as Real;

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -109,7 +109,7 @@ where
                     .in_set(RapierTransformPropagateSet),
                 (
                     systems::on_add_entity_with_parent,
-                    systems::on_change_world,
+                    systems::on_change_context,
                     systems::sync_removals,
                     #[cfg(all(feature = "dim3", feature = "async-collider"))]
                     systems::init_async_scene_colliders,
@@ -249,7 +249,12 @@ where
 
         // These *must* be in the main schedule currently so that they do not miss events.
         // See test `test_sync_removal` for an example of this.
-        app.add_systems(PostUpdate, (systems::sync_removals,));
+        if self.schedule != PostUpdate.intern() {
+            app.add_systems(
+                PostUpdate,
+                (systems::sync_removals,).before(TransformSystem::TransformPropagate),
+            );
+        }
 
         // Add each set as necessary
         if self.default_system_setup {
@@ -407,7 +412,7 @@ mod test {
                 .enable()
                 .set_breakpoint(PostUpdate, systems::on_add_entity_with_parent)
                 .set_breakpoint(PostUpdate, systems::init_rigid_bodies)
-                .set_breakpoint(PostUpdate, systems::on_change_world)
+                .set_breakpoint(PostUpdate, systems::on_change_context)
                 .set_breakpoint(PostUpdate, systems::sync_removals)
                 .set_breakpoint(Update, setup_physics);
 

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -495,7 +495,7 @@ mod test {
             }
 
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(0.0, 13.0, 0.0)),
+                Transform::from_xyz(0.0, 13.0, 0.0),
                 RigidBody::Dynamic,
                 cuboid(0.5, 0.5, 0.5),
                 TestMarker,

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -567,7 +567,7 @@ mod test {
 
         pub fn setup_physics(mut commands: Commands) {
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(0.0, 13.0, 0.0)),
+                Transform::from_xyz(0.0, 13.0, 0.0),
                 RigidBody::Dynamic,
                 cuboid(0.5, 0.5, 0.5),
                 TestMarker,

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -488,7 +488,7 @@ pub fn init_colliders(
 pub fn init_async_colliders(
     mut commands: Commands,
     meshes: Res<Assets<Mesh>>,
-    async_colliders: Query<(Entity, &Handle<Mesh>, &AsyncCollider)>,
+    async_colliders: Query<(Entity, &Mesh3d, &AsyncCollider)>,
 ) {
     for (entity, mesh_handle, async_collider) in async_colliders.iter() {
         if let Some(mesh) = meshes.get(mesh_handle) {
@@ -514,7 +514,7 @@ pub fn init_async_scene_colliders(
     scene_spawner: Res<SceneSpawner>,
     async_colliders: Query<(Entity, &SceneInstance, &AsyncSceneCollider)>,
     children: Query<&Children>,
-    mesh_handles: Query<(&Name, &Handle<Mesh>)>,
+    mesh_handles: Query<(&Name, &Mesh3d)>,
 ) {
     for (scene_entity, scene_instance, async_collider) in async_colliders.iter() {
         if scene_spawner.instance_is_ready(**scene_instance) {
@@ -588,7 +588,10 @@ pub mod test {
         let mut meshes = app.world_mut().resource_mut::<Assets<Mesh>>();
         let cube = meshes.add(Cuboid::default());
 
-        let entity = app.world_mut().spawn((cube, AsyncCollider::default())).id();
+        let entity = app
+            .world_mut()
+            .spawn((Mesh3d(cube), AsyncCollider::default()))
+            .id();
 
         app.update();
 
@@ -616,10 +619,13 @@ pub mod test {
         let mut meshes = app.world_mut().resource_mut::<Assets<Mesh>>();
         let cube_handle = meshes.add(Cuboid::default());
         let capsule_handle = meshes.add(Capsule3d::default());
-        let cube = app.world_mut().spawn((Name::new("Cube"), cube_handle)).id();
+        let cube = app
+            .world_mut()
+            .spawn((Name::new("Cube"), Mesh3d(cube_handle)))
+            .id();
         let capsule = app
             .world_mut()
-            .spawn((Name::new("Capsule"), capsule_handle))
+            .spawn((Name::new("Capsule"), Mesh3d(capsule_handle)))
             .id();
 
         let mut scenes = app.world_mut().resource_mut::<Assets<Scene>>();
@@ -630,13 +636,13 @@ pub mod test {
         let parent = app
             .world_mut()
             .spawn((
-                scene,
+                SceneRoot(scene),
                 AsyncSceneCollider {
                     named_shapes,
                     ..Default::default()
                 },
             ))
-            .push_children(&[cube, capsule])
+            .add_children(&[cube, capsule])
             .id();
 
         app.update();

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -80,7 +80,6 @@ pub mod tests {
         },
         scene::ScenePlugin,
         time::TimePlugin,
-        window::WindowPlugin,
     };
     use rapier::geometry::CollisionEventFlags;
     use std::f32::consts::PI;
@@ -317,7 +316,6 @@ pub mod tests {
     impl Plugin for HeadlessRenderPlugin {
         fn build(&self, app: &mut App) {
             app.add_plugins((
-                WindowPlugin::default(),
                 AssetPlugin::default(),
                 ScenePlugin,
                 RenderPlugin {

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -208,16 +208,12 @@ pub mod tests {
         for (child_transform, parent_transform) in [zero, same, different] {
             let child = app
                 .world_mut()
-                .spawn((
-                    TransformBundle::from(child_transform),
-                    RigidBody::Fixed,
-                    Collider::ball(1.0),
-                ))
+                .spawn((child_transform, RigidBody::Fixed, Collider::ball(1.0)))
                 .id();
 
             app.world_mut()
-                .spawn(TransformBundle::from(parent_transform))
-                .push_children(&[child]);
+                .spawn(parent_transform)
+                .add_children(&[child]);
 
             app.update();
 
@@ -268,13 +264,13 @@ pub mod tests {
         for (child_transform, parent_transform) in [zero, same, different] {
             let child = app
                 .world_mut()
-                .spawn((TransformBundle::from(child_transform), Collider::ball(1.0)))
+                .spawn((child_transform, Collider::ball(1.0)))
                 .id();
 
             let parent = app
                 .world_mut()
-                .spawn((TransformBundle::from(parent_transform), RigidBody::Fixed))
-                .push_children(&[child])
+                .spawn((parent_transform, RigidBody::Fixed))
+                .add_children(&[child])
                 .id();
 
             app.update();

--- a/src/plugin/systems/multiple_rapier_contexts.rs
+++ b/src/plugin/systems/multiple_rapier_contexts.rs
@@ -143,7 +143,7 @@ mod test {
         .add_systems(
             PostUpdate,
             setup_physics
-                .run_if(run_once())
+                .run_if(run_once)
                 .before(PhysicsSet::SyncBackend),
         );
         // Simulates 60 updates per seconds
@@ -188,13 +188,13 @@ mod test {
         }
         pub fn setup_physics(mut commands: Commands) {
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(0.0, -1.2, 0.0)),
+                Transform::from_xyz(0.0, -1.2, 0.0),
                 cuboid(4.0, 1.0, 1.0),
                 Marker::<'R'>,
             ));
 
             commands.spawn((
-                TransformBundle::from(Transform::from_xyz(0.0, 5.0, 0.0)),
+                Transform::from_xyz(0.0, 5.0, 0.0),
                 cuboid(4.0, 1.5, 1.0),
                 Sensor,
                 Marker::<'R'>,
@@ -202,7 +202,7 @@ mod test {
 
             commands
                 .spawn((
-                    TransformBundle::from(Transform::from_xyz(0.0, 13.0, 0.0)),
+                    Transform::from_xyz(0.0, 13.0, 0.0),
                     RigidBody::Dynamic,
                     cuboid(0.5, 0.5, 0.5),
                     ActiveEvents::COLLISION_EVENTS,
@@ -212,7 +212,7 @@ mod test {
                 ))
                 .with_children(|child_builder| {
                     child_builder.spawn((
-                        TransformBundle::from(Transform::from_xyz(0.0, -1.2, 0.0)),
+                        Transform::from_xyz(0.0, -1.2, 0.0),
                         cuboid(4.0, 1.0, 1.0),
                         Marker::<'C'>,
                         Marker::<'R'>,

--- a/src/plugin/systems/multiple_rapier_contexts.rs
+++ b/src/plugin/systems/multiple_rapier_contexts.rs
@@ -49,21 +49,22 @@ fn remove_old_physics(entity: Entity, commands: &mut Commands) {
         .remove::<RapierImpulseJointHandle>();
 }
 
-/// Flags the entity to have its physics updated to reflect new world
+/// reacts to modifications to [`RapierContextEntityLink`]
+/// to move an entity's physics data from a context to another.
 ///
-/// Also recursively bubbles down world changes to children & flags them to apply any needed physics changes
-pub fn on_change_world(
-    q_changed_worlds: Query<
+/// Also recursively bubbles down context changes to children & flags them to apply any needed physics changes
+pub fn on_change_context(
+    q_changed_contexts: Query<
         (Entity, Ref<RapierContextEntityLink>),
         Changed<RapierContextEntityLink>,
     >,
     q_children: Query<&Children>,
-    q_physics_world: Query<&RapierContextEntityLink>,
+    q_physics_context: Query<&RapierContextEntityLink>,
     q_context: Query<&RapierContext>,
     mut commands: Commands,
 ) {
-    for (entity, new_physics_world) in &q_changed_worlds {
-        let context = q_context.get(new_physics_world.0);
+    for (entity, new_physics_context) in &q_changed_contexts {
+        let context = q_context.get(new_physics_context.0);
         // Ensure the world actually changed before removing them from the world
         if !context
             .map(|x| {
@@ -76,46 +77,46 @@ pub fn on_change_world(
             .unwrap_or(false)
         {
             remove_old_physics(entity, &mut commands);
-            bubble_down_world_change(
+            bubble_down_context_change(
                 &mut commands,
                 entity,
                 &q_children,
-                *new_physics_world,
-                &q_physics_world,
+                *new_physics_context,
+                &q_physics_context,
             );
         }
     }
 }
 
-fn bubble_down_world_change(
+fn bubble_down_context_change(
     commands: &mut Commands,
     entity: Entity,
     q_children: &Query<&Children>,
-    new_physics_world: RapierContextEntityLink,
-    q_physics_world: &Query<&RapierContextEntityLink>,
+    new_physics_context: RapierContextEntityLink,
+    q_physics_context: &Query<&RapierContextEntityLink>,
 ) {
     let Ok(children) = q_children.get(entity) else {
         return;
     };
 
     children.iter().for_each(|&child| {
-        if q_physics_world
+        if q_physics_context
             .get(child)
-            .map(|x| *x == new_physics_world)
+            .map(|x| *x == new_physics_context)
             .unwrap_or(false)
         {
             return;
         }
 
         remove_old_physics(child, commands);
-        commands.entity(child).insert(new_physics_world);
+        commands.entity(child).insert(new_physics_context);
 
-        bubble_down_world_change(
+        bubble_down_context_change(
             commands,
             child,
             q_children,
-            new_physics_world,
-            q_physics_world,
+            new_physics_context,
+            q_physics_context,
         );
     });
 }
@@ -161,7 +162,7 @@ mod test {
         }
         // Verify link is correctly updated for children.
         let new_rapier_context = world.spawn(RapierContext::default()).id();
-        // FIXME: We need to wait 1 frame when creating a world.
+        // FIXME: We need to wait 1 frame when creating a context.
         // Ideally we should be able to order the systems so that we don't have to wait.
         app.update();
         let mut world = app.world_mut();


### PR DESCRIPTION
- [x] migrate to bevy 0.15 (rc)
- [x] support bevy_egui + bevy_inspector_egui for examples
- [x] blocked by https://github.com/mvlabat/bevy_egui/pull/309
- [x] blocked by https://github.com/jakobhellermann/bevy-inspector-egui/pull/221
- [x] blocked by https://github.com/jakobhellermann/bevy_mod_debugdump/pull/52 
  - [x] waiting for publish: https://github.com/jakobhellermann/bevy_mod_debugdump/issues/53 

## Follow ups

Those are outside of scope for this PR:

- [ ] Consider using required components https://github.com/dimforge/bevy_rapier/issues/605
- [ ]  fix upstream dependency to instant: https://github.com/dimforge/bevy_rapier/issues/607

## background

- Same changes as https://github.com/dimforge/bevy_rapier/pull/594 ; but made from master, thanks @tim-blackbird for the suggestion.