### PR TITLE
Upgrade to Bevy 0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ## Added
 
 - Added a serialization `serialization2` example for `bevy_rapier2d`.
-- Added reflection for `Default` in addition to `Component` [#649](https://github.com/dimforge/bevy_rapier/pull/649)
+- Added reflection for `Default` in addition to `Component`. [#649](https://github.com/dimforge/bevy_rapier/pull/649)
 
 ## Modified
 
+- Update Bevy to `0.16`.
 - Update from rapier `0.23` to rapier `0.24`,
   see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
 - `RapierContextInitialization::InitializeDefaultRapierContext` now has more fields for better control over default physics context.

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -64,7 +64,7 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.16.0-rc.1", default-features = false, features = ["std"] }
+bevy = { version = "0.16.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
 rapier2d = "0.23"
 bitflags = "2.4"
@@ -72,7 +72,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.1", default-features = false, features = [
+bevy = { version = "0.16.0", default-features = false, features = [
     "x11",
     "bevy_state",
     "bevy_window",

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -80,7 +80,7 @@ bevy = { version = "0.16.0-rc.1", default-features = false, features = [
 ] }
 oorandom = "11"
 approx = "0.5.1"
-glam = { version = "0.30", features = ["approx"] }
+glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.30.0"
 bevy_egui = "0.33"
 bevy_mod_debugdump = "0.12"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -83,7 +83,8 @@ approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.31"
 bevy_egui = "0.34"
-bevy_mod_debugdump = "0.12"
+# FIXME: target a proper release when support for bevy 0.16 is released.
+bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump.git", rev = "ad310179be78abb3c16c581324d7d83b26275028" }
 serde_json = "1.0"
 
 [package.metadata.docs.rs]

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -64,7 +64,7 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
+bevy = { version = "0.16.0-rc.1", default-features = false, features = ["std"] }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
 rapier2d = "0.23"
 bitflags = "2.4"
@@ -72,7 +72,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-rc.1", default-features = false, features = [
     "x11",
     "bevy_state",
     "bevy_window",
@@ -80,9 +80,9 @@ bevy = { version = "0.15", default-features = false, features = [
 ] }
 oorandom = "11"
 approx = "0.5.1"
-glam = { version = "0.29", features = ["approx"] }
-bevy-inspector-egui = "0.28.0"
-bevy_egui = "0.31"
+glam = { version = "0.30", features = ["approx"] }
+bevy-inspector-egui = "0.30.0"
+bevy_egui = "0.33"
 bevy_mod_debugdump = "0.12"
 serde_json = "1.0"
 

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -81,8 +81,8 @@ bevy = { version = "0.16.0", default-features = false, features = [
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
-bevy-inspector-egui = "0.30.0"
-bevy_egui = "0.33"
+bevy-inspector-egui = "0.31"
+bevy_egui = "0.34"
 bevy_mod_debugdump = "0.12"
 serde_json = "1.0"
 

--- a/bevy_rapier2d/examples/custom_system_setup2.rs
+++ b/bevy_rapier2d/examples/custom_system_setup2.rs
@@ -1,4 +1,4 @@
-use bevy::{core::FrameCount, prelude::*, transform::TransformSystem};
+use bevy::{diagnostic::FrameCount, prelude::*, transform::TransformSystem};
 use bevy_rapier2d::prelude::*;
 
 fn main() {

--- a/bevy_rapier2d/examples/debug_despawn2.rs
+++ b/bevy_rapier2d/examples/debug_despawn2.rs
@@ -259,7 +259,7 @@ fn clear_filled_rows(
             game.stats.cleared_blocks += game.n_lanes as i32;
 
             for block_entity in row_blocks {
-                commands.entity(block_entity).despawn_recursive();
+                commands.entity(block_entity).despawn();
             }
         }
     }

--- a/bevy_rapier2d/examples/debugdump2.rs
+++ b/bevy_rapier2d/examples/debugdump2.rs
@@ -2,33 +2,32 @@
 //! run with:
 //! `cargo run --example debugdump2 > dump.dot && dot -Tsvg dump.dot > dump.svg`
 
-// FIXME: Uncomment once `bevy_mod_debugdump` gets updated to be compatible with bevy 0.16
-// use bevy::prelude::*;
-// use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
-// use bevy_rapier2d::prelude::*;
+use bevy::prelude::*;
+use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
+use bevy_rapier2d::prelude::*;
 
 fn main() {
-//     let mut app = App::new();
-//     app.add_plugins((
-//         DefaultPlugins,
-//         RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
-//         RapierDebugRenderPlugin::default(),
-//     ));
+    let mut app = App::new();
+    app.add_plugins((
+        DefaultPlugins,
+        RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
+        RapierDebugRenderPlugin::default(),
+    ));
 
-//     let debugdump_settings = schedule_graph::Settings {
-//         include_system: Some(Box::new(|system: &(dyn System<In = (), Out = ()>)| {
-//             if system.name().starts_with("bevy_pbr")
-//                 || system.name().starts_with("bevy_render")
-//                 || system.name().starts_with("bevy_gizmos")
-//                 || system.name().starts_with("bevy_winit")
-//                 || system.name().starts_with("bevy_sprite")
-//             {
-//                 return false;
-//             }
-//             true
-//         })),
-//         ..Default::default()
-//     };
-//     let dot = schedule_graph_dot(&mut app, PostUpdate, &debugdump_settings);
-//     println!("{dot}");
+    let debugdump_settings = schedule_graph::Settings {
+        include_system: Some(Box::new(|system| {
+            if system.name().starts_with("bevy_pbr")
+                || system.name().starts_with("bevy_render")
+                || system.name().starts_with("bevy_gizmos")
+                || system.name().starts_with("bevy_winit")
+                || system.name().starts_with("bevy_sprite")
+            {
+                return false;
+            }
+            true
+        })),
+        ..Default::default()
+    };
+    let dot = schedule_graph_dot(&mut app, PostUpdate, &debugdump_settings);
+    println!("{dot}");
 }

--- a/bevy_rapier2d/examples/debugdump2.rs
+++ b/bevy_rapier2d/examples/debugdump2.rs
@@ -2,32 +2,33 @@
 //! run with:
 //! `cargo run --example debugdump2 > dump.dot && dot -Tsvg dump.dot > dump.svg`
 
-use bevy::prelude::*;
-use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
-use bevy_rapier2d::prelude::*;
+// FIXME: Uncomment once `bevy_mod_debugdump` gets updated to be compatible with bevy 0.16
+// use bevy::prelude::*;
+// use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
+// use bevy_rapier2d::prelude::*;
 
-fn main() {
-    let mut app = App::new();
-    app.add_plugins((
-        DefaultPlugins,
-        RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
-        RapierDebugRenderPlugin::default(),
-    ));
+// fn main() {
+//     let mut app = App::new();
+//     app.add_plugins((
+//         DefaultPlugins,
+//         RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
+//         RapierDebugRenderPlugin::default(),
+//     ));
 
-    let debugdump_settings = schedule_graph::Settings {
-        include_system: Some(Box::new(|system: &(dyn System<In = (), Out = ()>)| {
-            if system.name().starts_with("bevy_pbr")
-                || system.name().starts_with("bevy_render")
-                || system.name().starts_with("bevy_gizmos")
-                || system.name().starts_with("bevy_winit")
-                || system.name().starts_with("bevy_sprite")
-            {
-                return false;
-            }
-            true
-        })),
-        ..Default::default()
-    };
-    let dot = schedule_graph_dot(&mut app, PostUpdate, &debugdump_settings);
-    println!("{dot}");
-}
+//     let debugdump_settings = schedule_graph::Settings {
+//         include_system: Some(Box::new(|system: &(dyn System<In = (), Out = ()>)| {
+//             if system.name().starts_with("bevy_pbr")
+//                 || system.name().starts_with("bevy_render")
+//                 || system.name().starts_with("bevy_gizmos")
+//                 || system.name().starts_with("bevy_winit")
+//                 || system.name().starts_with("bevy_sprite")
+//             {
+//                 return false;
+//             }
+//             true
+//         })),
+//         ..Default::default()
+//     };
+//     let dot = schedule_graph_dot(&mut app, PostUpdate, &debugdump_settings);
+//     println!("{dot}");
+// }

--- a/bevy_rapier2d/examples/debugdump2.rs
+++ b/bevy_rapier2d/examples/debugdump2.rs
@@ -7,7 +7,7 @@
 // use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
 // use bevy_rapier2d::prelude::*;
 
-// fn main() {
+fn main() {
 //     let mut app = App::new();
 //     app.add_plugins((
 //         DefaultPlugins,
@@ -31,4 +31,4 @@
 //     };
 //     let dot = schedule_graph_dot(&mut app, PostUpdate, &debugdump_settings);
 //     println!("{dot}");
-// }
+}

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -24,8 +24,11 @@ fn main() {
 #[derive(Component)]
 pub struct Player(f32);
 
-pub fn spawn_player(mut commands: Commands, mut rapier_config: Query<&mut RapierConfiguration>) {
-    let mut rapier_config = rapier_config.single_mut().unwrap();
+pub fn spawn_player(
+    mut commands: Commands,
+    mut rapier_config: Query<&mut RapierConfiguration>,
+) -> Result<()> {
+    let mut rapier_config = rapier_config.single_mut()?;
     // Set gravity to 0.0 and spawn camera.
     rapier_config.gravity = Vec2::ZERO;
     commands.spawn(Camera2d);
@@ -44,6 +47,8 @@ pub fn spawn_player(mut commands: Commands, mut rapier_config: Query<&mut Rapier
         Collider::ball(sprite_size / 2.0),
         Player(100.0),
     ));
+
+    Ok(())
 }
 
 pub fn player_movement(

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -25,7 +25,7 @@ fn main() {
 pub struct Player(f32);
 
 pub fn spawn_player(mut commands: Commands, mut rapier_config: Query<&mut RapierConfiguration>) {
-    let mut rapier_config = rapier_config.single_mut();
+    let mut rapier_config = rapier_config.single_mut().unwrap();
     // Set gravity to 0.0 and spawn camera.
     rapier_config.gravity = Vec2::ZERO;
     commands.spawn(Camera2d);

--- a/bevy_rapier2d/examples/serialization2.rs
+++ b/bevy_rapier2d/examples/serialization2.rs
@@ -36,5 +36,5 @@ pub fn print_physics(_context: ReadRapierContext) {
 }
 
 fn quit(mut exit_event: EventWriter<AppExit>) {
-    exit_event.send(AppExit::Success);
+    exit_event.write(AppExit::Success);
 }

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -205,12 +205,15 @@ fn main() {
             OnExit(Examples::PlayerMovement2),
             (
                 cleanup,
-                |mut rapier_config: Query<&mut RapierConfiguration>, ctxt: ReadRapierContext| {
-                    let mut rapier_config = rapier_config.single_mut();
+                |mut rapier_config: Query<&mut RapierConfiguration>,
+                 ctxt: ReadRapierContext|
+                 -> Result<()> {
+                    let mut rapier_config = rapier_config.single_mut()?;
                     rapier_config.gravity = RapierConfiguration::new(
-                        ctxt.single().simulation.integration_parameters.length_unit,
+                        ctxt.single()?.simulation.integration_parameters.length_unit,
                     )
                     .gravity;
+                    Ok(())
                 },
             ),
         )

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -1,291 +1,292 @@
-#![allow(dead_code)]
+// FIXME: Uncomment once `bevy_egui` and `bevy_inspector_egui` get updated to be compatible with bevy 0.16
+// #![allow(dead_code)]
 
-mod boxes2;
-mod debug_despawn2;
-mod debug_toggle2;
-mod despawn2;
-mod events2;
-mod joints2;
-mod joints_despawn2;
-mod locked_rotations2;
-mod multiple_colliders2;
-mod player_movement2;
-mod rope_joint2;
+// mod boxes2;
+// mod debug_despawn2;
+// mod debug_toggle2;
+// mod despawn2;
+// mod events2;
+// mod joints2;
+// mod joints_despawn2;
+// mod locked_rotations2;
+// mod multiple_colliders2;
+// mod player_movement2;
+// mod rope_joint2;
 
-use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
-use bevy_rapier2d::prelude::*;
+// use bevy::prelude::*;
+// use bevy_egui::{egui, EguiContexts, EguiPlugin};
+// use bevy_inspector_egui::quick::WorldInspectorPlugin;
+// use bevy_rapier2d::prelude::*;
 
-#[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
-pub enum Examples {
-    #[default]
-    None,
-    Boxes2,
-    DebugToggle2,
-    RopeJoint2,
-    DebugDespawn2,
-    Despawn2,
-    Events2,
-    Joints2,
-    JointsDespawn2,
-    LockedRotations2,
-    MultipleColliders2,
-    PlayerMovement2,
-}
+// #[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
+// pub enum Examples {
+//     #[default]
+//     None,
+//     Boxes2,
+//     DebugToggle2,
+//     RopeJoint2,
+//     DebugDespawn2,
+//     Despawn2,
+//     Events2,
+//     Joints2,
+//     JointsDespawn2,
+//     LockedRotations2,
+//     MultipleColliders2,
+//     PlayerMovement2,
+// }
 
-#[derive(Resource, Default, Reflect)]
-struct ExamplesRes {
-    entities_before: Vec<Entity>,
-}
+// #[derive(Resource, Default, Reflect)]
+// struct ExamplesRes {
+//     entities_before: Vec<Entity>,
+// }
 
-#[derive(Resource, Debug, Default, Reflect)]
-struct ExampleSelected(pub usize);
+// #[derive(Resource, Debug, Default, Reflect)]
+// struct ExampleSelected(pub usize);
 
-#[derive(Debug, Reflect)]
-struct ExampleDefinition {
-    pub state: Examples,
-    pub name: &'static str,
-}
+// #[derive(Debug, Reflect)]
+// struct ExampleDefinition {
+//     pub state: Examples,
+//     pub name: &'static str,
+// }
 
-impl From<(Examples, &'static str)> for ExampleDefinition {
-    fn from((state, name): (Examples, &'static str)) -> Self {
-        Self { state, name }
-    }
-}
+// impl From<(Examples, &'static str)> for ExampleDefinition {
+//     fn from((state, name): (Examples, &'static str)) -> Self {
+//         Self { state, name }
+//     }
+// }
 
-#[derive(Resource, Debug, Reflect)]
-struct ExampleSet(pub Vec<ExampleDefinition>);
+// #[derive(Resource, Debug, Reflect)]
+// struct ExampleSet(pub Vec<ExampleDefinition>);
 
-fn main() {
-    let mut app = App::new();
-    app.init_resource::<ExamplesRes>()
-        .add_plugins((
-            DefaultPlugins,
-            EguiPlugin,
-            RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
-            RapierDebugRenderPlugin::default(),
-            WorldInspectorPlugin::new(),
-        ))
-        .register_type::<Examples>()
-        .register_type::<ExamplesRes>()
-        .register_type::<ExampleSelected>()
-        .init_state::<Examples>()
-        .insert_resource(ExampleSet(vec![
-            (Examples::Boxes2, "Boxes3").into(),
-            (Examples::RopeJoint2, "RopeJoint2").into(),
-            (Examples::DebugDespawn2, "DebugDespawn2").into(),
-            (Examples::Despawn2, "Despawn3").into(),
-            (Examples::Events2, "Events3").into(),
-            (Examples::Joints2, "Joints3").into(),
-            (Examples::JointsDespawn2, "JointsDespawn3").into(),
-            (Examples::LockedRotations2, "LockedRotations3").into(),
-            (Examples::MultipleColliders2, "MultipleColliders3").into(),
-            (Examples::PlayerMovement2, "PlayerMovement2").into(),
-        ]))
-        .init_resource::<ExampleSelected>()
-        //
-        //boxes2
-        .add_systems(
-            OnEnter(Examples::Boxes2),
-            (boxes2::setup_graphics, boxes2::setup_physics),
-        )
-        .add_systems(OnExit(Examples::Boxes2), cleanup)
-        //
-        // Debug toggle
-        .add_systems(
-            OnEnter(Examples::DebugToggle2),
-            (debug_toggle2::setup_graphics, debug_toggle2::setup_physics),
-        )
-        .add_systems(
-            Update,
-            (
-                debug_toggle2::toggle_debug,
-                (|mut debug_render_context: ResMut<DebugRenderContext>| {
-                    debug_render_context.enabled = !debug_render_context.enabled;
-                })
-                .run_if(debug_toggle2::input_just_pressed(KeyCode::KeyV)),
-            )
-                .run_if(in_state(Examples::DebugToggle2)),
-        )
-        .add_systems(OnExit(Examples::DebugToggle2), cleanup)
-        //
-        // rope joint
-        .add_systems(
-            OnEnter(Examples::RopeJoint2),
-            (rope_joint2::setup_graphics, rope_joint2::setup_physics),
-        )
-        .add_systems(OnExit(Examples::RopeJoint2), cleanup)
-        //
-        //debug despawn
-        .init_resource::<debug_despawn2::Game>()
-        .add_systems(OnEnter(Examples::DebugDespawn2), debug_despawn2::setup_game)
-        .add_systems(
-            Update,
-            debug_despawn2::cube_sleep_detection.run_if(in_state(Examples::DebugDespawn2)),
-        )
-        .add_systems(OnExit(Examples::DebugDespawn2), cleanup)
-        //
-        //despawn2
-        .insert_resource(despawn2::DespawnResource::default())
-        .insert_resource(despawn2::ResizeResource::default())
-        .add_systems(
-            OnEnter(Examples::Despawn2),
-            (despawn2::setup_graphics, despawn2::setup_physics),
-        )
-        .add_systems(
-            Update,
-            (despawn2::despawn, despawn2::resize).run_if(in_state(Examples::Despawn2)),
-        )
-        .add_systems(OnExit(Examples::Despawn2), cleanup)
-        //
-        //events
-        .add_systems(
-            OnEnter(Examples::Events2),
-            (events2::setup_graphics, events2::setup_physics),
-        )
-        .add_systems(
-            Update,
-            events2::display_events.run_if(in_state(Examples::Events2)),
-        )
-        .add_systems(OnExit(Examples::Events2), cleanup)
-        //
-        //events
-        .add_systems(
-            OnEnter(Examples::Joints2),
-            (joints2::setup_graphics, joints2::setup_physics),
-        )
-        .add_systems(OnExit(Examples::Joints2), cleanup)
-        //
-        //despawn2
-        .insert_resource(joints_despawn2::DespawnResource::default())
-        .add_systems(
-            OnEnter(Examples::JointsDespawn2),
-            (
-                joints_despawn2::setup_graphics,
-                joints_despawn2::setup_physics,
-            ),
-        )
-        .add_systems(
-            Update,
-            (joints_despawn2::despawn).run_if(in_state(Examples::JointsDespawn2)),
-        )
-        .add_systems(OnExit(Examples::JointsDespawn2), cleanup)
-        //
-        //locked rotations
-        .add_systems(
-            OnEnter(Examples::LockedRotations2),
-            (
-                locked_rotations2::setup_graphics,
-                locked_rotations2::setup_physics,
-            ),
-        )
-        .add_systems(OnExit(Examples::LockedRotations2), cleanup)
-        //
-        //multiple colliders
-        .add_systems(
-            OnEnter(Examples::MultipleColliders2),
-            (
-                multiple_colliders2::setup_graphics,
-                multiple_colliders2::setup_physics,
-            ),
-        )
-        .add_systems(OnExit(Examples::MultipleColliders2), cleanup)
-        //
-        //player movement
-        .add_systems(
-            OnEnter(Examples::PlayerMovement2),
-            player_movement2::spawn_player,
-        )
-        .add_systems(
-            Update,
-            (player_movement2::player_movement).run_if(in_state(Examples::PlayerMovement2)),
-        )
-        .add_systems(
-            OnExit(Examples::PlayerMovement2),
-            (
-                cleanup,
-                |mut rapier_config: Query<&mut RapierConfiguration>,
-                 ctxt: ReadRapierContext|
-                 -> Result<()> {
-                    let mut rapier_config = rapier_config.single_mut()?;
-                    rapier_config.gravity = RapierConfiguration::new(
-                        ctxt.single()?.simulation.integration_parameters.length_unit,
-                    )
-                    .gravity;
-                    Ok(())
-                },
-            ),
-        )
-        //
-        //testbed
-        .add_systems(
-            OnEnter(Examples::None),
-            |mut next_state: ResMut<NextState<Examples>>| {
-                next_state.set(Examples::Boxes2);
-            },
-        )
-        .add_systems(OnExit(Examples::None), init)
-        .add_systems(
-            Update,
-            (
-                ui_example_system,
-                change_example.run_if(resource_changed::<ExampleSelected>),
-            )
-                .chain(),
-        );
+// fn main() {
+//     let mut app = App::new();
+//     app.init_resource::<ExamplesRes>()
+//         .add_plugins((
+//             DefaultPlugins,
+//             EguiPlugin,
+//             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
+//             RapierDebugRenderPlugin::default(),
+//             WorldInspectorPlugin::new(),
+//         ))
+//         .register_type::<Examples>()
+//         .register_type::<ExamplesRes>()
+//         .register_type::<ExampleSelected>()
+//         .init_state::<Examples>()
+//         .insert_resource(ExampleSet(vec![
+//             (Examples::Boxes2, "Boxes3").into(),
+//             (Examples::RopeJoint2, "RopeJoint2").into(),
+//             (Examples::DebugDespawn2, "DebugDespawn2").into(),
+//             (Examples::Despawn2, "Despawn3").into(),
+//             (Examples::Events2, "Events3").into(),
+//             (Examples::Joints2, "Joints3").into(),
+//             (Examples::JointsDespawn2, "JointsDespawn3").into(),
+//             (Examples::LockedRotations2, "LockedRotations3").into(),
+//             (Examples::MultipleColliders2, "MultipleColliders3").into(),
+//             (Examples::PlayerMovement2, "PlayerMovement2").into(),
+//         ]))
+//         .init_resource::<ExampleSelected>()
+//         //
+//         //boxes2
+//         .add_systems(
+//             OnEnter(Examples::Boxes2),
+//             (boxes2::setup_graphics, boxes2::setup_physics),
+//         )
+//         .add_systems(OnExit(Examples::Boxes2), cleanup)
+//         //
+//         // Debug toggle
+//         .add_systems(
+//             OnEnter(Examples::DebugToggle2),
+//             (debug_toggle2::setup_graphics, debug_toggle2::setup_physics),
+//         )
+//         .add_systems(
+//             Update,
+//             (
+//                 debug_toggle2::toggle_debug,
+//                 (|mut debug_render_context: ResMut<DebugRenderContext>| {
+//                     debug_render_context.enabled = !debug_render_context.enabled;
+//                 })
+//                 .run_if(debug_toggle2::input_just_pressed(KeyCode::KeyV)),
+//             )
+//                 .run_if(in_state(Examples::DebugToggle2)),
+//         )
+//         .add_systems(OnExit(Examples::DebugToggle2), cleanup)
+//         //
+//         // rope joint
+//         .add_systems(
+//             OnEnter(Examples::RopeJoint2),
+//             (rope_joint2::setup_graphics, rope_joint2::setup_physics),
+//         )
+//         .add_systems(OnExit(Examples::RopeJoint2), cleanup)
+//         //
+//         //debug despawn
+//         .init_resource::<debug_despawn2::Game>()
+//         .add_systems(OnEnter(Examples::DebugDespawn2), debug_despawn2::setup_game)
+//         .add_systems(
+//             Update,
+//             debug_despawn2::cube_sleep_detection.run_if(in_state(Examples::DebugDespawn2)),
+//         )
+//         .add_systems(OnExit(Examples::DebugDespawn2), cleanup)
+//         //
+//         //despawn2
+//         .insert_resource(despawn2::DespawnResource::default())
+//         .insert_resource(despawn2::ResizeResource::default())
+//         .add_systems(
+//             OnEnter(Examples::Despawn2),
+//             (despawn2::setup_graphics, despawn2::setup_physics),
+//         )
+//         .add_systems(
+//             Update,
+//             (despawn2::despawn, despawn2::resize).run_if(in_state(Examples::Despawn2)),
+//         )
+//         .add_systems(OnExit(Examples::Despawn2), cleanup)
+//         //
+//         //events
+//         .add_systems(
+//             OnEnter(Examples::Events2),
+//             (events2::setup_graphics, events2::setup_physics),
+//         )
+//         .add_systems(
+//             Update,
+//             events2::display_events.run_if(in_state(Examples::Events2)),
+//         )
+//         .add_systems(OnExit(Examples::Events2), cleanup)
+//         //
+//         //events
+//         .add_systems(
+//             OnEnter(Examples::Joints2),
+//             (joints2::setup_graphics, joints2::setup_physics),
+//         )
+//         .add_systems(OnExit(Examples::Joints2), cleanup)
+//         //
+//         //despawn2
+//         .insert_resource(joints_despawn2::DespawnResource::default())
+//         .add_systems(
+//             OnEnter(Examples::JointsDespawn2),
+//             (
+//                 joints_despawn2::setup_graphics,
+//                 joints_despawn2::setup_physics,
+//             ),
+//         )
+//         .add_systems(
+//             Update,
+//             (joints_despawn2::despawn).run_if(in_state(Examples::JointsDespawn2)),
+//         )
+//         .add_systems(OnExit(Examples::JointsDespawn2), cleanup)
+//         //
+//         //locked rotations
+//         .add_systems(
+//             OnEnter(Examples::LockedRotations2),
+//             (
+//                 locked_rotations2::setup_graphics,
+//                 locked_rotations2::setup_physics,
+//             ),
+//         )
+//         .add_systems(OnExit(Examples::LockedRotations2), cleanup)
+//         //
+//         //multiple colliders
+//         .add_systems(
+//             OnEnter(Examples::MultipleColliders2),
+//             (
+//                 multiple_colliders2::setup_graphics,
+//                 multiple_colliders2::setup_physics,
+//             ),
+//         )
+//         .add_systems(OnExit(Examples::MultipleColliders2), cleanup)
+//         //
+//         //player movement
+//         .add_systems(
+//             OnEnter(Examples::PlayerMovement2),
+//             player_movement2::spawn_player,
+//         )
+//         .add_systems(
+//             Update,
+//             (player_movement2::player_movement).run_if(in_state(Examples::PlayerMovement2)),
+//         )
+//         .add_systems(
+//             OnExit(Examples::PlayerMovement2),
+//             (
+//                 cleanup,
+//                 |mut rapier_config: Query<&mut RapierConfiguration>,
+//                  ctxt: ReadRapierContext|
+//                  -> Result<()> {
+//                     let mut rapier_config = rapier_config.single_mut()?;
+//                     rapier_config.gravity = RapierConfiguration::new(
+//                         ctxt.single()?.simulation.integration_parameters.length_unit,
+//                     )
+//                     .gravity;
+//                     Ok(())
+//                 },
+//             ),
+//         )
+//         //
+//         //testbed
+//         .add_systems(
+//             OnEnter(Examples::None),
+//             |mut next_state: ResMut<NextState<Examples>>| {
+//                 next_state.set(Examples::Boxes2);
+//             },
+//         )
+//         .add_systems(OnExit(Examples::None), init)
+//         .add_systems(
+//             Update,
+//             (
+//                 ui_example_system,
+//                 change_example.run_if(resource_changed::<ExampleSelected>),
+//             )
+//                 .chain(),
+//         );
 
-    app.run();
-}
+//     app.run();
+// }
 
-fn init(world: &mut World) {
-    //save all entities that are in the world before setting up any example
-    // to be able to always return to this state when switching from one example to the other
-    world.resource_mut::<ExamplesRes>().entities_before =
-        world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
-}
+// fn init(world: &mut World) {
+//     //save all entities that are in the world before setting up any example
+//     // to be able to always return to this state when switching from one example to the other
+//     world.resource_mut::<ExamplesRes>().entities_before =
+//         world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+// }
 
-fn cleanup(world: &mut World) {
-    let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
+// fn cleanup(world: &mut World) {
+//     let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
 
-    let remove = world
-        .iter_entities()
-        .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
-        .collect::<Vec<_>>();
+//     let remove = world
+//         .iter_entities()
+//         .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
+//         .collect::<Vec<_>>();
 
-    for r in remove {
-        world.despawn(r);
-    }
-}
+//     for r in remove {
+//         world.despawn(r);
+//     }
+// }
 
-fn change_example(
-    example_selected: Res<ExampleSelected>,
-    examples_available: Res<ExampleSet>,
-    mut next_state: ResMut<NextState<Examples>>,
-) {
-    next_state.set(examples_available.0[example_selected.0].state);
-}
+// fn change_example(
+//     example_selected: Res<ExampleSelected>,
+//     examples_available: Res<ExampleSet>,
+//     mut next_state: ResMut<NextState<Examples>>,
+// ) {
+//     next_state.set(examples_available.0[example_selected.0].state);
+// }
 
-fn ui_example_system(
-    mut contexts: EguiContexts,
-    mut current_example: ResMut<ExampleSelected>,
-    examples_available: Res<ExampleSet>,
-) {
-    egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
-        let mut changed = false;
-        egui::ComboBox::from_label("example")
-            .width(150.0)
-            .selected_text(examples_available.0[current_example.0].name)
-            .show_ui(ui, |ui| {
-                for (id, value) in examples_available.0.iter().enumerate() {
-                    changed = ui
-                        .selectable_value(&mut current_example.0, id, value.name)
-                        .changed()
-                        || changed;
-                }
-            });
-        if ui.button("Next").clicked() {
-            current_example.0 = (current_example.0 + 1) % examples_available.0.len();
-        }
-    });
-}
+// fn ui_example_system(
+//     mut contexts: EguiContexts,
+//     mut current_example: ResMut<ExampleSelected>,
+//     examples_available: Res<ExampleSet>,
+// ) {
+//     egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
+//         let mut changed = false;
+//         egui::ComboBox::from_label("example")
+//             .width(150.0)
+//             .selected_text(examples_available.0[current_example.0].name)
+//             .show_ui(ui, |ui| {
+//                 for (id, value) in examples_available.0.iter().enumerate() {
+//                     changed = ui
+//                         .selectable_value(&mut current_example.0, id, value.name)
+//                         .changed()
+//                         || changed;
+//                 }
+//             });
+//         if ui.button("Next").clicked() {
+//             current_example.0 = (current_example.0 + 1) % examples_available.0.len();
+//         }
+//     });
+// }

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -58,7 +58,7 @@
 // #[derive(Resource, Debug, Reflect)]
 // struct ExampleSet(pub Vec<ExampleDefinition>);
 
-// fn main() {
+fn main() {
 //     let mut app = App::new();
 //     app.init_resource::<ExamplesRes>()
 //         .add_plugins((
@@ -289,4 +289,4 @@
 //             current_example.0 = (current_example.0 + 1) % examples_available.0.len();
 //         }
 //     });
-// }
+}

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -1,292 +1,293 @@
-// FIXME: Uncomment once `bevy_egui` and `bevy_inspector_egui` get updated to be compatible with bevy 0.16
-// #![allow(dead_code)]
+#![allow(dead_code)]
 
-// mod boxes2;
-// mod debug_despawn2;
-// mod debug_toggle2;
-// mod despawn2;
-// mod events2;
-// mod joints2;
-// mod joints_despawn2;
-// mod locked_rotations2;
-// mod multiple_colliders2;
-// mod player_movement2;
-// mod rope_joint2;
+mod boxes2;
+mod debug_despawn2;
+mod debug_toggle2;
+mod despawn2;
+mod events2;
+mod joints2;
+mod joints_despawn2;
+mod locked_rotations2;
+mod multiple_colliders2;
+mod player_movement2;
+mod rope_joint2;
 
-// use bevy::prelude::*;
-// use bevy_egui::{egui, EguiContexts, EguiPlugin};
-// use bevy_inspector_egui::quick::WorldInspectorPlugin;
-// use bevy_rapier2d::prelude::*;
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_rapier2d::prelude::*;
 
-// #[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
-// pub enum Examples {
-//     #[default]
-//     None,
-//     Boxes2,
-//     DebugToggle2,
-//     RopeJoint2,
-//     DebugDespawn2,
-//     Despawn2,
-//     Events2,
-//     Joints2,
-//     JointsDespawn2,
-//     LockedRotations2,
-//     MultipleColliders2,
-//     PlayerMovement2,
-// }
+#[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
+pub enum Examples {
+    #[default]
+    None,
+    Boxes2,
+    DebugToggle2,
+    RopeJoint2,
+    DebugDespawn2,
+    Despawn2,
+    Events2,
+    Joints2,
+    JointsDespawn2,
+    LockedRotations2,
+    MultipleColliders2,
+    PlayerMovement2,
+}
 
-// #[derive(Resource, Default, Reflect)]
-// struct ExamplesRes {
-//     entities_before: Vec<Entity>,
-// }
+#[derive(Resource, Default, Reflect)]
+struct ExamplesRes {
+    entities_before: Vec<Entity>,
+}
 
-// #[derive(Resource, Debug, Default, Reflect)]
-// struct ExampleSelected(pub usize);
+#[derive(Resource, Debug, Default, Reflect)]
+struct ExampleSelected(pub usize);
 
-// #[derive(Debug, Reflect)]
-// struct ExampleDefinition {
-//     pub state: Examples,
-//     pub name: &'static str,
-// }
+#[derive(Debug, Reflect)]
+struct ExampleDefinition {
+    pub state: Examples,
+    pub name: &'static str,
+}
 
-// impl From<(Examples, &'static str)> for ExampleDefinition {
-//     fn from((state, name): (Examples, &'static str)) -> Self {
-//         Self { state, name }
-//     }
-// }
+impl From<(Examples, &'static str)> for ExampleDefinition {
+    fn from((state, name): (Examples, &'static str)) -> Self {
+        Self { state, name }
+    }
+}
 
-// #[derive(Resource, Debug, Reflect)]
-// struct ExampleSet(pub Vec<ExampleDefinition>);
+#[derive(Resource, Debug, Reflect)]
+struct ExampleSet(pub Vec<ExampleDefinition>);
 
 fn main() {
-//     let mut app = App::new();
-//     app.init_resource::<ExamplesRes>()
-//         .add_plugins((
-//             DefaultPlugins,
-//             EguiPlugin,
-//             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
-//             RapierDebugRenderPlugin::default(),
-//             WorldInspectorPlugin::new(),
-//         ))
-//         .register_type::<Examples>()
-//         .register_type::<ExamplesRes>()
-//         .register_type::<ExampleSelected>()
-//         .init_state::<Examples>()
-//         .insert_resource(ExampleSet(vec![
-//             (Examples::Boxes2, "Boxes3").into(),
-//             (Examples::RopeJoint2, "RopeJoint2").into(),
-//             (Examples::DebugDespawn2, "DebugDespawn2").into(),
-//             (Examples::Despawn2, "Despawn3").into(),
-//             (Examples::Events2, "Events3").into(),
-//             (Examples::Joints2, "Joints3").into(),
-//             (Examples::JointsDespawn2, "JointsDespawn3").into(),
-//             (Examples::LockedRotations2, "LockedRotations3").into(),
-//             (Examples::MultipleColliders2, "MultipleColliders3").into(),
-//             (Examples::PlayerMovement2, "PlayerMovement2").into(),
-//         ]))
-//         .init_resource::<ExampleSelected>()
-//         //
-//         //boxes2
-//         .add_systems(
-//             OnEnter(Examples::Boxes2),
-//             (boxes2::setup_graphics, boxes2::setup_physics),
-//         )
-//         .add_systems(OnExit(Examples::Boxes2), cleanup)
-//         //
-//         // Debug toggle
-//         .add_systems(
-//             OnEnter(Examples::DebugToggle2),
-//             (debug_toggle2::setup_graphics, debug_toggle2::setup_physics),
-//         )
-//         .add_systems(
-//             Update,
-//             (
-//                 debug_toggle2::toggle_debug,
-//                 (|mut debug_render_context: ResMut<DebugRenderContext>| {
-//                     debug_render_context.enabled = !debug_render_context.enabled;
-//                 })
-//                 .run_if(debug_toggle2::input_just_pressed(KeyCode::KeyV)),
-//             )
-//                 .run_if(in_state(Examples::DebugToggle2)),
-//         )
-//         .add_systems(OnExit(Examples::DebugToggle2), cleanup)
-//         //
-//         // rope joint
-//         .add_systems(
-//             OnEnter(Examples::RopeJoint2),
-//             (rope_joint2::setup_graphics, rope_joint2::setup_physics),
-//         )
-//         .add_systems(OnExit(Examples::RopeJoint2), cleanup)
-//         //
-//         //debug despawn
-//         .init_resource::<debug_despawn2::Game>()
-//         .add_systems(OnEnter(Examples::DebugDespawn2), debug_despawn2::setup_game)
-//         .add_systems(
-//             Update,
-//             debug_despawn2::cube_sleep_detection.run_if(in_state(Examples::DebugDespawn2)),
-//         )
-//         .add_systems(OnExit(Examples::DebugDespawn2), cleanup)
-//         //
-//         //despawn2
-//         .insert_resource(despawn2::DespawnResource::default())
-//         .insert_resource(despawn2::ResizeResource::default())
-//         .add_systems(
-//             OnEnter(Examples::Despawn2),
-//             (despawn2::setup_graphics, despawn2::setup_physics),
-//         )
-//         .add_systems(
-//             Update,
-//             (despawn2::despawn, despawn2::resize).run_if(in_state(Examples::Despawn2)),
-//         )
-//         .add_systems(OnExit(Examples::Despawn2), cleanup)
-//         //
-//         //events
-//         .add_systems(
-//             OnEnter(Examples::Events2),
-//             (events2::setup_graphics, events2::setup_physics),
-//         )
-//         .add_systems(
-//             Update,
-//             events2::display_events.run_if(in_state(Examples::Events2)),
-//         )
-//         .add_systems(OnExit(Examples::Events2), cleanup)
-//         //
-//         //events
-//         .add_systems(
-//             OnEnter(Examples::Joints2),
-//             (joints2::setup_graphics, joints2::setup_physics),
-//         )
-//         .add_systems(OnExit(Examples::Joints2), cleanup)
-//         //
-//         //despawn2
-//         .insert_resource(joints_despawn2::DespawnResource::default())
-//         .add_systems(
-//             OnEnter(Examples::JointsDespawn2),
-//             (
-//                 joints_despawn2::setup_graphics,
-//                 joints_despawn2::setup_physics,
-//             ),
-//         )
-//         .add_systems(
-//             Update,
-//             (joints_despawn2::despawn).run_if(in_state(Examples::JointsDespawn2)),
-//         )
-//         .add_systems(OnExit(Examples::JointsDespawn2), cleanup)
-//         //
-//         //locked rotations
-//         .add_systems(
-//             OnEnter(Examples::LockedRotations2),
-//             (
-//                 locked_rotations2::setup_graphics,
-//                 locked_rotations2::setup_physics,
-//             ),
-//         )
-//         .add_systems(OnExit(Examples::LockedRotations2), cleanup)
-//         //
-//         //multiple colliders
-//         .add_systems(
-//             OnEnter(Examples::MultipleColliders2),
-//             (
-//                 multiple_colliders2::setup_graphics,
-//                 multiple_colliders2::setup_physics,
-//             ),
-//         )
-//         .add_systems(OnExit(Examples::MultipleColliders2), cleanup)
-//         //
-//         //player movement
-//         .add_systems(
-//             OnEnter(Examples::PlayerMovement2),
-//             player_movement2::spawn_player,
-//         )
-//         .add_systems(
-//             Update,
-//             (player_movement2::player_movement).run_if(in_state(Examples::PlayerMovement2)),
-//         )
-//         .add_systems(
-//             OnExit(Examples::PlayerMovement2),
-//             (
-//                 cleanup,
-//                 |mut rapier_config: Query<&mut RapierConfiguration>,
-//                  ctxt: ReadRapierContext|
-//                  -> Result<()> {
-//                     let mut rapier_config = rapier_config.single_mut()?;
-//                     rapier_config.gravity = RapierConfiguration::new(
-//                         ctxt.single()?.simulation.integration_parameters.length_unit,
-//                     )
-//                     .gravity;
-//                     Ok(())
-//                 },
-//             ),
-//         )
-//         //
-//         //testbed
-//         .add_systems(
-//             OnEnter(Examples::None),
-//             |mut next_state: ResMut<NextState<Examples>>| {
-//                 next_state.set(Examples::Boxes2);
-//             },
-//         )
-//         .add_systems(OnExit(Examples::None), init)
-//         .add_systems(
-//             Update,
-//             (
-//                 ui_example_system,
-//                 change_example.run_if(resource_changed::<ExampleSelected>),
-//             )
-//                 .chain(),
-//         );
+    let mut app = App::new();
+    app.init_resource::<ExamplesRes>()
+        .add_plugins((
+            DefaultPlugins,
+            EguiPlugin {
+                enable_multipass_for_primary_context: false,
+            },
+            RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
+            RapierDebugRenderPlugin::default(),
+            WorldInspectorPlugin::new(),
+        ))
+        .register_type::<Examples>()
+        .register_type::<ExamplesRes>()
+        .register_type::<ExampleSelected>()
+        .init_state::<Examples>()
+        .insert_resource(ExampleSet(vec![
+            (Examples::Boxes2, "Boxes3").into(),
+            (Examples::RopeJoint2, "RopeJoint2").into(),
+            (Examples::DebugDespawn2, "DebugDespawn2").into(),
+            (Examples::Despawn2, "Despawn3").into(),
+            (Examples::Events2, "Events3").into(),
+            (Examples::Joints2, "Joints3").into(),
+            (Examples::JointsDespawn2, "JointsDespawn3").into(),
+            (Examples::LockedRotations2, "LockedRotations3").into(),
+            (Examples::MultipleColliders2, "MultipleColliders3").into(),
+            (Examples::PlayerMovement2, "PlayerMovement2").into(),
+        ]))
+        .init_resource::<ExampleSelected>()
+        //
+        //boxes2
+        .add_systems(
+            OnEnter(Examples::Boxes2),
+            (boxes2::setup_graphics, boxes2::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Boxes2), cleanup)
+        //
+        // Debug toggle
+        .add_systems(
+            OnEnter(Examples::DebugToggle2),
+            (debug_toggle2::setup_graphics, debug_toggle2::setup_physics),
+        )
+        .add_systems(
+            Update,
+            (
+                debug_toggle2::toggle_debug,
+                (|mut debug_render_context: ResMut<DebugRenderContext>| {
+                    debug_render_context.enabled = !debug_render_context.enabled;
+                })
+                .run_if(debug_toggle2::input_just_pressed(KeyCode::KeyV)),
+            )
+                .run_if(in_state(Examples::DebugToggle2)),
+        )
+        .add_systems(OnExit(Examples::DebugToggle2), cleanup)
+        //
+        // rope joint
+        .add_systems(
+            OnEnter(Examples::RopeJoint2),
+            (rope_joint2::setup_graphics, rope_joint2::setup_physics),
+        )
+        .add_systems(OnExit(Examples::RopeJoint2), cleanup)
+        //
+        //debug despawn
+        .init_resource::<debug_despawn2::Game>()
+        .add_systems(OnEnter(Examples::DebugDespawn2), debug_despawn2::setup_game)
+        .add_systems(
+            Update,
+            debug_despawn2::cube_sleep_detection.run_if(in_state(Examples::DebugDespawn2)),
+        )
+        .add_systems(OnExit(Examples::DebugDespawn2), cleanup)
+        //
+        //despawn2
+        .insert_resource(despawn2::DespawnResource::default())
+        .insert_resource(despawn2::ResizeResource::default())
+        .add_systems(
+            OnEnter(Examples::Despawn2),
+            (despawn2::setup_graphics, despawn2::setup_physics),
+        )
+        .add_systems(
+            Update,
+            (despawn2::despawn, despawn2::resize).run_if(in_state(Examples::Despawn2)),
+        )
+        .add_systems(OnExit(Examples::Despawn2), cleanup)
+        //
+        //events
+        .add_systems(
+            OnEnter(Examples::Events2),
+            (events2::setup_graphics, events2::setup_physics),
+        )
+        .add_systems(
+            Update,
+            events2::display_events.run_if(in_state(Examples::Events2)),
+        )
+        .add_systems(OnExit(Examples::Events2), cleanup)
+        //
+        //events
+        .add_systems(
+            OnEnter(Examples::Joints2),
+            (joints2::setup_graphics, joints2::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Joints2), cleanup)
+        //
+        //despawn2
+        .insert_resource(joints_despawn2::DespawnResource::default())
+        .add_systems(
+            OnEnter(Examples::JointsDespawn2),
+            (
+                joints_despawn2::setup_graphics,
+                joints_despawn2::setup_physics,
+            ),
+        )
+        .add_systems(
+            Update,
+            (joints_despawn2::despawn).run_if(in_state(Examples::JointsDespawn2)),
+        )
+        .add_systems(OnExit(Examples::JointsDespawn2), cleanup)
+        //
+        //locked rotations
+        .add_systems(
+            OnEnter(Examples::LockedRotations2),
+            (
+                locked_rotations2::setup_graphics,
+                locked_rotations2::setup_physics,
+            ),
+        )
+        .add_systems(OnExit(Examples::LockedRotations2), cleanup)
+        //
+        //multiple colliders
+        .add_systems(
+            OnEnter(Examples::MultipleColliders2),
+            (
+                multiple_colliders2::setup_graphics,
+                multiple_colliders2::setup_physics,
+            ),
+        )
+        .add_systems(OnExit(Examples::MultipleColliders2), cleanup)
+        //
+        //player movement
+        .add_systems(
+            OnEnter(Examples::PlayerMovement2),
+            player_movement2::spawn_player,
+        )
+        .add_systems(
+            Update,
+            (player_movement2::player_movement).run_if(in_state(Examples::PlayerMovement2)),
+        )
+        .add_systems(
+            OnExit(Examples::PlayerMovement2),
+            (
+                cleanup,
+                |mut rapier_config: Query<&mut RapierConfiguration>,
+                 ctxt: ReadRapierContext|
+                 -> Result<()> {
+                    let mut rapier_config = rapier_config.single_mut()?;
+                    rapier_config.gravity = RapierConfiguration::new(
+                        ctxt.single()?.simulation.integration_parameters.length_unit,
+                    )
+                    .gravity;
+                    Ok(())
+                },
+            ),
+        )
+        //
+        //testbed
+        .add_systems(
+            OnEnter(Examples::None),
+            |mut next_state: ResMut<NextState<Examples>>| {
+                next_state.set(Examples::Boxes2);
+            },
+        )
+        .add_systems(OnExit(Examples::None), init)
+        .add_systems(
+            Update,
+            (
+                ui_example_system,
+                change_example.run_if(resource_changed::<ExampleSelected>),
+            )
+                .chain(),
+        );
 
-//     app.run();
-// }
+    app.run();
+}
 
-// fn init(world: &mut World) {
-//     //save all entities that are in the world before setting up any example
-//     // to be able to always return to this state when switching from one example to the other
-//     world.resource_mut::<ExamplesRes>().entities_before =
-//         world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
-// }
+fn init(world: &mut World) {
+    //save all entities that are in the world before setting up any example
+    // to be able to always return to this state when switching from one example to the other
+    world.resource_mut::<ExamplesRes>().entities_before =
+        world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+}
 
-// fn cleanup(world: &mut World) {
-//     let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
+fn cleanup(world: &mut World) {
+    let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
 
-//     let remove = world
-//         .iter_entities()
-//         .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
-//         .collect::<Vec<_>>();
+    let remove = world
+        .iter_entities()
+        .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
+        .collect::<Vec<_>>();
 
-//     for r in remove {
-//         world.despawn(r);
-//     }
-// }
+    for r in remove {
+        world.despawn(r);
+    }
+}
 
-// fn change_example(
-//     example_selected: Res<ExampleSelected>,
-//     examples_available: Res<ExampleSet>,
-//     mut next_state: ResMut<NextState<Examples>>,
-// ) {
-//     next_state.set(examples_available.0[example_selected.0].state);
-// }
+fn change_example(
+    example_selected: Res<ExampleSelected>,
+    examples_available: Res<ExampleSet>,
+    mut next_state: ResMut<NextState<Examples>>,
+) {
+    next_state.set(examples_available.0[example_selected.0].state);
+}
 
-// fn ui_example_system(
-//     mut contexts: EguiContexts,
-//     mut current_example: ResMut<ExampleSelected>,
-//     examples_available: Res<ExampleSet>,
-// ) {
-//     egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
-//         let mut changed = false;
-//         egui::ComboBox::from_label("example")
-//             .width(150.0)
-//             .selected_text(examples_available.0[current_example.0].name)
-//             .show_ui(ui, |ui| {
-//                 for (id, value) in examples_available.0.iter().enumerate() {
-//                     changed = ui
-//                         .selectable_value(&mut current_example.0, id, value.name)
-//                         .changed()
-//                         || changed;
-//                 }
-//             });
-//         if ui.button("Next").clicked() {
-//             current_example.0 = (current_example.0 + 1) % examples_available.0.len();
-//         }
-//     });
+fn ui_example_system(
+    mut contexts: EguiContexts,
+    mut current_example: ResMut<ExampleSelected>,
+    examples_available: Res<ExampleSet>,
+) {
+    egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
+        let mut changed = false;
+        egui::ComboBox::from_label("example")
+            .width(150.0)
+            .selected_text(examples_available.0[current_example.0].name)
+            .show_ui(ui, |ui| {
+                for (id, value) in examples_available.0.iter().enumerate() {
+                    changed = ui
+                        .selectable_value(&mut current_example.0, id, value.name)
+                        .changed()
+                        || changed;
+                }
+            });
+        if ui.button("Next").clicked() {
+            current_example.0 = (current_example.0 + 1) % examples_available.0.len();
+        }
+    });
 }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -85,8 +85,8 @@ bevy = { version = "0.16.0", default-features = false, features = [
 ] }
 approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
-bevy-inspector-egui = "0.30"
-bevy_egui = "0.33"
+bevy-inspector-egui = "0.31"
+bevy_egui = "0.34"
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -84,7 +84,7 @@ bevy = { version = "0.16.0-rc.1", default-features = false, features = [
     "default_font",
 ] }
 approx = "0.5.1"
-glam = { version = "0.30", features = ["approx"] }
+glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.30"
 bevy_egui = "0.33"
 

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -65,7 +65,7 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.16.0-rc.1", default-features = false, features = ["std"] }
+bevy = { version = "0.16.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
 rapier3d = "0.23"
 bitflags = "2.4"
@@ -73,7 +73,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.1", default-features = false, features = [
+bevy = { version = "0.16.0", default-features = false, features = [
     "bevy_window",
     "x11",
     "tonemapping_luts",

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -65,7 +65,7 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
+bevy = { version = "0.16.0-rc.1", default-features = false, features = ["std"] }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
 rapier3d = "0.23"
 bitflags = "2.4"
@@ -73,7 +73,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-rc.1", default-features = false, features = [
     "bevy_window",
     "x11",
     "tonemapping_luts",
@@ -84,9 +84,9 @@ bevy = { version = "0.15", default-features = false, features = [
     "default_font",
 ] }
 approx = "0.5.1"
-glam = { version = "0.29", features = ["approx"] }
-bevy-inspector-egui = "0.28"
-bevy_egui = "0.31"
+glam = { version = "0.30", features = ["approx"] }
+bevy-inspector-egui = "0.30"
+bevy_egui = "0.33"
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier3d/examples/character_controller3.rs
+++ b/bevy_rapier3d/examples/character_controller3.rs
@@ -152,7 +152,7 @@ fn player_movement(
     mut vertical_movement: Local<f32>,
     mut grounded_timer: Local<f32>,
 ) {
-    let Ok((transform, mut controller, output)) = player.get_single_mut() else {
+    let Ok((transform, mut controller, output)) = player.single_mut() else {
         return;
     };
     let delta_time = time.delta_secs();
@@ -185,11 +185,11 @@ fn player_look(
     mut camera: Query<&mut Transform, With<Camera>>,
     input: Res<LookInput>,
 ) {
-    let Ok(mut transform) = player.get_single_mut() else {
+    let Ok(mut transform) = player.single_mut() else {
         return;
     };
     transform.rotation = Quat::from_axis_angle(Vec3::Y, input.x.to_radians());
-    let Ok(mut transform) = camera.get_single_mut() else {
+    let Ok(mut transform) = camera.single_mut() else {
         return;
     };
     transform.rotation = Quat::from_axis_angle(Vec3::X, input.y.to_radians());

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -1,4 +1,4 @@
-use bevy::{core::FrameCount, prelude::*, transform::TransformSystem};
+use bevy::{diagnostic::FrameCount, prelude::*, transform::TransformSystem};
 use bevy_rapier3d::prelude::*;
 
 fn main() {

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -281,17 +281,16 @@ pub fn setup_physics(mut commands: Commands) {
 pub fn print_impulse_revolute_joints(
     context: ReadRapierContext,
     joints: Query<(Entity, &ImpulseJoint)>,
-) {
+) -> Result<()> {
     for (entity, impulse_joint) in joints.iter() {
         if let TypedJoint::RevoluteJoint(_revolute_joint) = &impulse_joint.data {
             println!(
                 "angle for {}: {:?}",
                 entity,
-                context
-                    .single()
-                    .unwrap()
-                    .impulse_revolute_joint_angle(entity),
+                context.single()?.impulse_revolute_joint_angle(entity),
             );
         }
     }
+
+    Ok(())
 }

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -287,7 +287,10 @@ pub fn print_impulse_revolute_joints(
             println!(
                 "angle for {}: {:?}",
                 entity,
-                context.single().impulse_revolute_joint_angle(entity),
+                context
+                    .single()
+                    .unwrap()
+                    .impulse_revolute_joint_angle(entity),
             );
         }
     }

--- a/bevy_rapier3d/examples/multi_contexts3.rs
+++ b/bevy_rapier3d/examples/multi_contexts3.rs
@@ -63,7 +63,7 @@ fn change_context(
     query_context: Query<Entity, With<DefaultRapierContext>>,
     mut query_links: Query<(Entity, &mut RapierContextEntityLink)>,
 ) {
-    let default_context = query_context.single();
+    let default_context = query_context.single().unwrap();
     for (e, mut link) in query_links.iter_mut() {
         if link.0 == default_context {
             continue;

--- a/bevy_rapier3d/examples/multi_contexts3.rs
+++ b/bevy_rapier3d/examples/multi_contexts3.rs
@@ -62,8 +62,8 @@ fn move_platforms(time: Res<Time>, mut query: Query<(&mut Transform, &Platform)>
 fn change_context(
     query_context: Query<Entity, With<DefaultRapierContext>>,
     mut query_links: Query<(Entity, &mut RapierContextEntityLink)>,
-) {
-    let default_context = query_context.single().unwrap();
+) -> Result<()> {
+    let default_context = query_context.single()?;
     for (e, mut link) in query_links.iter_mut() {
         if link.0 == default_context {
             continue;
@@ -71,6 +71,8 @@ fn change_context(
         link.0 = default_context;
         println!("changing context of {} for context {}", e, link.0);
     }
+
+    Ok(())
 }
 
 pub fn setup_physics(

--- a/bevy_rapier3d/examples/picking3.rs
+++ b/bevy_rapier3d/examples/picking3.rs
@@ -47,13 +47,13 @@ pub fn setup_physics(mut commands: Commands) {
         .observe(on_click_spawn_cube)
         .observe(
             |out: Trigger<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
-                let mut text_color = texts.get_mut(out.entity()).unwrap();
+                let mut text_color = texts.get_mut(out.target()).unwrap();
                 text_color.0 = Color::WHITE;
             },
         )
         .observe(
             |over: Trigger<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
-                let mut color = texts.get_mut(over.entity()).unwrap();
+                let mut color = texts.get_mut(over.target()).unwrap();
                 color.0 = bevy::color::palettes::tailwind::CYAN_400.into();
             },
         );
@@ -93,7 +93,7 @@ fn on_click_spawn_cube(
 }
 
 fn on_drag_rotate(drag: Trigger<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
-    if let Ok(mut transform) = transforms.get_mut(drag.entity()) {
+    if let Ok(mut transform) = transforms.get_mut(drag.target()) {
         transform.rotate_y(drag.delta.x * 0.02);
         transform.rotate_x(drag.delta.y * 0.02);
     }

--- a/bevy_rapier3d/examples/rapier_context_component.rs
+++ b/bevy_rapier3d/examples/rapier_context_component.rs
@@ -20,11 +20,13 @@ fn main() {
 fn display_nb_colliders(
     query_context: Query<&RapierContextColliders, With<DefaultRapierContext>>,
     mut exit: EventWriter<AppExit>,
-) {
-    let nb_colliders = query_context.single().unwrap().colliders.len();
+) -> Result<()> {
+    let nb_colliders = query_context.single()?.colliders.len();
     println!("There are {nb_colliders} colliders.");
     assert!(nb_colliders > 0);
     exit.write(AppExit::Success);
+
+    Ok(())
 }
 
 pub fn setup_physics(mut commands: Commands) {

--- a/bevy_rapier3d/examples/rapier_context_component.rs
+++ b/bevy_rapier3d/examples/rapier_context_component.rs
@@ -21,7 +21,7 @@ fn display_nb_colliders(
     query_context: Query<&RapierContextColliders, With<DefaultRapierContext>>,
     mut exit: EventWriter<AppExit>,
 ) {
-    let nb_colliders = query_context.single().colliders.len();
+    let nb_colliders = query_context.single().unwrap().colliders.len();
     println!("There are {nb_colliders} colliders.");
     assert!(nb_colliders > 0);
     exit.write(AppExit::Success);

--- a/bevy_rapier3d/examples/rapier_context_component.rs
+++ b/bevy_rapier3d/examples/rapier_context_component.rs
@@ -24,7 +24,7 @@ fn display_nb_colliders(
     let nb_colliders = query_context.single().colliders.len();
     println!("There are {nb_colliders} colliders.");
     assert!(nb_colliders > 0);
-    exit.send(AppExit::Success);
+    exit.write(AppExit::Success);
 }
 
 pub fn setup_physics(mut commands: Commands) {

--- a/bevy_rapier3d/examples/rapier_to_bevy_mesh.rs
+++ b/bevy_rapier3d/examples/rapier_to_bevy_mesh.rs
@@ -12,7 +12,7 @@ fn main() {
             DefaultPlugins,
             RapierPhysicsPlugin::<NoUserData>::default(),
             RapierDebugRenderPlugin::default(),
-            WireframePlugin,
+            WireframePlugin::default(),
         ))
         .add_systems(Startup, (setup_graphics, setup_physics))
         .add_systems(Update, (toggle_wireframe, toggle_dynamic, rotate))

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -78,7 +78,7 @@ pub fn cast_ray(
     rapier_context: ReadRapierContext,
     cameras: Query<(&Camera, &GlobalTransform)>,
 ) {
-    let window = windows.single();
+    let window = windows.single().unwrap();
 
     let Some(cursor_position) = window.cursor_position() else {
         return;
@@ -90,7 +90,7 @@ pub fn cast_ray(
         let Ok(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
             return;
         };
-        let context = rapier_context.single();
+        let context = rapier_context.single().unwrap();
         // Then cast the ray.
         let hit = context.cast_ray(
             ray.origin,

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -77,20 +77,20 @@ pub fn cast_ray(
     windows: Query<&Window, With<PrimaryWindow>>,
     rapier_context: ReadRapierContext,
     cameras: Query<(&Camera, &GlobalTransform)>,
-) {
-    let window = windows.single().unwrap();
+) -> Result<()> {
+    let window = windows.single()?;
 
     let Some(cursor_position) = window.cursor_position() else {
-        return;
+        return Err(BevyError::from("Cursor is outside the window area"));
     };
 
     // We will color in read the colliders hovered by the mouse.
     for (camera, camera_transform) in &cameras {
         // First, compute a ray from the mouse position.
         let Ok(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
-            return;
+            return Err(BevyError::from("Unable to compute ray from mouse position"));
         };
-        let context = rapier_context.single().unwrap();
+        let context = rapier_context.single()?;
         // Then cast the ray.
         let hit = context.cast_ray(
             ray.origin,
@@ -108,4 +108,6 @@ pub fn cast_ray(
             commands.entity(entity).insert(ColliderDebugColor(color));
         }
     }
+
+    Ok(())
 }

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -74,21 +74,21 @@ pub fn setup_physics(mut commands: Commands) {
 
 pub fn cast_ray(
     mut commands: Commands,
-    windows: Query<&Window, With<PrimaryWindow>>,
+    window: Single<&Window, With<PrimaryWindow>>,
     rapier_context: ReadRapierContext,
     cameras: Query<(&Camera, &GlobalTransform)>,
 ) -> Result<()> {
-    let window = windows.single()?;
-
     let Some(cursor_position) = window.cursor_position() else {
-        return Err(BevyError::from("Cursor is outside the window area"));
+        log::warn!("Cursor is outside the window area");
+        return Ok(());
     };
 
     // We will color in read the colliders hovered by the mouse.
     for (camera, camera_transform) in &cameras {
         // First, compute a ray from the mouse position.
         let Ok(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
-            return Err(BevyError::from("Unable to compute ray from mouse position"));
+            log::warn!("Unable to compute ray from mouse position");
+            return Ok(());
         };
         let context = rapier_context.single()?;
         // Then cast the ray.

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -1,284 +1,285 @@
-// FIXME: Uncomment plugins once `bevy_egui` and `bevy_inspector_egui` get updated to be compatible with bevy 0.16
-// #![allow(dead_code)]
+#![allow(dead_code)]
 
-// mod boxes3;
-// mod debug_toggle3;
-// mod despawn3;
-// mod events3;
-// mod joints3;
-// mod joints_despawn3;
-// mod locked_rotations3;
-// mod multiple_colliders3;
-// mod picking3;
-// mod ray_casting3;
-// mod static_trimesh3;
+mod boxes3;
+mod debug_toggle3;
+mod despawn3;
+mod events3;
+mod joints3;
+mod joints_despawn3;
+mod locked_rotations3;
+mod multiple_colliders3;
+mod picking3;
+mod ray_casting3;
+mod static_trimesh3;
 
-// use bevy::prelude::*;
-// use bevy_egui::{egui, EguiContexts, EguiPlugin};
-// use bevy_inspector_egui::quick::WorldInspectorPlugin;
-// use bevy_rapier3d::prelude::*;
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_rapier3d::prelude::*;
 
-// #[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
-// pub enum Examples {
-//     #[default]
-//     None,
-//     Boxes3,
-//     DebugToggle3,
-//     Despawn3,
-//     Events3,
-//     Joints3,
-//     JointsDespawn3,
-//     LockedRotations3,
-//     MultipleColliders3,
-//     Picking3,
-//     Raycasting3,
-//     StaticTrimesh3,
-// }
+#[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
+pub enum Examples {
+    #[default]
+    None,
+    Boxes3,
+    DebugToggle3,
+    Despawn3,
+    Events3,
+    Joints3,
+    JointsDespawn3,
+    LockedRotations3,
+    MultipleColliders3,
+    Picking3,
+    Raycasting3,
+    StaticTrimesh3,
+}
 
-// #[derive(Resource, Default, Reflect)]
-// struct ExamplesRes {
-//     entities_before: Vec<Entity>,
-// }
+#[derive(Resource, Default, Reflect)]
+struct ExamplesRes {
+    entities_before: Vec<Entity>,
+}
 
-// #[derive(Resource, Debug, Default, Reflect)]
-// struct ExampleSelected(pub usize);
+#[derive(Resource, Debug, Default, Reflect)]
+struct ExampleSelected(pub usize);
 
-// #[derive(Debug, Reflect)]
-// struct ExampleDefinition {
-//     pub state: Examples,
-//     pub name: &'static str,
-// }
+#[derive(Debug, Reflect)]
+struct ExampleDefinition {
+    pub state: Examples,
+    pub name: &'static str,
+}
 
-// impl From<(Examples, &'static str)> for ExampleDefinition {
-//     fn from((state, name): (Examples, &'static str)) -> Self {
-//         Self { state, name }
-//     }
-// }
+impl From<(Examples, &'static str)> for ExampleDefinition {
+    fn from((state, name): (Examples, &'static str)) -> Self {
+        Self { state, name }
+    }
+}
 
-// #[derive(Resource, Debug, Reflect)]
-// struct ExampleSet(pub Vec<ExampleDefinition>);
+#[derive(Resource, Debug, Reflect)]
+struct ExampleSet(pub Vec<ExampleDefinition>);
 
 fn main() {
-//     let mut app = App::new();
-//     app.init_resource::<ExamplesRes>()
-//         .add_plugins((
-//             DefaultPlugins,
-//             EguiPlugin,
-//             RapierPhysicsPlugin::<NoUserData>::default(),
-//             RapierDebugRenderPlugin::default(),
-//             WorldInspectorPlugin::new(),
-//             RapierPickingPlugin,
-//         ))
-//         .register_type::<Examples>()
-//         .register_type::<ExamplesRes>()
-//         .register_type::<ExampleSelected>()
-//         .init_state::<Examples>()
-//         .insert_resource(ExampleSet(vec![
-//             (Examples::Boxes3, "Boxes3").into(),
-//             (Examples::DebugToggle3, "DebugToggle3").into(),
-//             (Examples::Despawn3, "Despawn3").into(),
-//             (Examples::Events3, "Events3").into(),
-//             (Examples::Joints3, "Joints3").into(),
-//             (Examples::JointsDespawn3, "JointsDespawn3").into(),
-//             (Examples::LockedRotations3, "LockedRotations3").into(),
-//             (Examples::MultipleColliders3, "MultipleColliders3").into(),
-//             (Examples::Picking3, "Picking3").into(),
-//             (Examples::Raycasting3, "Raycasting3").into(),
-//             (Examples::StaticTrimesh3, "StaticTrimesh3").into(),
-//         ]))
-//         .init_resource::<ExampleSelected>()
-//         //
-//         //boxes2
-//         .add_systems(
-//             OnEnter(Examples::Boxes3),
-//             (boxes3::setup_graphics, boxes3::setup_physics),
-//         )
-//         .add_systems(OnExit(Examples::Boxes3), cleanup)
-//         //
-//         // Debug toggle
-//         .add_systems(
-//             OnEnter(Examples::DebugToggle3),
-//             (debug_toggle3::setup_graphics, debug_toggle3::setup_physics),
-//         )
-//         .add_systems(
-//             Update,
-//             (
-//                 debug_toggle3::toggle_debug,
-//                 (|mut debug_render_context: ResMut<DebugRenderContext>| {
-//                     debug_render_context.enabled = !debug_render_context.enabled;
-//                 })
-//                 .run_if(debug_toggle3::input_just_pressed(KeyCode::KeyV)),
-//             )
-//                 .run_if(in_state(Examples::DebugToggle3)),
-//         )
-//         .add_systems(OnExit(Examples::DebugToggle3), cleanup)
-//         //
-//         // despawn
-//         .init_resource::<despawn3::DespawnResource>()
-//         .add_systems(
-//             OnEnter(Examples::Despawn3),
-//             (despawn3::setup_graphics, despawn3::setup_physics),
-//         )
-//         .add_systems(
-//             Update,
-//             despawn3::despawn.run_if(in_state(Examples::Despawn3)),
-//         )
-//         .add_systems(OnExit(Examples::Despawn3), cleanup)
-//         //
-//         // events
-//         .add_systems(
-//             OnEnter(Examples::Events3),
-//             (events3::setup_graphics, events3::setup_physics),
-//         )
-//         .add_systems(
-//             Update,
-//             events3::display_events.run_if(in_state(Examples::Events3)),
-//         )
-//         .add_systems(OnExit(Examples::Events3), cleanup)
-//         //
-//         // joints
-//         .add_systems(
-//             OnEnter(Examples::Joints3),
-//             (joints3::setup_graphics, joints3::setup_physics),
-//         )
-//         .add_systems(OnExit(Examples::Joints3), cleanup)
-//         //
-//         // joints despawn
-//         .init_resource::<joints_despawn3::DespawnResource>()
-//         .add_systems(
-//             OnEnter(Examples::JointsDespawn3),
-//             (
-//                 joints_despawn3::setup_graphics,
-//                 joints_despawn3::setup_physics,
-//             ),
-//         )
-//         .add_systems(
-//             Update,
-//             joints_despawn3::despawn.run_if(in_state(Examples::JointsDespawn3)),
-//         )
-//         .add_systems(OnExit(Examples::JointsDespawn3), cleanup)
-//         //
-//         // locked rotations
-//         .add_systems(
-//             OnEnter(Examples::LockedRotations3),
-//             (
-//                 locked_rotations3::setup_graphics,
-//                 locked_rotations3::setup_physics,
-//             ),
-//         )
-//         .add_systems(OnExit(Examples::LockedRotations3), cleanup)
-//         //
-//         // multiple colliders
-//         .add_systems(
-//             OnEnter(Examples::MultipleColliders3),
-//             (
-//                 multiple_colliders3::setup_graphics,
-//                 multiple_colliders3::setup_physics,
-//             ),
-//         )
-//         .add_systems(OnExit(Examples::MultipleColliders3), cleanup)
-//         //
-//         // picking
-//         .add_systems(
-//             OnEnter(Examples::Picking3),
-//             (picking3::setup_graphics, picking3::setup_physics),
-//         )
-//         .add_systems(OnExit(Examples::Picking3), cleanup)
-//         //
-//         // raycasting
-//         .add_systems(
-//             OnEnter(Examples::Raycasting3),
-//             (ray_casting3::setup_graphics, ray_casting3::setup_physics),
-//         )
-//         .add_systems(
-//             Update,
-//             ray_casting3::cast_ray.run_if(in_state(Examples::Raycasting3)),
-//         )
-//         .add_systems(OnExit(Examples::Raycasting3), cleanup)
-//         //
-//         // static trimesh
-//         .init_resource::<static_trimesh3::BallState>()
-//         .add_systems(
-//             OnEnter(Examples::StaticTrimesh3),
-//             (
-//                 static_trimesh3::setup_graphics,
-//                 static_trimesh3::setup_physics,
-//             ),
-//         )
-//         .add_systems(
-//             Update,
-//             static_trimesh3::ball_spawner.run_if(in_state(Examples::StaticTrimesh3)),
-//         )
-//         .add_systems(OnExit(Examples::StaticTrimesh3), cleanup)
-//         //
-//         //testbed
-//         .add_systems(
-//             OnEnter(Examples::None),
-//             |mut next_state: ResMut<NextState<Examples>>| {
-//                 next_state.set(Examples::Boxes3);
-//             },
-//         )
-//         .add_systems(OnExit(Examples::None), init)
-//         .add_systems(
-//             Update,
-//             (
-//                 ui_example_system,
-//                 change_example.run_if(resource_changed::<ExampleSelected>),
-//             )
-//                 .chain(),
-//         );
+    let mut app = App::new();
+    app.init_resource::<ExamplesRes>()
+        .add_plugins((
+            DefaultPlugins,
+            EguiPlugin {
+                enable_multipass_for_primary_context: false,
+            },
+            RapierPhysicsPlugin::<NoUserData>::default(),
+            RapierDebugRenderPlugin::default(),
+            WorldInspectorPlugin::new(),
+            RapierPickingPlugin,
+        ))
+        .register_type::<Examples>()
+        .register_type::<ExamplesRes>()
+        .register_type::<ExampleSelected>()
+        .init_state::<Examples>()
+        .insert_resource(ExampleSet(vec![
+            (Examples::Boxes3, "Boxes3").into(),
+            (Examples::DebugToggle3, "DebugToggle3").into(),
+            (Examples::Despawn3, "Despawn3").into(),
+            (Examples::Events3, "Events3").into(),
+            (Examples::Joints3, "Joints3").into(),
+            (Examples::JointsDespawn3, "JointsDespawn3").into(),
+            (Examples::LockedRotations3, "LockedRotations3").into(),
+            (Examples::MultipleColliders3, "MultipleColliders3").into(),
+            (Examples::Picking3, "Picking3").into(),
+            (Examples::Raycasting3, "Raycasting3").into(),
+            (Examples::StaticTrimesh3, "StaticTrimesh3").into(),
+        ]))
+        .init_resource::<ExampleSelected>()
+        //
+        //boxes2
+        .add_systems(
+            OnEnter(Examples::Boxes3),
+            (boxes3::setup_graphics, boxes3::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Boxes3), cleanup)
+        //
+        // Debug toggle
+        .add_systems(
+            OnEnter(Examples::DebugToggle3),
+            (debug_toggle3::setup_graphics, debug_toggle3::setup_physics),
+        )
+        .add_systems(
+            Update,
+            (
+                debug_toggle3::toggle_debug,
+                (|mut debug_render_context: ResMut<DebugRenderContext>| {
+                    debug_render_context.enabled = !debug_render_context.enabled;
+                })
+                .run_if(debug_toggle3::input_just_pressed(KeyCode::KeyV)),
+            )
+                .run_if(in_state(Examples::DebugToggle3)),
+        )
+        .add_systems(OnExit(Examples::DebugToggle3), cleanup)
+        //
+        // despawn
+        .init_resource::<despawn3::DespawnResource>()
+        .add_systems(
+            OnEnter(Examples::Despawn3),
+            (despawn3::setup_graphics, despawn3::setup_physics),
+        )
+        .add_systems(
+            Update,
+            despawn3::despawn.run_if(in_state(Examples::Despawn3)),
+        )
+        .add_systems(OnExit(Examples::Despawn3), cleanup)
+        //
+        // events
+        .add_systems(
+            OnEnter(Examples::Events3),
+            (events3::setup_graphics, events3::setup_physics),
+        )
+        .add_systems(
+            Update,
+            events3::display_events.run_if(in_state(Examples::Events3)),
+        )
+        .add_systems(OnExit(Examples::Events3), cleanup)
+        //
+        // joints
+        .add_systems(
+            OnEnter(Examples::Joints3),
+            (joints3::setup_graphics, joints3::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Joints3), cleanup)
+        //
+        // joints despawn
+        .init_resource::<joints_despawn3::DespawnResource>()
+        .add_systems(
+            OnEnter(Examples::JointsDespawn3),
+            (
+                joints_despawn3::setup_graphics,
+                joints_despawn3::setup_physics,
+            ),
+        )
+        .add_systems(
+            Update,
+            joints_despawn3::despawn.run_if(in_state(Examples::JointsDespawn3)),
+        )
+        .add_systems(OnExit(Examples::JointsDespawn3), cleanup)
+        //
+        // locked rotations
+        .add_systems(
+            OnEnter(Examples::LockedRotations3),
+            (
+                locked_rotations3::setup_graphics,
+                locked_rotations3::setup_physics,
+            ),
+        )
+        .add_systems(OnExit(Examples::LockedRotations3), cleanup)
+        //
+        // multiple colliders
+        .add_systems(
+            OnEnter(Examples::MultipleColliders3),
+            (
+                multiple_colliders3::setup_graphics,
+                multiple_colliders3::setup_physics,
+            ),
+        )
+        .add_systems(OnExit(Examples::MultipleColliders3), cleanup)
+        //
+        // picking
+        .add_systems(
+            OnEnter(Examples::Picking3),
+            (picking3::setup_graphics, picking3::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Picking3), cleanup)
+        //
+        // raycasting
+        .add_systems(
+            OnEnter(Examples::Raycasting3),
+            (ray_casting3::setup_graphics, ray_casting3::setup_physics),
+        )
+        .add_systems(
+            Update,
+            ray_casting3::cast_ray.run_if(in_state(Examples::Raycasting3)),
+        )
+        .add_systems(OnExit(Examples::Raycasting3), cleanup)
+        //
+        // static trimesh
+        .init_resource::<static_trimesh3::BallState>()
+        .add_systems(
+            OnEnter(Examples::StaticTrimesh3),
+            (
+                static_trimesh3::setup_graphics,
+                static_trimesh3::setup_physics,
+            ),
+        )
+        .add_systems(
+            Update,
+            static_trimesh3::ball_spawner.run_if(in_state(Examples::StaticTrimesh3)),
+        )
+        .add_systems(OnExit(Examples::StaticTrimesh3), cleanup)
+        //
+        //testbed
+        .add_systems(
+            OnEnter(Examples::None),
+            |mut next_state: ResMut<NextState<Examples>>| {
+                next_state.set(Examples::Boxes3);
+            },
+        )
+        .add_systems(OnExit(Examples::None), init)
+        .add_systems(
+            Update,
+            (
+                ui_example_system,
+                change_example.run_if(resource_changed::<ExampleSelected>),
+            )
+                .chain(),
+        );
 
-//     app.run();
-// }
+    app.run();
+}
 
-// fn init(world: &mut World) {
-//     //save all entities that are in the world before setting up any example
-//     // to be able to always return to this state when switching from one example to the other
-//     world.resource_mut::<ExamplesRes>().entities_before =
-//         world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
-// }
+fn init(world: &mut World) {
+    //save all entities that are in the world before setting up any example
+    // to be able to always return to this state when switching from one example to the other
+    world.resource_mut::<ExamplesRes>().entities_before =
+        world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+}
 
-// fn cleanup(world: &mut World) {
-//     let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
+fn cleanup(world: &mut World) {
+    let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
 
-//     let remove = world
-//         .iter_entities()
-//         .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
-//         .collect::<Vec<_>>();
+    let remove = world
+        .iter_entities()
+        .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
+        .collect::<Vec<_>>();
 
-//     for r in remove {
-//         world.despawn(r);
-//     }
-// }
+    for r in remove {
+        world.despawn(r);
+    }
+}
 
-// fn change_example(
-//     example_selected: Res<ExampleSelected>,
-//     examples_available: Res<ExampleSet>,
-//     mut next_state: ResMut<NextState<Examples>>,
-// ) {
-//     next_state.set(examples_available.0[example_selected.0].state);
-// }
+fn change_example(
+    example_selected: Res<ExampleSelected>,
+    examples_available: Res<ExampleSet>,
+    mut next_state: ResMut<NextState<Examples>>,
+) {
+    next_state.set(examples_available.0[example_selected.0].state);
+}
 
-// fn ui_example_system(
-//     mut contexts: EguiContexts,
-//     mut current_example: ResMut<ExampleSelected>,
-//     examples_available: Res<ExampleSet>,
-// ) {
-//     egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
-//         let mut changed = false;
-//         egui::ComboBox::from_label("example")
-//             .width(150.0)
-//             .selected_text(examples_available.0[current_example.0].name)
-//             .show_ui(ui, |ui| {
-//                 for (id, value) in examples_available.0.iter().enumerate() {
-//                     changed = ui
-//                         .selectable_value(&mut current_example.0, id, value.name)
-//                         .changed()
-//                         || changed;
-//                 }
-//             });
-//         if ui.button("Next").clicked() {
-//             current_example.0 = (current_example.0 + 1) % examples_available.0.len();
-//         }
-//     });
+fn ui_example_system(
+    mut contexts: EguiContexts,
+    mut current_example: ResMut<ExampleSelected>,
+    examples_available: Res<ExampleSet>,
+) {
+    egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
+        let mut changed = false;
+        egui::ComboBox::from_label("example")
+            .width(150.0)
+            .selected_text(examples_available.0[current_example.0].name)
+            .show_ui(ui, |ui| {
+                for (id, value) in examples_available.0.iter().enumerate() {
+                    changed = ui
+                        .selectable_value(&mut current_example.0, id, value.name)
+                        .changed()
+                        || changed;
+                }
+            });
+        if ui.button("Next").clicked() {
+            current_example.0 = (current_example.0 + 1) % examples_available.0.len();
+        }
+    });
 }

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -1,283 +1,284 @@
-#![allow(dead_code)]
+// FIXME: Uncomment plugins once `bevy_egui` and `bevy_inspector_egui` get updated to be compatible with bevy 0.16
+// #![allow(dead_code)]
 
-mod boxes3;
-mod debug_toggle3;
-mod despawn3;
-mod events3;
-mod joints3;
-mod joints_despawn3;
-mod locked_rotations3;
-mod multiple_colliders3;
-mod picking3;
-mod ray_casting3;
-mod static_trimesh3;
+// mod boxes3;
+// mod debug_toggle3;
+// mod despawn3;
+// mod events3;
+// mod joints3;
+// mod joints_despawn3;
+// mod locked_rotations3;
+// mod multiple_colliders3;
+// mod picking3;
+// mod ray_casting3;
+// mod static_trimesh3;
 
-use bevy::prelude::*;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
-use bevy_rapier3d::prelude::*;
+// use bevy::prelude::*;
+// use bevy_egui::{egui, EguiContexts, EguiPlugin};
+// use bevy_inspector_egui::quick::WorldInspectorPlugin;
+// use bevy_rapier3d::prelude::*;
 
-#[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
-pub enum Examples {
-    #[default]
-    None,
-    Boxes3,
-    DebugToggle3,
-    Despawn3,
-    Events3,
-    Joints3,
-    JointsDespawn3,
-    LockedRotations3,
-    MultipleColliders3,
-    Picking3,
-    Raycasting3,
-    StaticTrimesh3,
-}
+// #[derive(Debug, Reflect, Clone, Copy, Eq, PartialEq, Default, Hash, States)]
+// pub enum Examples {
+//     #[default]
+//     None,
+//     Boxes3,
+//     DebugToggle3,
+//     Despawn3,
+//     Events3,
+//     Joints3,
+//     JointsDespawn3,
+//     LockedRotations3,
+//     MultipleColliders3,
+//     Picking3,
+//     Raycasting3,
+//     StaticTrimesh3,
+// }
 
-#[derive(Resource, Default, Reflect)]
-struct ExamplesRes {
-    entities_before: Vec<Entity>,
-}
+// #[derive(Resource, Default, Reflect)]
+// struct ExamplesRes {
+//     entities_before: Vec<Entity>,
+// }
 
-#[derive(Resource, Debug, Default, Reflect)]
-struct ExampleSelected(pub usize);
+// #[derive(Resource, Debug, Default, Reflect)]
+// struct ExampleSelected(pub usize);
 
-#[derive(Debug, Reflect)]
-struct ExampleDefinition {
-    pub state: Examples,
-    pub name: &'static str,
-}
+// #[derive(Debug, Reflect)]
+// struct ExampleDefinition {
+//     pub state: Examples,
+//     pub name: &'static str,
+// }
 
-impl From<(Examples, &'static str)> for ExampleDefinition {
-    fn from((state, name): (Examples, &'static str)) -> Self {
-        Self { state, name }
-    }
-}
+// impl From<(Examples, &'static str)> for ExampleDefinition {
+//     fn from((state, name): (Examples, &'static str)) -> Self {
+//         Self { state, name }
+//     }
+// }
 
-#[derive(Resource, Debug, Reflect)]
-struct ExampleSet(pub Vec<ExampleDefinition>);
+// #[derive(Resource, Debug, Reflect)]
+// struct ExampleSet(pub Vec<ExampleDefinition>);
 
-fn main() {
-    let mut app = App::new();
-    app.init_resource::<ExamplesRes>()
-        .add_plugins((
-            DefaultPlugins,
-            EguiPlugin,
-            RapierPhysicsPlugin::<NoUserData>::default(),
-            RapierDebugRenderPlugin::default(),
-            WorldInspectorPlugin::new(),
-            RapierPickingPlugin,
-        ))
-        .register_type::<Examples>()
-        .register_type::<ExamplesRes>()
-        .register_type::<ExampleSelected>()
-        .init_state::<Examples>()
-        .insert_resource(ExampleSet(vec![
-            (Examples::Boxes3, "Boxes3").into(),
-            (Examples::DebugToggle3, "DebugToggle3").into(),
-            (Examples::Despawn3, "Despawn3").into(),
-            (Examples::Events3, "Events3").into(),
-            (Examples::Joints3, "Joints3").into(),
-            (Examples::JointsDespawn3, "JointsDespawn3").into(),
-            (Examples::LockedRotations3, "LockedRotations3").into(),
-            (Examples::MultipleColliders3, "MultipleColliders3").into(),
-            (Examples::Picking3, "Picking3").into(),
-            (Examples::Raycasting3, "Raycasting3").into(),
-            (Examples::StaticTrimesh3, "StaticTrimesh3").into(),
-        ]))
-        .init_resource::<ExampleSelected>()
-        //
-        //boxes2
-        .add_systems(
-            OnEnter(Examples::Boxes3),
-            (boxes3::setup_graphics, boxes3::setup_physics),
-        )
-        .add_systems(OnExit(Examples::Boxes3), cleanup)
-        //
-        // Debug toggle
-        .add_systems(
-            OnEnter(Examples::DebugToggle3),
-            (debug_toggle3::setup_graphics, debug_toggle3::setup_physics),
-        )
-        .add_systems(
-            Update,
-            (
-                debug_toggle3::toggle_debug,
-                (|mut debug_render_context: ResMut<DebugRenderContext>| {
-                    debug_render_context.enabled = !debug_render_context.enabled;
-                })
-                .run_if(debug_toggle3::input_just_pressed(KeyCode::KeyV)),
-            )
-                .run_if(in_state(Examples::DebugToggle3)),
-        )
-        .add_systems(OnExit(Examples::DebugToggle3), cleanup)
-        //
-        // despawn
-        .init_resource::<despawn3::DespawnResource>()
-        .add_systems(
-            OnEnter(Examples::Despawn3),
-            (despawn3::setup_graphics, despawn3::setup_physics),
-        )
-        .add_systems(
-            Update,
-            despawn3::despawn.run_if(in_state(Examples::Despawn3)),
-        )
-        .add_systems(OnExit(Examples::Despawn3), cleanup)
-        //
-        // events
-        .add_systems(
-            OnEnter(Examples::Events3),
-            (events3::setup_graphics, events3::setup_physics),
-        )
-        .add_systems(
-            Update,
-            events3::display_events.run_if(in_state(Examples::Events3)),
-        )
-        .add_systems(OnExit(Examples::Events3), cleanup)
-        //
-        // joints
-        .add_systems(
-            OnEnter(Examples::Joints3),
-            (joints3::setup_graphics, joints3::setup_physics),
-        )
-        .add_systems(OnExit(Examples::Joints3), cleanup)
-        //
-        // joints despawn
-        .init_resource::<joints_despawn3::DespawnResource>()
-        .add_systems(
-            OnEnter(Examples::JointsDespawn3),
-            (
-                joints_despawn3::setup_graphics,
-                joints_despawn3::setup_physics,
-            ),
-        )
-        .add_systems(
-            Update,
-            joints_despawn3::despawn.run_if(in_state(Examples::JointsDespawn3)),
-        )
-        .add_systems(OnExit(Examples::JointsDespawn3), cleanup)
-        //
-        // locked rotations
-        .add_systems(
-            OnEnter(Examples::LockedRotations3),
-            (
-                locked_rotations3::setup_graphics,
-                locked_rotations3::setup_physics,
-            ),
-        )
-        .add_systems(OnExit(Examples::LockedRotations3), cleanup)
-        //
-        // multiple colliders
-        .add_systems(
-            OnEnter(Examples::MultipleColliders3),
-            (
-                multiple_colliders3::setup_graphics,
-                multiple_colliders3::setup_physics,
-            ),
-        )
-        .add_systems(OnExit(Examples::MultipleColliders3), cleanup)
-        //
-        // picking
-        .add_systems(
-            OnEnter(Examples::Picking3),
-            (picking3::setup_graphics, picking3::setup_physics),
-        )
-        .add_systems(OnExit(Examples::Picking3), cleanup)
-        //
-        // raycasting
-        .add_systems(
-            OnEnter(Examples::Raycasting3),
-            (ray_casting3::setup_graphics, ray_casting3::setup_physics),
-        )
-        .add_systems(
-            Update,
-            ray_casting3::cast_ray.run_if(in_state(Examples::Raycasting3)),
-        )
-        .add_systems(OnExit(Examples::Raycasting3), cleanup)
-        //
-        // static trimesh
-        .init_resource::<static_trimesh3::BallState>()
-        .add_systems(
-            OnEnter(Examples::StaticTrimesh3),
-            (
-                static_trimesh3::setup_graphics,
-                static_trimesh3::setup_physics,
-            ),
-        )
-        .add_systems(
-            Update,
-            static_trimesh3::ball_spawner.run_if(in_state(Examples::StaticTrimesh3)),
-        )
-        .add_systems(OnExit(Examples::StaticTrimesh3), cleanup)
-        //
-        //testbed
-        .add_systems(
-            OnEnter(Examples::None),
-            |mut next_state: ResMut<NextState<Examples>>| {
-                next_state.set(Examples::Boxes3);
-            },
-        )
-        .add_systems(OnExit(Examples::None), init)
-        .add_systems(
-            Update,
-            (
-                ui_example_system,
-                change_example.run_if(resource_changed::<ExampleSelected>),
-            )
-                .chain(),
-        );
+// fn main() {
+//     let mut app = App::new();
+//     app.init_resource::<ExamplesRes>()
+//         .add_plugins((
+//             DefaultPlugins,
+//             EguiPlugin,
+//             RapierPhysicsPlugin::<NoUserData>::default(),
+//             RapierDebugRenderPlugin::default(),
+//             WorldInspectorPlugin::new(),
+//             RapierPickingPlugin,
+//         ))
+//         .register_type::<Examples>()
+//         .register_type::<ExamplesRes>()
+//         .register_type::<ExampleSelected>()
+//         .init_state::<Examples>()
+//         .insert_resource(ExampleSet(vec![
+//             (Examples::Boxes3, "Boxes3").into(),
+//             (Examples::DebugToggle3, "DebugToggle3").into(),
+//             (Examples::Despawn3, "Despawn3").into(),
+//             (Examples::Events3, "Events3").into(),
+//             (Examples::Joints3, "Joints3").into(),
+//             (Examples::JointsDespawn3, "JointsDespawn3").into(),
+//             (Examples::LockedRotations3, "LockedRotations3").into(),
+//             (Examples::MultipleColliders3, "MultipleColliders3").into(),
+//             (Examples::Picking3, "Picking3").into(),
+//             (Examples::Raycasting3, "Raycasting3").into(),
+//             (Examples::StaticTrimesh3, "StaticTrimesh3").into(),
+//         ]))
+//         .init_resource::<ExampleSelected>()
+//         //
+//         //boxes2
+//         .add_systems(
+//             OnEnter(Examples::Boxes3),
+//             (boxes3::setup_graphics, boxes3::setup_physics),
+//         )
+//         .add_systems(OnExit(Examples::Boxes3), cleanup)
+//         //
+//         // Debug toggle
+//         .add_systems(
+//             OnEnter(Examples::DebugToggle3),
+//             (debug_toggle3::setup_graphics, debug_toggle3::setup_physics),
+//         )
+//         .add_systems(
+//             Update,
+//             (
+//                 debug_toggle3::toggle_debug,
+//                 (|mut debug_render_context: ResMut<DebugRenderContext>| {
+//                     debug_render_context.enabled = !debug_render_context.enabled;
+//                 })
+//                 .run_if(debug_toggle3::input_just_pressed(KeyCode::KeyV)),
+//             )
+//                 .run_if(in_state(Examples::DebugToggle3)),
+//         )
+//         .add_systems(OnExit(Examples::DebugToggle3), cleanup)
+//         //
+//         // despawn
+//         .init_resource::<despawn3::DespawnResource>()
+//         .add_systems(
+//             OnEnter(Examples::Despawn3),
+//             (despawn3::setup_graphics, despawn3::setup_physics),
+//         )
+//         .add_systems(
+//             Update,
+//             despawn3::despawn.run_if(in_state(Examples::Despawn3)),
+//         )
+//         .add_systems(OnExit(Examples::Despawn3), cleanup)
+//         //
+//         // events
+//         .add_systems(
+//             OnEnter(Examples::Events3),
+//             (events3::setup_graphics, events3::setup_physics),
+//         )
+//         .add_systems(
+//             Update,
+//             events3::display_events.run_if(in_state(Examples::Events3)),
+//         )
+//         .add_systems(OnExit(Examples::Events3), cleanup)
+//         //
+//         // joints
+//         .add_systems(
+//             OnEnter(Examples::Joints3),
+//             (joints3::setup_graphics, joints3::setup_physics),
+//         )
+//         .add_systems(OnExit(Examples::Joints3), cleanup)
+//         //
+//         // joints despawn
+//         .init_resource::<joints_despawn3::DespawnResource>()
+//         .add_systems(
+//             OnEnter(Examples::JointsDespawn3),
+//             (
+//                 joints_despawn3::setup_graphics,
+//                 joints_despawn3::setup_physics,
+//             ),
+//         )
+//         .add_systems(
+//             Update,
+//             joints_despawn3::despawn.run_if(in_state(Examples::JointsDespawn3)),
+//         )
+//         .add_systems(OnExit(Examples::JointsDespawn3), cleanup)
+//         //
+//         // locked rotations
+//         .add_systems(
+//             OnEnter(Examples::LockedRotations3),
+//             (
+//                 locked_rotations3::setup_graphics,
+//                 locked_rotations3::setup_physics,
+//             ),
+//         )
+//         .add_systems(OnExit(Examples::LockedRotations3), cleanup)
+//         //
+//         // multiple colliders
+//         .add_systems(
+//             OnEnter(Examples::MultipleColliders3),
+//             (
+//                 multiple_colliders3::setup_graphics,
+//                 multiple_colliders3::setup_physics,
+//             ),
+//         )
+//         .add_systems(OnExit(Examples::MultipleColliders3), cleanup)
+//         //
+//         // picking
+//         .add_systems(
+//             OnEnter(Examples::Picking3),
+//             (picking3::setup_graphics, picking3::setup_physics),
+//         )
+//         .add_systems(OnExit(Examples::Picking3), cleanup)
+//         //
+//         // raycasting
+//         .add_systems(
+//             OnEnter(Examples::Raycasting3),
+//             (ray_casting3::setup_graphics, ray_casting3::setup_physics),
+//         )
+//         .add_systems(
+//             Update,
+//             ray_casting3::cast_ray.run_if(in_state(Examples::Raycasting3)),
+//         )
+//         .add_systems(OnExit(Examples::Raycasting3), cleanup)
+//         //
+//         // static trimesh
+//         .init_resource::<static_trimesh3::BallState>()
+//         .add_systems(
+//             OnEnter(Examples::StaticTrimesh3),
+//             (
+//                 static_trimesh3::setup_graphics,
+//                 static_trimesh3::setup_physics,
+//             ),
+//         )
+//         .add_systems(
+//             Update,
+//             static_trimesh3::ball_spawner.run_if(in_state(Examples::StaticTrimesh3)),
+//         )
+//         .add_systems(OnExit(Examples::StaticTrimesh3), cleanup)
+//         //
+//         //testbed
+//         .add_systems(
+//             OnEnter(Examples::None),
+//             |mut next_state: ResMut<NextState<Examples>>| {
+//                 next_state.set(Examples::Boxes3);
+//             },
+//         )
+//         .add_systems(OnExit(Examples::None), init)
+//         .add_systems(
+//             Update,
+//             (
+//                 ui_example_system,
+//                 change_example.run_if(resource_changed::<ExampleSelected>),
+//             )
+//                 .chain(),
+//         );
 
-    app.run();
-}
+//     app.run();
+// }
 
-fn init(world: &mut World) {
-    //save all entities that are in the world before setting up any example
-    // to be able to always return to this state when switching from one example to the other
-    world.resource_mut::<ExamplesRes>().entities_before =
-        world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
-}
+// fn init(world: &mut World) {
+//     //save all entities that are in the world before setting up any example
+//     // to be able to always return to this state when switching from one example to the other
+//     world.resource_mut::<ExamplesRes>().entities_before =
+//         world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+// }
 
-fn cleanup(world: &mut World) {
-    let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
+// fn cleanup(world: &mut World) {
+//     let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
 
-    let remove = world
-        .iter_entities()
-        .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
-        .collect::<Vec<_>>();
+//     let remove = world
+//         .iter_entities()
+//         .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
+//         .collect::<Vec<_>>();
 
-    for r in remove {
-        world.despawn(r);
-    }
-}
+//     for r in remove {
+//         world.despawn(r);
+//     }
+// }
 
-fn change_example(
-    example_selected: Res<ExampleSelected>,
-    examples_available: Res<ExampleSet>,
-    mut next_state: ResMut<NextState<Examples>>,
-) {
-    next_state.set(examples_available.0[example_selected.0].state);
-}
+// fn change_example(
+//     example_selected: Res<ExampleSelected>,
+//     examples_available: Res<ExampleSet>,
+//     mut next_state: ResMut<NextState<Examples>>,
+// ) {
+//     next_state.set(examples_available.0[example_selected.0].state);
+// }
 
-fn ui_example_system(
-    mut contexts: EguiContexts,
-    mut current_example: ResMut<ExampleSelected>,
-    examples_available: Res<ExampleSet>,
-) {
-    egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
-        let mut changed = false;
-        egui::ComboBox::from_label("example")
-            .width(150.0)
-            .selected_text(examples_available.0[current_example.0].name)
-            .show_ui(ui, |ui| {
-                for (id, value) in examples_available.0.iter().enumerate() {
-                    changed = ui
-                        .selectable_value(&mut current_example.0, id, value.name)
-                        .changed()
-                        || changed;
-                }
-            });
-        if ui.button("Next").clicked() {
-            current_example.0 = (current_example.0 + 1) % examples_available.0.len();
-        }
-    });
-}
+// fn ui_example_system(
+//     mut contexts: EguiContexts,
+//     mut current_example: ResMut<ExampleSelected>,
+//     examples_available: Res<ExampleSet>,
+// ) {
+//     egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
+//         let mut changed = false;
+//         egui::ComboBox::from_label("example")
+//             .width(150.0)
+//             .selected_text(examples_available.0[current_example.0].name)
+//             .show_ui(ui, |ui| {
+//                 for (id, value) in examples_available.0.iter().enumerate() {
+//                     changed = ui
+//                         .selectable_value(&mut current_example.0, id, value.name)
+//                         .changed()
+//                         || changed;
+//                 }
+//             });
+//         if ui.button("Next").clicked() {
+//             current_example.0 = (current_example.0 + 1) % examples_available.0.len();
+//         }
+//     });
+// }

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -58,7 +58,7 @@
 // #[derive(Resource, Debug, Reflect)]
 // struct ExampleSet(pub Vec<ExampleDefinition>);
 
-// fn main() {
+fn main() {
 //     let mut app = App::new();
 //     app.init_resource::<ExamplesRes>()
 //         .add_plugins((
@@ -281,4 +281,4 @@
 //             current_example.0 = (current_example.0 + 1) % examples_available.0.len();
 //         }
 //     });
-// }
+}

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 rapier3d = { features = ["profiler"], version = "0.23" }
 bevy_rapier3d = { version = "0.29", path = "../bevy_rapier3d" }
-bevy = { version = "0.16.0-rc.1", default-features = false }
+bevy = { version = "0.16.0", default-features = false }
 
 [dev-dependencies]
 divan = "0.1"

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 rapier3d = { features = ["profiler"], version = "0.23" }
 bevy_rapier3d = { version = "0.29", path = "../bevy_rapier3d" }
-bevy = { version = "0.15", default-features = false }
+bevy = { version = "0.16.0-rc.1", default-features = false }
 
 [dev-dependencies]
 divan = "0.1"

--- a/bevy_rapier_benches3d/src/common.rs
+++ b/bevy_rapier_benches3d/src/common.rs
@@ -6,7 +6,7 @@ pub fn default_app() -> App {
 
     app.add_plugins((
         MinimalPlugins,
-        HierarchyPlugin,
+        TransformPlugin,
         TransformPlugin,
         RapierPhysicsPlugin::<()>::default(),
     ));

--- a/bevy_rapier_benches3d/src/lib.rs
+++ b/bevy_rapier_benches3d/src/lib.rs
@@ -30,7 +30,7 @@ pub fn custom_bencher(steps: usize, setup: impl Fn(&mut App)) {
             .world_mut()
             .query::<&RapierContextSimulation>()
             .single(app.world());
-        rapier_step_times.push(rc.pipeline.counters.step_time.time().as_millis() as f32);
+        rapier_step_times.push(rc.unwrap().pipeline.counters.step_time.time().as_millis() as f32);
         total_update_times.push(elapsed_time);
     }
     timer_total.pause();

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.16.0-rc.1"
+bevy = "0.16.0"
 bevy_rapier3d = { version = "0.29", path = "../bevy_rapier3d" }
 bevy_rapier2d = { version = "0.29", path = "../bevy_rapier2d" }
 

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.15.0"
+bevy = "0.16.0-rc.1"
 bevy_rapier3d = { version = "0.29", path = "../bevy_rapier3d" }
 bevy_rapier2d = { version = "0.29", path = "../bevy_rapier2d" }
 

--- a/ci/src/bin/ambiguity_detection.rs
+++ b/ci/src/bin/ambiguity_detection.rs
@@ -8,7 +8,7 @@ use bevy::{
     app::Plugins,
     ecs::schedule::{InternedScheduleLabel, LogLevel, ScheduleBuildSettings},
     log::LogPlugin,
-    platform_support::collections::HashMap,
+    platform::collections::HashMap,
     prelude::*,
 };
 

--- a/ci/src/bin/ambiguity_detection.rs
+++ b/ci/src/bin/ambiguity_detection.rs
@@ -16,28 +16,28 @@ fn main() {
     check_ambiguities(
         (
             bevy_rapier3d::plugin::RapierPhysicsPlugin::<()>::default(),
-            bevy_rapier3d::prelude::RapierPickingPlugin::default(),
+            bevy_rapier3d::prelude::RapierPickingPlugin,
         ),
         true,
     );
     check_ambiguities(
         (
             bevy_rapier3d::plugin::RapierPhysicsPlugin::<()>::default().in_fixed_schedule(),
-            bevy_rapier3d::prelude::RapierPickingPlugin::default(),
+            bevy_rapier3d::prelude::RapierPickingPlugin,
         ),
         false,
     );
     check_ambiguities(
         (
             bevy_rapier2d::plugin::RapierPhysicsPlugin::<()>::default(),
-            bevy_rapier3d::prelude::RapierPickingPlugin::default(),
+            bevy_rapier3d::prelude::RapierPickingPlugin,
         ),
         false,
     );
     check_ambiguities(
         (
             bevy_rapier2d::plugin::RapierPhysicsPlugin::<()>::default().in_fixed_schedule(),
-            bevy_rapier3d::prelude::RapierPickingPlugin::default(),
+            bevy_rapier3d::prelude::RapierPickingPlugin,
         ),
         false,
     );

--- a/ci/src/bin/ambiguity_detection.rs
+++ b/ci/src/bin/ambiguity_detection.rs
@@ -8,8 +8,8 @@ use bevy::{
     app::Plugins,
     ecs::schedule::{InternedScheduleLabel, LogLevel, ScheduleBuildSettings},
     log::LogPlugin,
+    platform_support::collections::HashMap,
     prelude::*,
-    utils::HashMap,
 };
 
 fn main() {
@@ -90,7 +90,7 @@ fn configure_ambiguity_detection(sub_app: &mut SubApp) {
 /// Returns the number of conflicting systems per schedule.
 fn count_ambiguities(sub_app: &SubApp) -> AmbiguitiesCount {
     let schedules = sub_app.world().resource::<Schedules>();
-    let mut ambiguities = HashMap::new();
+    let mut ambiguities = HashMap::default();
     for (_, schedule) in schedules.iter() {
         let ambiguities_in_schedule = schedule.graph().conflicting_systems().len();
         ambiguities.insert(schedule.label(), ambiguities_in_schedule);

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -3,12 +3,12 @@ use std::fmt;
 #[cfg(all(feature = "dim3", feature = "async-collider"))]
 use {
     crate::geometry::{TriMeshFlags, VHACDParameters},
-    bevy::platform_support::collections::HashMap,
+    bevy::platform::collections::HashMap,
 };
 
 use bevy::prelude::*;
 
-use bevy::platform_support::collections::HashSet;
+use bevy::platform::collections::HashSet;
 use rapier::geometry::Shape;
 use rapier::prelude::{ColliderHandle, InteractionGroups, SharedShape};
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -3,12 +3,12 @@ use std::fmt;
 #[cfg(all(feature = "dim3", feature = "async-collider"))]
 use {
     crate::geometry::{TriMeshFlags, VHACDParameters},
-    bevy::utils::HashMap,
+    bevy::platform_support::collections::HashMap,
 };
 
 use bevy::prelude::*;
 
-use bevy::utils::HashSet;
+use bevy::platform_support::collections::HashSet;
 use rapier::geometry::Shape;
 use rapier::prelude::{ColliderHandle, InteractionGroups, SharedShape};
 

--- a/src/geometry/to_bevy_mesh.rs
+++ b/src/geometry/to_bevy_mesh.rs
@@ -118,7 +118,10 @@ pub fn typed_shape_to_mesh(typed_shape: &TypedShape) -> Option<Mesh> {
                 let mesh = typed_shape_to_mesh(&typed_shape)?;
                 if let Some(ref mut final_mesh) = final_mesh {
                     // FIXME: check the result when released upstream (https://github.com/bevyengine/bevy/pull/17475)
-                    final_mesh.merge(&mesh);
+                    // FIXME: Error is simply "peeked" and ignored. Handle it properly by returning a Result from this function.
+                    let _ = final_mesh.merge(&mesh).inspect_err(|e| {
+                        log::warn!("Error merging mesh data: {e}");
+                    });
                 } else {
                     final_mesh = Some(mesh);
                 }

--- a/src/picking_backend/mod.rs
+++ b/src/picking_backend/mod.rs
@@ -89,7 +89,7 @@ pub fn update_hits(
     )>,
     mut output: EventWriter<PointerHits>,
 ) {
-    for (&ray_id, &ray) in ray_map.map().iter() {
+    for (&ray_id, &ray) in ray_map.map.iter() {
         let Ok((camera, cam_pickable, cam_layers)) = picking_cameras.get(ray_id.camera) else {
             continue;
         };

--- a/src/picking_backend/mod.rs
+++ b/src/picking_backend/mod.rs
@@ -171,7 +171,7 @@ pub fn update_hits(
             );
 
             if !picks.is_empty() {
-                output.send(PointerHits::new(ray_id.pointer, picks, order));
+                output.write(PointerHits::new(ray_id.pointer, picks, order));
             }
         }
     }

--- a/src/picking_backend/mod.rs
+++ b/src/picking_backend/mod.rs
@@ -1,7 +1,7 @@
 //! A picking backend for Rapier physics entities.
 //!
 //! By default, all colliders are pickable. Picking can be disabled for individual entities
-//! by adding [`PickingBehavior::IGNORE`](bevy::picking::PickingBehavior::IGNORE).
+//! by adding [`Pickable::IGNORE`](bevy::picking::Pickable::IGNORE).
 //!
 //! To make rapier picking entirely opt-in, set [`RapierPickingSettings::require_markers`]
 //! to `true` and add a [`RapierPickable`] component to the desired camera and target entities.

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -189,12 +189,12 @@ mod test {
                 .world()
                 .get_resource::<EventsSaver<CollisionEvent>>()
                 .unwrap();
-            assert!(saved_collisions.events.len() > 0);
+            assert!(!saved_collisions.events.is_empty());
             let saved_contact_forces = app
                 .world()
                 .get_resource::<EventsSaver<CollisionEvent>>()
                 .unwrap();
-            assert!(saved_contact_forces.events.len() > 0);
+            assert!(!saved_contact_forces.events.is_empty());
         }
 
         /// Adapted from events example

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -785,7 +785,7 @@ impl Default for RapierContextSimulation {
             pipeline: PhysicsPipeline::new(),
             integration_parameters: IntegrationParameters::default(),
             event_handler: None,
-            deleted_colliders: HashMap::new(),
+            deleted_colliders: HashMap::default(),
             collision_events_to_send: Vec::new(),
             contact_force_events_to_send: Vec::new(),
             character_collisions_collector: Vec::new(),

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -959,10 +959,10 @@ impl RapierContextSimulation {
         contact_force_event_writer: &mut EventWriter<ContactForceEvent>,
     ) {
         for collision_event in self.collision_events_to_send.drain(..) {
-            collision_event_writer.send(collision_event);
+            collision_event_writer.write(collision_event);
         }
         for contact_force_event in self.contact_force_events_to_send.drain(..) {
-            contact_force_event_writer.send(contact_force_event);
+            contact_force_event_writer.write(contact_force_event);
         }
     }
 

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -35,21 +35,21 @@ pub struct ReadRapierContext<'w, 's, T: query::QueryFilter + 'static = With<Defa
 }
 
 impl<'w, 's, T: query::QueryFilter + 'static> ReadRapierContext<'w, 's, T> {
-    /// Use this method if you only have one [`RapierContext`].
+    /// Returns a single [`RapierContext`] corresponding to the filter (T) of [`ReadRapierContext`].
     ///
-    /// SAFETY: This method will panic if its underlying query fails.
+    /// If the number of query items is not exactly one, a [`bevy::ecs::query::QuerySingleError`] is returned instead.
     ///
-    /// Use the underlying query [`ReadRapierContext::rapier_context`] for safer alternatives.
-    pub fn single(&self) -> RapierContext {
+    /// You can also use the underlying query [`WriteRapierContext::rapier_context`] for finer grained queries.
+    pub fn single(&self) -> Result<RapierContext> {
         let (simulation, colliders, joints, query_pipeline, rigidbody_set) =
-            self.rapier_context.single();
-        RapierContext {
+            self.rapier_context.single()?;
+        Ok(RapierContext {
             simulation,
             colliders,
             joints,
             query_pipeline,
             rigidbody_set,
-        }
+        })
     }
 }
 
@@ -94,35 +94,38 @@ pub struct WriteRapierContext<'w, 's, T: query::QueryFilter + 'static = With<Def
 }
 
 impl<'w, 's, T: query::QueryFilter + 'static> WriteRapierContext<'w, 's, T> {
-    /// Use this method if you only have one [`RapierContext`] corresponding to the filter (T) of [`WriteRapierContext`].
+    /// Returns a single [`RapierContext`] corresponding to the filter (T) of [`WriteRapierContext`].
     ///
-    /// SAFETY: This method will panic if its underlying query fails.
-    /// Use the underlying query [`WriteRapierContext::rapier_context`] for safer alternatives.
-    pub fn single(&self) -> RapierContext {
+    /// If the number of query items is not exactly one, a [`bevy::ecs::query::QuerySingleError`] is returned instead.
+    ///
+    /// You can also use the underlying query [`WriteRapierContext::rapier_context`] for finer grained queries.
+    pub fn single(&self) -> Result<RapierContext> {
         let (simulation, colliders, joints, query_pipeline, rigidbody_set) =
-            self.rapier_context.single();
-        RapierContext {
+            self.rapier_context.single()?;
+        Ok(RapierContext {
             simulation,
             colliders,
             joints,
             query_pipeline,
             rigidbody_set,
-        }
+        })
     }
-    /// Use this method if you only have one [`RapierContext`].
+
+    /// Returns a single mutable [`RapierContextMut`] corresponding to the filter (T) of [`WriteRapierContext`].
     ///
-    /// SAFETY: This method will panic if its underlying query fails.
-    /// Use the underlying query [`WriteRapierContext::rapier_context`] for safer alternatives.
-    pub fn single_mut(&mut self) -> RapierContextMut {
+    /// If the number of query items is not exactly one, a [`bevy::ecs::query::QuerySingleError`] is returned instead.
+    ///
+    /// You can also use the underlying query [`WriteRapierContext::rapier_context`] for finer grained queries.
+    pub fn single_mut(&mut self) -> Result<RapierContextMut> {
         let (simulation, colliders, joints, query_pipeline, rigidbody_set) =
-            self.rapier_context.single_mut();
-        RapierContextMut {
+            self.rapier_context.single_mut()?;
+        Ok(RapierContextMut {
             simulation,
             colliders,
             joints,
             query_pipeline,
             rigidbody_set,
-        }
+        })
     }
 }
 

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -39,7 +39,7 @@ impl<'w, 's, T: query::QueryFilter + 'static> ReadRapierContext<'w, 's, T> {
     ///
     /// If the number of query items is not exactly one, a [`bevy::ecs::query::QuerySingleError`] is returned instead.
     ///
-    /// You can also use the underlying query [`WriteRapierContext::rapier_context`] for finer grained queries.
+    /// You can also use the underlying query [`ReadRapierContext::rapier_context`] for finer grained queries.
     pub fn single(&self) -> Result<RapierContext> {
         let (simulation, colliders, joints, query_pipeline, rigidbody_set) =
             self.rapier_context.single()?;

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -507,7 +507,7 @@ mod test {
                 let rigidbody_set = app
                     .world_mut()
                     .query::<&RapierRigidBodySet>()
-                    .get_single(&app.world())
+                    .single(&app.world())
                     .unwrap();
 
                 println!("{:?}", &rigidbody_set.entity2body);
@@ -515,7 +515,7 @@ mod test {
             let rigidbody_set = app
                 .world_mut()
                 .query::<&RapierRigidBodySet>()
-                .get_single(&app.world())
+                .single(&app.world())
                 .unwrap();
 
             assert_eq!(
@@ -588,7 +588,7 @@ mod test {
             let context = app
                 .world_mut()
                 .query::<RapierContext>()
-                .get_single(&app.world())
+                .single(&app.world())
                 .unwrap();
             assert_eq!(context.rigidbody_set.entity2body.len(), 1);
 
@@ -599,7 +599,7 @@ mod test {
             let context = app
                 .world_mut()
                 .query::<RapierContext>()
-                .get_single(&app.world())
+                .single(&app.world())
                 .unwrap();
 
             println!("{:?}", &context.rigidbody_set.entity2body);

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -507,7 +507,7 @@ mod test {
                 let rigidbody_set = app
                     .world_mut()
                     .query::<&RapierRigidBodySet>()
-                    .single(&app.world())
+                    .single(app.world())
                     .unwrap();
 
                 println!("{:?}", &rigidbody_set.entity2body);
@@ -515,7 +515,7 @@ mod test {
             let rigidbody_set = app
                 .world_mut()
                 .query::<&RapierRigidBodySet>()
-                .single(&app.world())
+                .single(app.world())
                 .unwrap();
 
             assert_eq!(
@@ -588,7 +588,7 @@ mod test {
             let context = app
                 .world_mut()
                 .query::<RapierContext>()
-                .single(&app.world())
+                .single(app.world())
                 .unwrap();
             assert_eq!(context.rigidbody_set.entity2body.len(), 1);
 
@@ -599,7 +599,7 @@ mod test {
             let context = app
                 .world_mut()
                 .query::<RapierContext>()
-                .single(&app.world())
+                .single(app.world())
                 .unwrap();
 
             println!("{:?}", &context.rigidbody_set.entity2body);

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -695,7 +695,7 @@ mod test {
             let context = app
                 .world_mut()
                 .query::<RapierContext>()
-                .get_single(&app.world())
+                .single(app.world())
                 .unwrap();
 
             println!("{:#?}", &context.rigidbody_set.bodies);
@@ -715,12 +715,12 @@ mod test {
             let parent = commands
                 .spawn(Transform::from_scale(Vec3::splat(5f32)))
                 .id();
-            let mut entity = commands.spawn((
+            let mut entity_commands = commands.spawn((
                 Collider::ball(1f32),
                 Transform::from_translation(Vec3::new(200f32, 100f32, 3f32)),
                 RigidBody::Fixed,
             ));
-            entity.set_parent(parent);
+            entity_commands.insert(ChildOf(parent));
         }
     }
 }

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -6,7 +6,7 @@ use bevy::ecs::{
     schedule::{IntoScheduleConfigs, ScheduleConfigs, ScheduleLabel},
     system::SystemParamItem,
 };
-use bevy::platform_support::collections::HashSet;
+use bevy::platform::collections::HashSet;
 use bevy::{prelude::*, transform::TransformSystem};
 use rapier::dynamics::IntegrationParameters;
 use std::marker::PhantomData;

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -704,7 +704,7 @@ mod test {
         pub fn init_rapier_configuration(
             mut config: Query<&mut RapierConfiguration, With<DefaultRapierContext>>,
         ) {
-            let mut config = config.single_mut();
+            let mut config = config.single_mut().unwrap();
             *config = RapierConfiguration {
                 force_update_from_transform_changes: true,
                 ..RapierConfiguration::new(1f32)

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -190,7 +190,7 @@ pub fn apply_collider_user_changes(
 
             if let Some(body) = co.parent() {
                 if let Some(body_entity) = rigidbody_set.rigid_body_entity(body) {
-                    mass_modified.send(body_entity.into());
+                    mass_modified.write(body_entity.into());
                 }
             }
         }
@@ -312,7 +312,7 @@ pub fn apply_collider_user_changes(
 
             if let Some(body) = co.parent() {
                 if let Some(body_entity) = rigidbody_set.rigid_body_entity(body) {
-                    mass_modified.send(body_entity.into());
+                    mass_modified.write(body_entity.into());
                 }
             }
         }

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -389,7 +389,7 @@ pub fn init_colliders(
         // Get rapier context from RapierContextEntityLink or insert its default value.
         let context_entity = entity_context_link.map_or_else(
             || {
-                let context_entity = default_context_access.get_single().ok()?;
+                let context_entity = default_context_access.single().ok()?;
                 commands
                     .entity(entity)
                     .insert(RapierContextEntityLink(context_entity));

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -333,7 +333,7 @@ pub(crate) fn collider_offset(
             if let Ok(transform) = transform_query.get(body_entity) {
                 child_transform = *transform * child_transform;
             }
-            body_entity = child_of.parent;
+            body_entity = child_of.parent();
         } else {
             break;
         }
@@ -656,7 +656,7 @@ pub mod test {
         let mut scenes = app.world_mut().resource_mut::<Assets<Scene>>();
         let scene = scenes.add(Scene::new(World::new()));
 
-        let mut named_shapes = bevy::platform_support::collections::HashMap::default();
+        let mut named_shapes = bevy::platform::collections::HashMap::default();
         named_shapes.insert("Capsule".to_string(), None);
         let parent = app
             .world_mut()

--- a/src/plugin/systems/joint.rs
+++ b/src/plugin/systems/joint.rs
@@ -28,7 +28,7 @@ pub fn init_joints(
         // Get rapier context from RapierContextEntityLink or insert its default value.
         let context_entity = entity_context_link.map_or_else(
             || {
-                let context_entity = default_context_access.get_single().ok()?;
+                let context_entity = default_context_access.single().ok()?;
                 commands
                     .entity(entity)
                     .insert(RapierContextEntityLink(context_entity));
@@ -76,7 +76,7 @@ pub fn init_joints(
         // Get rapier context from RapierContextEntityLink or insert its default value.
         let context_entity = entity_context_link.map_or_else(
             || {
-                let context_entity = default_context_access.get_single().ok()?;
+                let context_entity = default_context_access.single().ok()?;
                 commands
                     .entity(entity)
                     .insert(RapierContextEntityLink(context_entity));

--- a/src/plugin/systems/joint.rs
+++ b/src/plugin/systems/joint.rs
@@ -50,7 +50,7 @@ pub fn init_joints(
         while target.is_none() {
             target = rigidbody_set.entity2body.get(&body_entity).copied();
             if let Ok(child_of) = child_of_query.get(body_entity) {
-                body_entity = child_of.parent;
+                body_entity = child_of.parent();
             } else {
                 break;
             }

--- a/src/plugin/systems/joint.rs
+++ b/src/plugin/systems/joint.rs
@@ -22,7 +22,7 @@ pub fn init_joints(
         (Entity, Option<&RapierContextEntityLink>, &MultibodyJoint),
         Without<RapierMultibodyJointHandle>,
     >,
-    parent_query: Query<&Parent>,
+    child_of_query: Query<&ChildOf>,
 ) {
     for (entity, entity_context_link, joint) in impulse_joints.iter() {
         // Get rapier context from RapierContextEntityLink or insert its default value.
@@ -49,8 +49,8 @@ pub fn init_joints(
         let mut body_entity = entity;
         while target.is_none() {
             target = rigidbody_set.entity2body.get(&body_entity).copied();
-            if let Ok(parent_entity) = parent_query.get(body_entity) {
-                body_entity = parent_entity.get();
+            if let Ok(child_of) = child_of_query.get(body_entity) {
+                body_entity = child_of.parent;
             } else {
                 break;
             }
@@ -108,7 +108,7 @@ pub fn init_joints(
                     .insert(RapierMultibodyJointHandle(handle));
                 joints.entity2multibody_joint.insert(entity, handle);
             } else {
-                error!("Failed to create multibody joint: loop detected.")
+                log::error!("Failed to create multibody joint: loop detected.")
             }
         }
     }

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -232,7 +232,7 @@ pub mod tests {
             let world = app.world_mut();
             let rigidbody_set = world
                 .query::<&RapierRigidBodySet>()
-                .iter(&world)
+                .iter(world)
                 .next()
                 .unwrap();
             let child_transform = world.entity(child).get::<GlobalTransform>().unwrap();
@@ -300,7 +300,7 @@ pub mod tests {
             let world = app.world_mut();
             let (rigidbody_set, context_colliders) = world
                 .query::<(&RapierRigidBodySet, &RapierContextColliders)>()
-                .iter(&world)
+                .iter(world)
                 .next()
                 .unwrap();
             let parent_handle = rigidbody_set.entity2body[&parent];

--- a/src/plugin/systems/multiple_rapier_contexts.rs
+++ b/src/plugin/systems/multiple_rapier_contexts.rs
@@ -174,12 +174,12 @@ mod test {
         app.update();
         let mut world = app.world_mut();
         let mut query = world.query_filtered::<&mut RapierContextEntityLink, With<Marker<'P'>>>();
-        let mut link_parent = query.get_single_mut(&mut world).unwrap();
+        let mut link_parent = query.single_mut(&mut world).unwrap();
         link_parent.0 = new_rapier_context;
         app.update();
         let mut world = app.world_mut();
         let mut query = world.query_filtered::<&RapierContextEntityLink, With<Marker<'C'>>>();
-        let link_child = query.get_single_mut(&mut world).unwrap();
+        let link_child = query.single_mut(&mut world).unwrap();
         assert_eq!(link_child.0, new_rapier_context);
         return;
 

--- a/src/plugin/systems/multiple_rapier_contexts.rs
+++ b/src/plugin/systems/multiple_rapier_contexts.rs
@@ -27,7 +27,7 @@ pub fn on_add_entity_with_parent(
     mut commands: Commands,
 ) {
     for (ent, child_of) in &q_add_entity_without_parent {
-        let mut parent = Some(child_of.parent);
+        let mut parent = Some(child_of.parent());
         while let Some(parent_entity) = parent {
             if let Ok(pw) = q_physics_world.get(parent_entity) {
                 // Change rapier context link only if the existing link isn't the correct one.
@@ -37,7 +37,7 @@ pub fn on_add_entity_with_parent(
                 }
                 break;
             }
-            parent = q_child_of.get(parent_entity).ok().map(|x| x.parent);
+            parent = q_child_of.get(parent_entity).ok().map(|x| x.parent());
         }
     }
 }

--- a/src/plugin/systems/multiple_rapier_contexts.rs
+++ b/src/plugin/systems/multiple_rapier_contexts.rs
@@ -162,7 +162,7 @@ mod test {
         // Verify all rapier entities have a `RapierContextEntityLink`.
         let world = app.world_mut();
         let mut query = world.query_filtered::<Entity, With<Marker<'R'>>>();
-        for entity in query.iter(&world) {
+        for entity in query.iter(world) {
             world
                 .get::<RapierContextEntityLink>(entity)
                 .unwrap_or_else(|| panic!("no link to rapier context entity from {entity}."));
@@ -172,14 +172,14 @@ mod test {
         // FIXME: We need to wait 1 frame when creating a context.
         // Ideally we should be able to order the systems so that we don't have to wait.
         app.update();
-        let mut world = app.world_mut();
+        let world = app.world_mut();
         let mut query = world.query_filtered::<&mut RapierContextEntityLink, With<Marker<'P'>>>();
-        let mut link_parent = query.single_mut(&mut world).unwrap();
+        let mut link_parent = query.single_mut(world).unwrap();
         link_parent.0 = new_rapier_context;
         app.update();
-        let mut world = app.world_mut();
+        let world = app.world_mut();
         let mut query = world.query_filtered::<&RapierContextEntityLink, With<Marker<'C'>>>();
-        let link_child = query.single_mut(&mut world).unwrap();
+        let link_child = query.single_mut(world).unwrap();
         assert_eq!(link_child.0, new_rapier_context);
         return;
 

--- a/src/plugin/systems/remove.rs
+++ b/src/plugin/systems/remove.rs
@@ -100,7 +100,7 @@ pub fn sync_removals(
         };
         let context = &mut *context;
         if let Some(parent) = context_colliders.collider_parent(&rigidbody_set, entity) {
-            mass_modified.send(parent.into());
+            mass_modified.write(parent.into());
         }
 
         context_colliders.colliders.remove(
@@ -121,7 +121,7 @@ pub fn sync_removals(
             let context = &mut *context;
             let context_colliders = &mut *context_colliders;
             if let Some(parent) = context_colliders.collider_parent(&rigidbody_set, entity) {
-                mass_modified.send(parent.into());
+                mass_modified.write(parent.into());
             }
 
             context_colliders.colliders.remove(

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -465,7 +465,7 @@ pub fn writeback_rigid_bodies(
                 //       that we do to detect if the user’s transform has to be written
                 //       into the rigid-body.
                 if let Some(parent_global_transform) =
-                    child_of.and_then(|c| global_transforms.get(c.parent).ok())
+                    child_of.and_then(|c| global_transforms.get(c.parent()).ok())
                 {
                     // We need to compute the new local transform such that:
                     // curr_parent_global_transform * new_transform = interpolated_pos

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -660,7 +660,7 @@ pub fn init_rigid_bodies(
         // Get rapier context from RapierContextEntityLink or insert its default value.
         let context_entity = entity_context_link.map_or_else(
             || {
-                let context_entity = default_context_access.get_single().ok()?;
+                let context_entity = default_context_access.single().ok()?;
                 commands
                     .entity(entity)
                     .insert(RapierContextEntityLink(context_entity));

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -285,7 +285,7 @@ pub fn apply_rigid_body_user_changes(
                 }
             }
 
-            mass_modified.send(entity.into());
+            mass_modified.write(entity.into());
         }
     }
 

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 pub type RigidBodyWritebackComponents<'a> = (
     &'a RapierRigidBodyHandle,
     &'a RapierContextEntityLink,
-    Option<&'a Parent>,
+    Option<&'a ChildOf>,
     Option<&'a mut Transform>,
     Option<&'a mut TransformInterpolation>,
     Option<&'a mut Velocity>,
@@ -411,7 +411,7 @@ pub fn writeback_rigid_bodies(
         (With<RigidBody>, Without<RigidBodyDisabled>),
     >,
 ) {
-    for (handle, link, parent, transform, mut interpolation, mut velocity, mut sleeping) in
+    for (handle, link, child_of, transform, mut interpolation, mut velocity, mut sleeping) in
         writeback.iter_mut()
     {
         let config = config
@@ -465,7 +465,7 @@ pub fn writeback_rigid_bodies(
                 //       that we do to detect if the user’s transform has to be written
                 //       into the rigid-body.
                 if let Some(parent_global_transform) =
-                    parent.and_then(|p| global_transforms.get(**p).ok())
+                    child_of.and_then(|c| global_transforms.get(c.parent).ok())
                 {
                     // We need to compute the new local transform such that:
                     // curr_parent_global_transform * new_transform = interpolated_pos


### PR DESCRIPTION
TODO:
- [x] In `to_bevy_mesh.rs:121:21` a comment reads `"// FIXME: check the result when released upstream (https://github.com/bevyengine/bevy/pull/17475)"` but I'm unsure on what to "check" (i.e. how to handle the error). I'd appreciate more context for this item.
- [x] Some examples require bumping `bevy_mod_debugdump`, `bevy_egui`, `bevy_inspector_egui` to a version compatible with 0.16. We might be blocked on these ones for a bit I guess?
- [x] I've unwrapped `Single` queries in all examples. I'm not sure if this is appropriate, yet it'll keep the old behavior as far as I'm aware. I'll check the updated Bevy examples to see how they are being handled in the new version to confirm, any advice will be welcomed.