### PR TITLE
Fix typo in collider comment

### DIFF
--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -50,14 +50,14 @@ impl Collider {
     }
 
     /// Initialize a new collider with a cylindrical shape defined by its half-height
-    /// (along along the y axis) and its radius.
+    /// (along the y axis) and its radius.
     #[cfg(feature = "dim3")]
     pub fn cylinder(half_height: Real, radius: Real) -> Self {
         SharedShape::cylinder(half_height, radius).into()
     }
 
     /// Initialize a new collider with a rounded cylindrical shape defined by its half-height
-    /// (along along the y axis), its radius, and its roundedness (the
+    /// (along the y axis), its radius, and its roundedness (the
     /// radius of the sphere used for dilating the cylinder).
     #[cfg(feature = "dim3")]
     pub fn round_cylinder(half_height: Real, radius: Real, border_radius: Real) -> Self {
@@ -65,14 +65,14 @@ impl Collider {
     }
 
     /// Initialize a new collider with a cone shape defined by its half-height
-    /// (along along the y axis) and its basis radius.
+    /// (along the y axis) and its basis radius.
     #[cfg(feature = "dim3")]
     pub fn cone(half_height: Real, radius: Real) -> Self {
         SharedShape::cone(half_height, radius).into()
     }
 
     /// Initialize a new collider with a rounded cone shape defined by its half-height
-    /// (along along the y axis), its radius, and its roundedness (the
+    /// (along the y axis), its radius, and its roundedness (the
     /// radius of the sphere used for dilating the cylinder).
     #[cfg(feature = "dim3")]
     pub fn round_cone(half_height: Real, radius: Real, border_radius: Real) -> Self {


### PR DESCRIPTION
Noticed that `along` was repeated twice here while viewing the source code, so here's a small fix.