### PR TITLE
fix: add separate joint axes for each link resolving issue #665

### DIFF
--- a/src/dynamics/revolute_joint.rs
+++ b/src/dynamics/revolute_joint.rs
@@ -245,13 +245,13 @@ impl RevoluteJointBuilder {
     pub fn local_axis1(mut self, axis1: Vect) -> Self {
         self.0.set_local_axis1(axis1);
         self
-    } 
+    }
 
     /// Sets the joint's axis, expressed in the local-space of the second rigid-body
     pub fn local_axis2(mut self, axis2: Vect) -> Self {
         self.0.set_local_axis2(axis2);
         self
-    } 
+    }
 
     /// Set the spring-like model used by the motor to reach the desired target velocity and position.
     #[must_use]


### PR DESCRIPTION
- Added setters to RevoluteJointBuilder to handle different joint axes in the links' local-spaces.
- Tested the feature
- Resolved #665 
- Add `set_local_axis1` and `set_local_axis2` to `RevoluteJoint` and `RevoluteJointBuilder`.