### PR TITLE
Upgrade bevy_mod_debugdump to 0.13

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -84,8 +84,7 @@ approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.31"
 bevy_egui = "0.34"
-# FIXME: target a proper release when support for bevy 0.16 is released.
-bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump.git", rev = "ad310179be78abb3c16c581324d7d83b26275028" }
+bevy_mod_debugdump = "0.13"
 serde_json = "1.0"
 
 [package.metadata.docs.rs]

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -88,8 +88,7 @@ approx = "0.5.1"
 glam = { version = "0.29", features = ["approx"] }
 bevy-inspector-egui = "0.31"
 bevy_egui = "0.34"
-# FIXME: target a proper release when support for bevy 0.16 is released.
-bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump.git", rev = "ad310179be78abb3c16c581324d7d83b26275028" }
+bevy_mod_debugdump = "0.13"
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs


### PR DESCRIPTION
Switch from Git dependency to already released 0.13 version of `bevy_mod_debugdump` compatible with Bevy 0.16.
Addresses one of points in #650