### PR TITLE
fix publish script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,6 @@
 members = ["bevy_rapier2d", "bevy_rapier3d", "bevy_rapier_benches3d"]
 resolver = "2"
 
-[workspace.lints]
-rust.unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(feature, values("dim2", "dim3"))',
-] }
-
-[workspace.lints.clippy]
-needless_lifetimes = "allow"
-
 [profile.dev]
 # Use slightly better optimization by default, as examples otherwise seem laggy.
 opt-level = 1

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -18,7 +18,10 @@ path = "../src/lib.rs"
 required-features = ["dim2"]
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim3"))',
+] }
+clippy = { needless_lifetimes = "allow" }
 
 [features]
 default = ["dim2", "async-collider", "debug-render-2d"]

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -18,7 +18,10 @@ path = "../src/lib.rs"
 required-features = ["dim3"]
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim2"))',
+] }
+clippy = { needless_lifetimes = "allow" }
 
 [features]
 default = ["dim3", "async-collider", "debug-render-3d"]


### PR DESCRIPTION
Due to the publish script, we should avoid toml instructions related to workspace, as the `cargo.toml` are copied in the root path, effectively removing the workspace concept when publishing, resulting in an error.