### PR TITLE
Rapier 0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 ## Modified
 
 - Update Bevy to `0.16`.
-- Update from rapier `0.23` to rapier `0.24`,
+- Update from rapier `0.23` to rapier `0.25`,
   see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
+  - Notably, support and examples for parry's new `Voxels` shape have been added.
 - `RapierContextInitialization::InitializeDefaultRapierContext` now has more fields for better control over default physics context.
 
 ## Fixed

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -77,6 +77,7 @@ bevy = { version = "0.16.0", default-features = false, features = [
     "bevy_state",
     "bevy_window",
     "bevy_debug_stepping",
+    "bevy_log",
 ] }
 oorandom = "11"
 approx = "0.5.1"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -66,7 +66,7 @@ to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 [dependencies]
 bevy = { version = "0.16.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
-rapier2d = "0.24"
+rapier2d = "0.25"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -11,6 +11,7 @@ mod locked_rotations2;
 mod multiple_colliders2;
 mod player_movement2;
 mod rope_joint2;
+mod voxels2;
 
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts, EguiPlugin};
@@ -22,6 +23,7 @@ pub enum Examples {
     #[default]
     None,
     Boxes2,
+    Voxels2,
     DebugToggle2,
     RopeJoint2,
     DebugDespawn2,
@@ -75,6 +77,7 @@ fn main() {
         .init_state::<Examples>()
         .insert_resource(ExampleSet(vec![
             (Examples::Boxes2, "Boxes3").into(),
+            (Examples::Voxels2, "Voxels2").into(),
             (Examples::RopeJoint2, "RopeJoint2").into(),
             (Examples::DebugDespawn2, "DebugDespawn2").into(),
             (Examples::Despawn2, "Despawn3").into(),
@@ -93,6 +96,13 @@ fn main() {
             (boxes2::setup_graphics, boxes2::setup_physics),
         )
         .add_systems(OnExit(Examples::Boxes2), cleanup)
+        //
+        //boxes2
+        .add_systems(
+            OnEnter(Examples::Voxels2),
+            (voxels2::setup_graphics, voxels2::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Voxels2), cleanup)
         //
         // Debug toggle
         .add_systems(

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -97,7 +97,7 @@ fn main() {
         )
         .add_systems(OnExit(Examples::Boxes2), cleanup)
         //
-        //boxes2
+        //voxels2
         .add_systems(
             OnEnter(Examples::Voxels2),
             (voxels2::setup_graphics, voxels2::setup_physics),

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -13,7 +13,7 @@ mod player_movement2;
 mod rope_joint2;
 mod voxels2;
 
-use bevy::prelude::*;
+use bevy::{ecs::world::error::EntityMutableFetchError, prelude::*};
 use bevy_egui::{egui, EguiContexts, EguiPlugin};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -13,7 +13,10 @@ mod player_movement2;
 mod rope_joint2;
 mod voxels2;
 
-use bevy::{ecs::world::error::EntityMutableFetchError, prelude::*};
+use bevy::{
+    ecs::world::error::{EntityDespawnError, EntityMutableFetchError},
+    prelude::*,
+};
 use bevy_egui::{egui, EguiContexts, EguiPlugin};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;
@@ -266,11 +269,10 @@ fn cleanup(world: &mut World) {
         .collect::<Vec<_>>();
 
     for r in remove {
-        match world.try_despawn(r) {
-            Err(error @ EntityDespawnError(EntityMutableFetchError::AliasedMutability(_))) => {
-                warn!("Cleanup error: {error:?}");
-            }
-            _ => {}
+        if let Err(error @ EntityDespawnError(EntityMutableFetchError::AliasedMutability(_))) =
+            world.try_despawn(r)
+        {
+            warn!("Cleanup error: {error:?}");
         }
     }
 }

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -266,7 +266,12 @@ fn cleanup(world: &mut World) {
         .collect::<Vec<_>>();
 
     for r in remove {
-        world.despawn(r);
+        match world.try_despawn(r) {
+            Err(error @ EntityDespawnError(EntityMutableFetchError::AliasedMutability(_))) => {
+                warn!("Cleanup error: {error:?}");
+            }
+            _ => {}
+        }
     }
 }
 

--- a/bevy_rapier2d/examples/voxels2.rs
+++ b/bevy_rapier2d/examples/voxels2.rs
@@ -55,7 +55,7 @@ pub fn setup_physics(mut commands: Commands) {
     /*
      * Voxelization.
      */
-    let polyline = vec![
+    let polyline = [
         point![0.0, 0.0],
         point![0.0, 10.0],
         point![7.0, 4.0],

--- a/bevy_rapier2d/examples/voxels2.rs
+++ b/bevy_rapier2d/examples/voxels2.rs
@@ -1,0 +1,129 @@
+use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+use nalgebra::{point, Vector2};
+use rapier2d::prelude::{SharedShape, VoxelPrimitiveGeometry};
+
+fn main() {
+    App::new()
+        .insert_resource(ClearColor(Color::srgb(
+            0xF9 as f32 / 255.0,
+            0xF9 as f32 / 255.0,
+            0xFF as f32 / 255.0,
+        )))
+        .add_plugins((
+            DefaultPlugins,
+            RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
+            RapierDebugRenderPlugin::default(),
+        ))
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .run();
+}
+
+pub fn setup_graphics(mut commands: Commands) {
+    commands.spawn((Camera2d, Transform::from_xyz(0.0, 20.0, 0.0)));
+}
+
+pub fn setup_physics(mut commands: Commands) {
+    let scale = 15f32;
+    /*
+     * Create dynamic objects to fall on voxels.
+     */
+    let nx = 50;
+    for i in 0..nx {
+        for j in 0..10 {
+            // if test_ccd {
+            //     rb = rb.linvel(vector![0.0, -1000.0] * scale).ccd_enabled(true);
+            // }
+            // let falling_objects = if falling_objects == 3 {
+            //     j % 3
+            // } else {
+            //     falling_objects
+            // };
+
+            let ball_radius = 0.5 * scale;
+            let co = match 0 {
+                0 => Collider::ball(ball_radius),
+                1 => Collider::cuboid(ball_radius, ball_radius),
+                2 => Collider::capsule_y(ball_radius, ball_radius),
+                _ => unreachable!(),
+            };
+            commands.spawn((
+                Transform::from_xyz(
+                    (i as f32 * 2.0 - nx as f32 / 2.0) * scale,
+                    (20.0 + j as f32 * 2.0) * scale,
+                    0.0,
+                ),
+                RigidBody::Dynamic,
+                co,
+            ));
+        }
+    }
+    let num = 8;
+    let rad = 10.0;
+
+    let shift = rad * 2.0 + rad;
+    let centerx = shift * (num / 2) as f32;
+    let centery = shift / 2.0;
+
+    let mut offset = -(num as f32) * (rad * 2.0 + rad) * 0.5;
+
+    for j in 0usize..20 {
+        for i in 0..num {
+            let x = i as f32 * shift - centerx + offset;
+            let y = j as f32 * shift + centery + 30.0;
+        }
+
+        offset -= 0.05 * rad * (num as f32 - 1.0);
+    }
+
+    /*
+     * Voxelization.
+     */
+    let polyline = vec![
+        point![0.0, 0.0],
+        point![0.0, 10.0],
+        point![7.0, 4.0],
+        point![14.0, 10.0],
+        point![14.0, 0.0],
+        point![13.0, 7.0],
+        point![7.0, 2.0],
+        point![1.0, 7.0],
+    ]
+    .iter()
+    .map(|p| p * scale)
+    .collect::<Vec<_>>();
+    let indices: Vec<_> = (0..polyline.len() as u32)
+        .map(|i| [i, (i + 1) % polyline.len() as u32])
+        .collect();
+
+    let shape = SharedShape::voxelized_mesh(
+        VoxelPrimitiveGeometry::PseudoCube,
+        &polyline,
+        &indices,
+        0.2 * scale,
+        FillMode::default(),
+    );
+    commands.spawn((
+        Transform::from_xyz(-20.0 * scale, -10.0 * scale, 0.0),
+        Collider::from(shape),
+    ));
+
+    /*
+     * A voxel wavy floor.
+     */
+    let voxel_size = Vector2::new(scale, scale);
+    let voxels: Vec<_> = (0..300)
+        .map(|i| {
+            let y = (i as f32 / 20.0).sin().clamp(-0.5, 0.5) * 20.0;
+            point![(i as f32 - 125.0) * voxel_size.x / 2.0, y * voxel_size.y]
+        })
+        .collect();
+    commands.spawn((
+        Transform::from_xyz(0.0, 0.0, 0.0),
+        Collider::from(rapier2d::prelude::SharedShape::voxels_from_points(
+            VoxelPrimitiveGeometry::PseudoCube,
+            voxel_size,
+            &voxels,
+        )),
+    ));
+}

--- a/bevy_rapier2d/examples/voxels2.rs
+++ b/bevy_rapier2d/examples/voxels2.rs
@@ -31,17 +31,10 @@ pub fn setup_physics(mut commands: Commands) {
     let nx = 50;
     for i in 0..nx {
         for j in 0..10 {
-            // if test_ccd {
-            //     rb = rb.linvel(vector![0.0, -1000.0] * scale).ccd_enabled(true);
-            // }
-            // let falling_objects = if falling_objects == 3 {
-            //     j % 3
-            // } else {
-            //     falling_objects
-            // };
+            let falling_objects = (j + i) % 3;
 
             let ball_radius = 0.5 * scale;
-            let co = match 0 {
+            let co = match falling_objects {
                 0 => Collider::ball(ball_radius),
                 1 => Collider::cuboid(ball_radius, ball_radius),
                 2 => Collider::capsule_y(ball_radius, ball_radius),
@@ -57,23 +50,6 @@ pub fn setup_physics(mut commands: Commands) {
                 co,
             ));
         }
-    }
-    let num = 8;
-    let rad = 10.0;
-
-    let shift = rad * 2.0 + rad;
-    let centerx = shift * (num / 2) as f32;
-    let centery = shift / 2.0;
-
-    let mut offset = -(num as f32) * (rad * 2.0 + rad) * 0.5;
-
-    for j in 0usize..20 {
-        for i in 0..num {
-            let x = i as f32 * shift - centerx + offset;
-            let y = j as f32 * shift + centery + 30.0;
-        }
-
-        offset -= 0.05 * rad * (num as f32 - 1.0);
     }
 
     /*

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -67,7 +67,7 @@ to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 [dependencies]
 bevy = { version = "0.16.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
-rapier3d = "0.24"
+rapier3d = "0.25"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -82,11 +82,14 @@ bevy = { version = "0.16.0", default-features = false, features = [
     "bevy_text",
     "bevy_ui",
     "default_font",
+    "bevy_log",
 ] }
 approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.31"
 bevy_egui = "0.34"
+# FIXME: target a proper release when support for bevy 0.16 is released.
+bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump.git", rev = "ad310179be78abb3c16c581324d7d83b26275028" }
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier3d/examples/debugdump3.rs
+++ b/bevy_rapier3d/examples/debugdump3.rs
@@ -1,0 +1,33 @@
+//! Example using bevy_mod_debugdump to output a graph of systems execution order.
+//! run with:
+//! `cargo run --example debugdump3 > dump.dot && dot -Tsvg dump.dot > dump.svg`
+
+use bevy::prelude::*;
+use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
+use bevy_rapier3d::prelude::*;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins((
+        DefaultPlugins,
+        RapierPhysicsPlugin::<NoUserData>::default(),
+        RapierDebugRenderPlugin::default(),
+    ));
+
+    let debugdump_settings = schedule_graph::Settings {
+        include_system: Some(Box::new(|system| {
+            if system.name().starts_with("bevy_pbr")
+                || system.name().starts_with("bevy_render")
+                || system.name().starts_with("bevy_gizmos")
+                || system.name().starts_with("bevy_winit")
+                || system.name().starts_with("bevy_sprite")
+            {
+                return false;
+            }
+            true
+        })),
+        ..Default::default()
+    };
+    let dot = schedule_graph_dot(&mut app, PostUpdate, &debugdump_settings);
+    println!("{dot}");
+}

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -11,6 +11,7 @@ mod multiple_colliders3;
 mod picking3;
 mod ray_casting3;
 mod static_trimesh3;
+mod voxels3;
 
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts, EguiPlugin};
@@ -22,6 +23,7 @@ pub enum Examples {
     #[default]
     None,
     Boxes3,
+    Voxels3,
     DebugToggle3,
     Despawn3,
     Events3,
@@ -76,6 +78,7 @@ fn main() {
         .init_state::<Examples>()
         .insert_resource(ExampleSet(vec![
             (Examples::Boxes3, "Boxes3").into(),
+            (Examples::Voxels3, "Voxels3").into(),
             (Examples::DebugToggle3, "DebugToggle3").into(),
             (Examples::Despawn3, "Despawn3").into(),
             (Examples::Events3, "Events3").into(),
@@ -89,12 +92,19 @@ fn main() {
         ]))
         .init_resource::<ExampleSelected>()
         //
-        //boxes2
+        // boxes3
         .add_systems(
             OnEnter(Examples::Boxes3),
             (boxes3::setup_graphics, boxes3::setup_physics),
         )
         .add_systems(OnExit(Examples::Boxes3), cleanup)
+        //
+        // voxels3
+        .add_systems(
+            OnEnter(Examples::Voxels3),
+            (voxels3::setup_graphics, voxels3::setup_physics),
+        )
+        .add_systems(OnExit(Examples::Voxels3), cleanup)
         //
         // Debug toggle
         .add_systems(

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -13,7 +13,10 @@ mod ray_casting3;
 mod static_trimesh3;
 mod voxels3;
 
-use bevy::prelude::*;
+use bevy::{
+    ecs::world::error::{EntityDespawnError, EntityMutableFetchError},
+    prelude::*,
+};
 use bevy_egui::{egui, EguiContexts, EguiPlugin};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
@@ -258,7 +261,12 @@ fn cleanup(world: &mut World) {
         .collect::<Vec<_>>();
 
     for r in remove {
-        world.despawn(r);
+        match world.try_despawn(r) {
+            Err(error @ EntityDespawnError(EntityMutableFetchError::AliasedMutability(_))) => {
+                warn!("Cleanup error: {error:?}");
+            }
+            _ => {}
+        }
     }
 }
 

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -259,13 +259,11 @@ fn cleanup(world: &mut World) {
         .iter_entities()
         .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
         .collect::<Vec<_>>();
-
     for r in remove {
-        match world.try_despawn(r) {
-            Err(error @ EntityDespawnError(EntityMutableFetchError::AliasedMutability(_))) => {
-                warn!("Cleanup error: {error:?}");
-            }
-            _ => {}
+        if let Err(error @ EntityDespawnError(EntityMutableFetchError::AliasedMutability(_))) =
+            world.try_despawn(r)
+        {
+            warn!("Cleanup error: {error:?}");
         }
     }
 }

--- a/bevy_rapier3d/examples/voxels3.rs
+++ b/bevy_rapier3d/examples/voxels3.rs
@@ -1,0 +1,104 @@
+use bevy::prelude::*;
+use bevy_rapier3d::prelude::*;
+use nalgebra::{point, Isometry, Vector3};
+use rapier3d::prelude::VoxelPrimitiveGeometry;
+
+fn main() {
+    App::new()
+        .insert_resource(ClearColor(Color::srgb(
+            0xF9 as f32 / 255.0,
+            0xF9 as f32 / 255.0,
+            0xFF as f32 / 255.0,
+        )))
+        .add_plugins((
+            DefaultPlugins,
+            RapierPhysicsPlugin::<NoUserData>::default(),
+            RapierDebugRenderPlugin::default(),
+        ))
+        .add_systems(Startup, (setup_graphics, setup_physics))
+        .run();
+}
+
+pub fn setup_graphics(mut commands: Commands) {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-100.0, 100.0, -100.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+    ));
+}
+
+pub fn setup_physics(mut commands: Commands) {
+    /*
+     * Create a voxelized wavy floor.
+     */
+    let voxel_size = Vector3::new(1f32, 1f32, 1f32);
+    let mut samples = vec![];
+    let n = 200;
+    for i in 0..n {
+        for j in 0..n {
+            let y = (i as f32 / n as f32 * 10.0).sin().clamp(-0.8, 0.8)
+                * (j as f32 / n as f32 * 10.0).cos().clamp(-0.8, 0.8)
+                * 16.0;
+
+            samples.push(point![
+                i as f32 * voxel_size.x,
+                y * voxel_size.y,
+                j as f32 * voxel_size.z
+            ]);
+
+            if i == 0 || i == n - 1 || j == 0 || j == n - 1 {
+                // Create walls so the object at the edge don’t fall into the infinite void.
+                for k in 0..4 {
+                    samples.push(point![
+                        i as f32 * voxel_size.x,
+                        (y + k as f32) * voxel_size.y,
+                        j as f32 * voxel_size.z
+                    ]);
+                }
+            }
+        }
+    }
+    let collider = rapier3d::prelude::SharedShape::voxels_from_points(
+        VoxelPrimitiveGeometry::PseudoCube,
+        voxel_size,
+        &samples,
+    );
+    let ground_position = Vec3::new(voxel_size.x / 2f32, 0.0, voxel_size.z / 2f32);
+    let floor_aabb = collider.compute_aabb(&Isometry::identity());
+    commands.spawn((
+        Transform::from_translation(ground_position),
+        Collider::from(collider),
+    ));
+
+    /*
+     * Create dynamic objects to fall on voxels.
+     */
+    let extents = floor_aabb.extents() * 0.75;
+    let margin = (floor_aabb.extents() - extents) / 2.0;
+    let nik = 30;
+    for i in 0..nik {
+        for j in 0..5 {
+            for k in 0..nik {
+                let falling_objects = (j + i + k) % 3;
+
+                let ball_radius = 0.5;
+                let co = match falling_objects {
+                    0 => Collider::ball(ball_radius),
+                    1 => Collider::cuboid(ball_radius, ball_radius, ball_radius),
+                    2 => Collider::capsule_y(ball_radius, ball_radius),
+                    _ => unreachable!(),
+                };
+                commands.spawn((
+                    Transform::from_xyz(
+                        floor_aabb.mins.x + margin.x + i as f32 * extents.x / nik as f32
+                            - ground_position.x,
+                        floor_aabb.maxs.y + j as f32 * 2.0 - ground_position.y,
+                        floor_aabb.mins.z + margin.z + k as f32 * extents.z / nik as f32
+                            - -ground_position.z,
+                    ),
+                    RigidBody::Dynamic,
+                    co,
+                ));
+            }
+        }
+    }
+}

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rapier3d = { features = ["profiler"], version = "0.23" }
+rapier3d = { features = ["profiler"], version = "0.25" }
 bevy_rapier3d = { version = "0.29", path = "../bevy_rapier3d" }
 bevy = { version = "0.16.0", default-features = false }
 

--- a/bevy_rapier_benches3d/README.md
+++ b/bevy_rapier_benches3d/README.md
@@ -16,7 +16,7 @@ For short-lived benchmarks based on statistical analysis,
 benchmarks can be run through the [divan](https://github.com/nvzqz/divan) bench harness.
 
 ```sh
-cargo bench -p bevy_rapier3d
+cargo bench -p bevy_rapier_benches3d
 ```
 
 ## Other resources

--- a/bevy_rapier_benches3d/src/common.rs
+++ b/bevy_rapier_benches3d/src/common.rs
@@ -7,7 +7,6 @@ pub fn default_app() -> App {
     app.add_plugins((
         MinimalPlugins,
         TransformPlugin,
-        TransformPlugin,
         RapierPhysicsPlugin::<()>::default(),
     ));
 

--- a/ci/src/bin/ambiguity_detection.rs
+++ b/ci/src/bin/ambiguity_detection.rs
@@ -19,6 +19,7 @@ fn main() {
             bevy_rapier3d::prelude::RapierPickingPlugin,
         ),
         true,
+        // FIXME: See https://github.com/dimforge/bevy_rapier/issues/650
         2,
     );
     check_ambiguities(

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -349,6 +349,11 @@ impl Collider {
         self.raw.as_triangle().map(|s| TriangleView { raw: s })
     }
 
+    /// Downcast this collider to a voxels, if it is one.
+    pub fn as_voxels(&self) -> Option<VoxelsView> {
+        self.raw.as_voxels().map(|s| VoxelsView { raw: s })
+    }
+
     /// Downcast this collider to a triangle mesh, if it is one.
     pub fn as_trimesh(&self) -> Option<TriMeshView> {
         self.raw.as_trimesh().map(|s| TriMeshView { raw: s })
@@ -442,6 +447,14 @@ impl Collider {
             .make_mut()
             .as_triangle_mut()
             .map(|s| TriangleViewMut { raw: s })
+    }
+
+    /// Downcast this collider to a mutable voxels, if it is one.
+    pub fn as_voxels_mut(&mut self) -> Option<VoxelsViewMut> {
+        self.raw
+            .make_mut()
+            .as_voxels_mut()
+            .map(|s| VoxelsViewMut { raw: s })
     }
 
     /// Downcast this collider to a mutable triangle mesh, if it is one.

--- a/src/geometry/shape_views/collider_view.rs
+++ b/src/geometry/shape_views/collider_view.rs
@@ -22,6 +22,8 @@ pub enum ColliderView<'a> {
     Segment(SegmentView<'a>),
     /// A triangle shape.
     Triangle(TriangleView<'a>),
+    /// A Voxels shape.
+    Voxels(VoxelsView<'a>),
     /// A triangle mesh shape.
     TriMesh(TriMeshView<'a>),
     /// A set of segments.
@@ -73,6 +75,7 @@ impl fmt::Debug for ColliderView<'_> {
             ColliderView::Capsule(view) => write!(f, "{:?}", view.raw),
             ColliderView::Segment(view) => write!(f, "{:?}", view.raw),
             ColliderView::Triangle(view) => write!(f, "{:?}", view.raw),
+            ColliderView::Voxels(view) => write!(f, "{:?}", view.raw),
             ColliderView::TriMesh(_) => write!(f, "Trimesh (not representable)"),
             ColliderView::Polyline(_) => write!(f, "Polyline (not representable)"),
             ColliderView::HalfSpace(view) => write!(f, "{:?}", view.raw),
@@ -108,6 +111,7 @@ impl<'a> From<TypedShape<'a>> for ColliderView<'a> {
             TypedShape::Capsule(s) => ColliderView::Capsule(CapsuleView { raw: s }),
             TypedShape::Segment(s) => ColliderView::Segment(SegmentView { raw: s }),
             TypedShape::Triangle(s) => ColliderView::Triangle(TriangleView { raw: s }),
+            TypedShape::Voxels(s) => ColliderView::Voxels(VoxelsView { raw: s }),
             TypedShape::TriMesh(s) => ColliderView::TriMesh(TriMeshView { raw: s }),
             TypedShape::Polyline(s) => ColliderView::Polyline(PolylineView { raw: s }),
             TypedShape::HalfSpace(s) => ColliderView::HalfSpace(HalfSpaceView { raw: s }),
@@ -129,8 +133,6 @@ impl<'a> From<TypedShape<'a>> for ColliderView<'a> {
             TypedShape::RoundTriangle(s) => {
                 ColliderView::RoundTriangle(RoundTriangleView { raw: s })
             }
-            // RoundedTriMesh,
-            // RoundedHeightField,
             #[cfg(feature = "dim2")]
             TypedShape::RoundConvexPolygon(s) => {
                 ColliderView::RoundConvexPolygon(RoundConvexPolygonView { raw: s })
@@ -171,6 +173,7 @@ impl<'a> ColliderView<'a> {
             ColliderView::Capsule(CapsuleView { raw: s }) => TypedShape::Capsule(s),
             ColliderView::Segment(SegmentView { raw: s }) => TypedShape::Segment(s),
             ColliderView::Triangle(TriangleView { raw: s }) => TypedShape::Triangle(s),
+            ColliderView::Voxels(VoxelsView { raw: s }) => TypedShape::Voxels(s),
             ColliderView::TriMesh(TriMeshView { raw: s }) => TypedShape::TriMesh(s),
             ColliderView::Polyline(PolylineView { raw: s }) => TypedShape::Polyline(s),
             ColliderView::HalfSpace(HalfSpaceView { raw: s }) => TypedShape::HalfSpace(s),
@@ -192,8 +195,6 @@ impl<'a> ColliderView<'a> {
             ColliderView::RoundTriangle(RoundTriangleView { raw: s }) => {
                 TypedShape::RoundTriangle(s)
             }
-            // RoundedTriMesh,
-            // RoundedHeightField,
             #[cfg(feature = "dim2")]
             ColliderView::RoundConvexPolygon(RoundConvexPolygonView { raw: s }) => {
                 TypedShape::RoundConvexPolygon(s)
@@ -219,6 +220,7 @@ impl<'a> ColliderView<'a> {
             ColliderView::Capsule(CapsuleView { raw }) => SharedShape::new(*raw),
             ColliderView::Segment(SegmentView { raw }) => SharedShape::new(*raw),
             ColliderView::Triangle(TriangleView { raw }) => SharedShape::new(*raw),
+            ColliderView::Voxels(VoxelsView { raw }) => SharedShape::new(raw.clone()),
             ColliderView::TriMesh(TriMeshView { raw }) => SharedShape::new(raw.clone()),
             ColliderView::Polyline(PolylineView { raw }) => SharedShape::new(raw.clone()),
             ColliderView::HalfSpace(HalfSpaceView { raw }) => SharedShape::new(*raw),
@@ -276,11 +278,14 @@ impl<'a> ColliderView<'a> {
                 Some(Either::Right(b)) => SharedShape::new(b),
             },
             ColliderView::Segment(s) => SharedShape::new(s.raw.scaled(&scale.into())),
-            // ColliderView::RoundSegment(s) => SharedShape::new(RoundShape {
-            //     border_radius: s.raw.border_radius,
-            //     inner_shape: s.raw.inner_shape.scaled(&scale.into()),
-            // }),
             ColliderView::Triangle(t) => SharedShape::new(t.raw.scaled(&scale.into())),
+            ColliderView::Voxels(cp) => match cp.raw.clone().scaled(&scale.into()) {
+                None => {
+                    log::error!("Failed to apply scale {} to Voxels shape.", scale);
+                    SharedShape::ball(0.0)
+                }
+                Some(scaled) => SharedShape::new(scaled),
+            },
             ColliderView::RoundTriangle(t) => SharedShape::new(RoundShape {
                 border_radius: t.raw.border_radius,
                 inner_shape: t.raw.inner_shape.scaled(&scale.into()),

--- a/src/geometry/shape_views/mod.rs
+++ b/src/geometry/shape_views/mod.rs
@@ -10,6 +10,7 @@ pub use self::round_shape::*;
 pub use self::segment::*;
 pub use self::triangle::*;
 pub use self::trimesh::*;
+pub use self::voxels::*;
 
 #[cfg(feature = "dim2")]
 pub use self::convex_polygon::*;
@@ -29,6 +30,7 @@ mod round_shape;
 mod segment;
 mod triangle;
 mod trimesh;
+mod voxels;
 
 #[cfg(feature = "dim2")]
 mod convex_polygon;

--- a/src/geometry/shape_views/voxels.rs
+++ b/src/geometry/shape_views/voxels.rs
@@ -6,3 +6,9 @@ pub struct VoxelsView<'a> {
     /// The raw shape from Rapier.
     pub raw: &'a Voxels,
 }
+
+/// Read-write access to the properties of a [`Voxels`].
+pub struct VoxelsViewMut<'a> {
+    /// The raw shape from Rapier.
+    pub raw: &'a mut Voxels,
+}

--- a/src/geometry/shape_views/voxels.rs
+++ b/src/geometry/shape_views/voxels.rs
@@ -1,0 +1,8 @@
+use rapier::prelude::Voxels;
+
+/// Read-only access to the properties of a [`Voxels`] shape.
+#[derive(Copy, Clone)]
+pub struct VoxelsView<'a> {
+    /// The raw shape from Rapier.
+    pub raw: &'a Voxels,
+}

--- a/src/geometry/to_bevy_mesh.rs
+++ b/src/geometry/to_bevy_mesh.rs
@@ -83,8 +83,8 @@ pub fn typed_shape_to_mesh(typed_shape: &TypedShape) -> Option<Mesh> {
             {
                 log::warn!("Voxels not implemented in 2d yet");
                 // let (vtx, idx) = voxels.to_polyline();
+                return None;
             }
-            return None;
         }
         TypedShape::TriMesh(tri_mesh) => {
             let vertices = tri_mesh.vertices();


### PR DESCRIPTION
upgrade to rapier 0.25, fix benches, and adds support for `Voxels` shape, + examples for 2d and 3d.