### PR TITLE
Use cargo all feature in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           prefix-key: ${{ env.RUST_CACHE_KEY }}
       - run: sudo apt update && sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
+      - run: cargo install cargo-all-features
       - name: Clippy for bevy_rapier2d
         run: cargo clippy --verbose -p bevy_rapier2d
       - name: Clippy for bevy_rapier3d
@@ -58,6 +59,8 @@ jobs:
         run: cargo test --verbose -p bevy_rapier2d
       - name: Test for bevy_rapier3d
         run: cargo test --verbose -p bevy_rapier3d
+      - name: Check all features individually
+        run: cargo check-all-features
   test-wasm:
     runs-on: ubuntu-latest
     env:

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -76,3 +76,17 @@ bevy_mod_debugdump = "0.12"
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs
 features = ["debug-render-2d", "serde-serialize"]
+
+[package.metadata.cargo-all-features]
+
+denylist = ["simd-nightly"]
+
+# Features "dim2" and "dim3" are incompatible, so skip permutations including them
+skip_feature_sets = [["enhanced-determinism", "simd-stable"]]
+
+always_include_features = ["dim2"]
+
+# The maximum number of features to try at once. Does not count features from `always_include_features`.
+# This is useful for reducing the number of combinations run for a crate with a large amount of features,
+# since in most cases a bug just needs a small set of 2-3 features to reproduce.
+max_combination_size = 1

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -48,7 +48,7 @@ simd-nightly = ["rapier2d/simd-nightly"]
 serde-serialize = ["rapier2d/serde-serialize", "bevy/serialize", "serde"]
 enhanced-determinism = ["rapier2d/enhanced-determinism"]
 headless = []
-picking-backend = ["bevy/bevy_picking"]
+picking-backend = ["bevy/bevy_picking", "bevy/bevy_render"]
 async-collider = [
     "bevy/bevy_asset",
     "bevy/bevy_scene",

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -76,3 +76,17 @@ bevy_egui = "0.31"
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs
 features = ["debug-render-3d", "serde-serialize"]
+
+[package.metadata.cargo-all-features]
+
+denylist = ["simd-nightly"]
+
+# Features "dim2" and "dim3" are incompatible, so skip permutations including them
+skip_feature_sets = [["enhanced-determinism", "simd-stable"]]
+
+always_include_features = ["dim3"]
+
+# The maximum number of features to try at once. Does not count features from `always_include_features`.
+# This is useful for reducing the number of combinations run for a crate with a large amount of features,
+# since in most cases a bug just needs a small set of 2-3 features to reproduce.
+max_combination_size = 1

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -49,7 +49,7 @@ simd-nightly = ["rapier3d/simd-nightly"]
 serde-serialize = ["rapier3d/serde-serialize", "bevy/serialize", "serde"]
 enhanced-determinism = ["rapier3d/enhanced-determinism"]
 headless = []
-picking-backend = ["bevy/bevy_picking"]
+picking-backend = ["bevy/bevy_picking", "bevy/bevy_render"]
 async-collider = [
     "bevy/bevy_asset",
     "bevy/bevy_scene",


### PR DESCRIPTION
Consolidate CI with more feature checks

Follow up to https://github.com/dimforge/bevy_rapier/pull/601

To avoid the test taking forever (all features combinations with up to 4 features takes more than 500 checks) ; we check only each feature independently.