### PR TITLE
Expose RapierBevyComponentApply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Expose `RapierBevyComponentApply`, to help with creating your own schedules when you set `default_system_setup` to `false`.
+
 ## v0.30.0 (15 May 2025)
 
 ### Added

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -4,8 +4,8 @@ pub use self::context::{
     DefaultRapierContext, RapierContextEntityLink, SimulationToRenderTime,
 };
 pub use self::plugin::{
-    NoUserData, PhysicsSet, RapierContextInitialization, RapierPhysicsPlugin,
-    RapierTransformPropagateSet,
+    NoUserData, PhysicsSet, RapierBevyComponentApply, RapierContextInitialization,
+    RapierPhysicsPlugin, RapierTransformPropagateSet,
 };
 pub use narrow_phase::{ContactManifoldView, ContactPairView, ContactView, SolverContactView};
 


### PR DESCRIPTION
This is required so that you can create your own schedules when you set `default_system_setup` to false.