### PR TITLE
Fix positioning due to scaling in hierarchies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added a serialization `serialization2` example for `bevy_rapier2d`.
 
+## Fixed
+
+- Fix position being incorrect when a rigidbody bevy entity has a scaled parent. [#646](https://github.com/dimforge/bevy_rapier/pull/646)
+
 ## v0.29.0 (18 February 2025)
 
 ### Added

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -692,7 +692,7 @@ mod test {
                 .spawn(Transform::from_scale(Vec3::splat(5f32)))
                 .id();
             let mut entity = commands.spawn((
-                Collider::cuboid(1f32, 1f32, 1f32),
+                Collider::ball(1f32),
                 Transform::from_translation(Vec3::new(200f32, 100f32, 3f32)),
                 RigidBody::Fixed,
             ));

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -661,11 +661,11 @@ mod test {
             app.insert_resource(TimeUpdateStrategy::ManualDuration(
                 std::time::Duration::from_secs_f32(1f32 / 60f32),
             ));
+            app.add_systems(Startup, init_rapier_configuration);
             app.add_systems(Startup, setup_physics);
 
             app.finish();
-            for i in 0..100000 {
-                println!("{}", i);
+            for _ in 0..100 {
                 app.update();
             }
             let context = app
@@ -677,23 +677,26 @@ mod test {
             println!("{:#?}", &context.rigidbody_set.bodies);
         }
 
+        pub fn init_rapier_configuration(
+            mut config: Query<&mut RapierConfiguration, With<DefaultRapierContext>>,
+        ) {
+            let mut config = config.single_mut();
+            *config = RapierConfiguration {
+                force_update_from_transform_changes: true,
+                ..RapierConfiguration::new(1f32)
+            };
+        }
+
         pub fn setup_physics(mut commands: Commands) {
             let parent = commands
-                .spawn(Transform::from_scale(Vec3::splat(2f32)))
+                .spawn(Transform::from_scale(Vec3::splat(5f32)))
                 .id();
             let mut entity = commands.spawn((
                 Collider::cuboid(1f32, 1f32, 1f32),
-                Transform::from_translation(Vec3::splat(5f32)).with_scale(Vec3::splat(2f32)),
-                RigidBody::Dynamic,
+                Transform::from_translation(Vec3::new(200f32, 100f32, 3f32)),
+                RigidBody::Fixed,
             ));
             entity.set_parent(parent);
-            println!("spawned rapier entity");
-
-            let ground_size = 100f32;
-            commands.spawn((
-                Transform::from_xyz(0.0, -5.0, 0.0),
-                Collider::cuboid(ground_size, 1.0, ground_size),
-            ));
         }
     }
 }

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -239,10 +239,23 @@ pub mod tests {
             let child_handle = rigidbody_set.entity2body[&child];
             let child_body = rigidbody_set.bodies.get(child_handle).unwrap();
             let body_transform = utils::iso_to_transform(child_body.position());
-            assert_eq!(
-                GlobalTransform::from(body_transform),
-                *child_transform,
-                "Collider transform should have have global rotation and translation"
+
+            fn transforms_approx_equal(
+                a: &GlobalTransform,
+                b: &GlobalTransform,
+                epsilon: f32,
+            ) -> bool {
+                a.translation().abs_diff_eq(b.translation(), epsilon)
+                    && a.scale().abs_diff_eq(b.scale(), epsilon)
+                    && a.rotation().abs_diff_eq(b.rotation(), epsilon)
+            }
+            assert!(
+                transforms_approx_equal(
+                    &GlobalTransform::from(body_transform),
+                    child_transform,
+                    1.0e-5,
+                ),
+                "Collider transforms should have have equal global rotation and translation"
             );
         }
     }

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -479,7 +479,10 @@ pub fn writeback_rigid_bodies(
 
                     #[allow(unused_mut)] // mut is needed in 2D but not in 3D.
                     let mut new_translation = inverse_parent_rotation
-                        * inverse_parent_scale
+                        // FIXME: should we multiply `inverse_parent_scale` ? 
+                        // This fixes https://github.com/ForesightMiningSoftwareCorporation/multiphysics_examples/pull/1,
+                        // but I'm not sure that's the root issue, as `parent_child` test is not failing without it.
+                        // * inverse_parent_scale
                         * interpolated_pos.translation
                         + inverse_parent_translation;
 

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -470,7 +470,7 @@ pub fn writeback_rigid_bodies(
                     // We need to compute the new local transform such that:
                     // curr_parent_global_transform * new_transform = interpolated_pos
                     // new_transform = curr_parent_global_transform.inverse() * interpolated_pos
-                    let (_, inverse_parent_rotation, inverse_parent_translation) =
+                    let (inverse_parent_scale, inverse_parent_rotation, inverse_parent_translation) =
                         parent_global_transform
                             .affine()
                             .inverse()
@@ -479,6 +479,7 @@ pub fn writeback_rigid_bodies(
 
                     #[allow(unused_mut)] // mut is needed in 2D but not in 3D.
                     let mut new_translation = inverse_parent_rotation
+                        * inverse_parent_scale
                         * interpolated_pos.translation
                         + inverse_parent_translation;
 

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -479,10 +479,7 @@ pub fn writeback_rigid_bodies(
 
                     #[allow(unused_mut)] // mut is needed in 2D but not in 3D.
                     let mut new_translation = inverse_parent_rotation
-                        // FIXME: should we multiply `inverse_parent_scale` ? 
-                        // This fixes https://github.com/ForesightMiningSoftwareCorporation/multiphysics_examples/pull/1,
-                        // but I'm not sure that's the root issue, as `parent_child` test is not failing without it.
-                        // * inverse_parent_scale
+                        * inverse_parent_scale
                         * interpolated_pos.translation
                         + inverse_parent_translation;
 


### PR DESCRIPTION
With https://github.com/ForesightMiningSoftwareCorporation/multiphysics_examples/pull/1 ; using `force_update_from_transform_changes` and using hierarchies was applying scale of the parent to the position, leading to a crash.