### PR TITLE
Update rapier to 0.27

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -2,17 +2,17 @@ name: Dependencies
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
-      - 'releases/**'
+      - "dependabot/**"
+      - "releases/**"
     paths:
-      - 'Cargo.toml'
-      - 'deny.toml'
+      - "Cargo.toml"
+      - "deny.toml"
   pull_request:
     paths:
-      - 'Cargo.toml'
-      - 'deny.toml'
+      - "Cargo.toml"
+      - "deny.toml"
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
 env:
   CARGO_TERM_COLOR: always
 jobs:
@@ -24,4 +24,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check dependencies
-        uses: EmbarkStudios/cargo-deny-action@v1
+        uses: EmbarkStudios/cargo-deny-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 - Update from rapier `0.25` to rapier `0.27`,
   see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
+  - `RapierQueryPipeline` is no longer a component.
+    - Migration: Use `RapierContext` or retrieve the needed components to pass to `RapierQueryPipeline::new_scoped` and make your logic in a scoped function. This function allows capturing and returning information.
+  - a new `QueryPipelineMut`  to provide the same API as rapier. It's currently used for the character controller.
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Expose `RapierBevyComponentApply`, to help with creating your own schedules when you set `default_system_setup` to `false`.
 - Add `set_local_axis1` and `set_local_axis2` to `RevoluteJoint` and `RevoluteJointBuilder`. [#666](https://github.com/dimforge/bevy_rapier/pull/666)
 
+### Modified
+
+- Update from rapier `0.25` to rapier `0.27`,
+  see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
+
 ### Fix
 
 - Fix scale being applied with a frame delay. [#659](https://github.com/dimforge/bevy_rapier/pull/659)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,12 @@ codegen-units = 1
 #nalgebra = { path = "../nalgebra" }
 #parry2d = { path = "../parry/crates/parry2d" }
 #parry3d = { path = "../parry/crates/parry3d" }
-rapier2d = { path = "../rapier/crates/rapier2d" }
-rapier3d = { path = "../rapier/crates/rapier3d" }
+#rapier2d = { path = "../rapier/crates/rapier2d" }
+#rapier3d = { path = "../rapier/crates/rapier3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
 #parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #rapier2d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
+rapier2d = { git = "https://github.com/vrixyz/rapier", branch = "bevy_rapier_compatibility" }
+rapier3d = { git = "https://github.com/vrixyz/rapier", branch = "bevy_rapier_compatibility" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,3 @@ codegen-units = 1
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #rapier2d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
-rapier2d = { git = "https://github.com/vrixyz/rapier", branch = "bevy_rapier_compatibility" }
-rapier3d = { git = "https://github.com/vrixyz/rapier", branch = "bevy_rapier_compatibility" }
-parry2d = { git = "https://github.com/dimforge/parry", branch = "bvh-remove-fix2" }
-parry3d = { git = "https://github.com/dimforge/parry", branch = "bvh-remove-fix2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ codegen-units = 1
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
 rapier2d = { git = "https://github.com/vrixyz/rapier", branch = "bevy_rapier_compatibility" }
 rapier3d = { git = "https://github.com/vrixyz/rapier", branch = "bevy_rapier_compatibility" }
+parry2d = { git = "https://github.com/vrixyz/parry", branch = "fix_bvh_index_update" }
+parry3d = { git = "https://github.com/vrixyz/parry", branch = "fix_bvh_index_update" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ codegen-units = 1
 #nalgebra = { path = "../nalgebra" }
 #parry2d = { path = "../parry/crates/parry2d" }
 #parry3d = { path = "../parry/crates/parry3d" }
-# rapier2d = { path = "../rapier/crates/rapier2d" }
-# rapier3d = { path = "../rapier/crates/rapier3d" }
+rapier2d = { path = "../rapier/crates/rapier2d" }
+rapier3d = { path = "../rapier/crates/rapier3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
 #parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
 #parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ codegen-units = 1
 #rapier3d = { git = "https://github.com/dimforge/rapier", branch = "character-controller" }
 rapier2d = { git = "https://github.com/vrixyz/rapier", branch = "bevy_rapier_compatibility" }
 rapier3d = { git = "https://github.com/vrixyz/rapier", branch = "bevy_rapier_compatibility" }
-parry2d = { git = "https://github.com/vrixyz/parry", branch = "fix_bvh_index_update" }
-parry3d = { git = "https://github.com/vrixyz/parry", branch = "fix_bvh_index_update" }
+parry2d = { git = "https://github.com/dimforge/parry", branch = "bvh-remove-fix2" }
+parry3d = { git = "https://github.com/dimforge/parry", branch = "bvh-remove-fix2" }

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -66,7 +66,7 @@ to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 [dependencies]
 bevy = { version = "0.16.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
-rapier2d = "0.25"
+rapier2d = "0.27.0-beta.0"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/bevy_rapier2d/examples/custom_system_setup2.rs
+++ b/bevy_rapier2d/examples/custom_system_setup2.rs
@@ -51,7 +51,7 @@ fn despawn_one_box(
     query: Query<Entity, (With<Collider>, With<RigidBody>)>,
 ) {
     // Delete a box every 10 frames
-    if frame_count.0 % 10 == 0 && !query.is_empty() {
+    if frame_count.0.is_multiple_of(10) && !query.is_empty() {
         let len = query.iter().len();
         // Get a "random" box to make sim interesting
         if let Some(entity) = query.iter().nth(frame_count.0 as usize % len) {

--- a/bevy_rapier2d/examples/despawn2.rs
+++ b/bevy_rapier2d/examples/despawn2.rs
@@ -85,7 +85,7 @@ pub fn setup_physics(mut commands: Commands) {
                 Collider::cuboid(rad, rad),
             ));
 
-            if (i + j * num) % 100 == 0 {
+            if (i + j * num).is_multiple_of(100) {
                 entity.insert(Resize);
             }
         }

--- a/bevy_rapier2d/examples/voxels2.rs
+++ b/bevy_rapier2d/examples/voxels2.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
-use rapier2d::prelude::VoxelPrimitiveGeometry;
 
 fn main() {
     App::new()
@@ -73,13 +72,7 @@ pub fn setup_physics(mut commands: Commands) {
 
     commands.spawn((
         Transform::from_xyz(-20.0 * scale, -10.0 * scale, 0.0),
-        Collider::voxelized_mesh(
-            VoxelPrimitiveGeometry::PseudoCube,
-            &polyline,
-            &indices,
-            0.2 * scale,
-            FillMode::default(),
-        ),
+        Collider::voxelized_mesh(&polyline, &indices, 0.2 * scale, FillMode::default()),
     ));
 
     /*
@@ -94,6 +87,6 @@ pub fn setup_physics(mut commands: Commands) {
         .collect();
     commands.spawn((
         Transform::from_xyz(0.0, 0.0, 0.0),
-        Collider::voxels_from_points(VoxelPrimitiveGeometry::PseudoCube, voxel_size, &voxels),
+        Collider::voxels_from_points(voxel_size, &voxels),
     ));
 }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -67,7 +67,7 @@ to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 [dependencies]
 bevy = { version = "0.16.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.33", features = ["convert-glam029"] }
-rapier3d = "0.25"
+rapier3d = "0.27.0-beta.0"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -51,7 +51,7 @@ fn despawn_one_box(
     query: Query<Entity, (With<Collider>, With<RigidBody>)>,
 ) {
     // Delete a box every 5 frames
-    if frame_count.0 % 5 == 0 && !query.is_empty() {
+    if frame_count.0.is_multiple_of(5) && !query.is_empty() {
         let len = query.iter().len();
         // Get a "random" box to make sim interesting
         if let Some(entity) = query.iter().nth(frame_count.0 as usize % len) {

--- a/bevy_rapier3d/examples/joints3.rs
+++ b/bevy_rapier3d/examples/joints3.rs
@@ -46,7 +46,7 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
     for i in 0..num {
         let dz = (i + 1) as f32 * shift;
 
-        let axis = if i % 2 == 0 {
+        let axis = if i.is_multiple_of(2) {
             Vec3::new(1.0, 1.0, 0.0)
         } else {
             Vec3::new(-1.0, 1.0, 0.0)
@@ -171,7 +171,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Vec3, num: usize) {
             // NOTE: the num - 2 test is to avoid two consecutive
             // fixed bodies. Because physx will crash if we add
             // a joint between these.
-            let rigid_body = if i == 0 && (k % 4 == 0 && k != num - 2 || k == num - 1) {
+            let rigid_body = if i == 0 && (k.is_multiple_of(4) && k != num - 2 || k == num - 1) {
                 RigidBody::Fixed
             } else {
                 RigidBody::Dynamic
@@ -226,7 +226,7 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
             let fk = k as f32;
             let fi = i as f32;
 
-            let rigid_body = if i == 0 && (k % 4 == 0 || k == num - 1) {
+            let rigid_body = if i == 0 && (k.is_multiple_of(4) || k == num - 1) {
                 RigidBody::Fixed
             } else {
                 RigidBody::Dynamic

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -51,7 +51,7 @@ fn create_prismatic_joints(commands: &mut Commands, origin: Vect, num: usize) {
     for i in 0..num {
         let dz = (i + 1) as f32 * shift;
 
-        let axis = if i % 2 == 0 {
+        let axis = if i.is_multiple_of(2) {
             Vec3::new(1.0, 1.0, 0.0)
         } else {
             Vec3::new(-1.0, 1.0, 0.0)
@@ -158,7 +158,7 @@ fn create_fixed_joints(commands: &mut Commands, origin: Vec3, num: usize) {
             // NOTE: the num - 2 test is to avoid two consecutive
             // fixed bodies. Because physx will crash if we add
             // a joint between these.
-            let rigid_body = if i == 0 && (k % 4 == 0 && k != num - 2 || k == num - 1) {
+            let rigid_body = if i == 0 && (k.is_multiple_of(4) && k != num - 2 || k == num - 1) {
                 RigidBody::Fixed
             } else {
                 RigidBody::Dynamic
@@ -213,7 +213,7 @@ fn create_ball_joints(commands: &mut Commands, num: usize) {
             let fk = k as f32;
             let fi = i as f32;
 
-            let rigid_body = if i == 0 && (k % 4 == 0 || k == num - 1) {
+            let rigid_body = if i == 0 && (k.is_multiple_of(4) || k == num - 1) {
                 RigidBody::Fixed
             } else {
                 RigidBody::Dynamic

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -2,6 +2,7 @@ use bevy::color::palettes::basic;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use bevy_rapier3d::prelude::*;
+use rapier3d::prelude::QueryFilter;
 
 fn main() {
     App::new()
@@ -91,13 +92,14 @@ pub fn cast_ray(
             return Ok(());
         };
         let context = rapier_context.single()?;
+        let query_pipeline = context.query_pipeline(QueryFilter::only_dynamic());
         // Then cast the ray.
         let hit = context.cast_ray(
+            &query_pipeline,
             ray.origin,
             ray.direction.into(),
             f32::MAX,
             true,
-            QueryFilter::only_dynamic(),
         );
 
         if let Some((entity, _toi)) = hit {

--- a/bevy_rapier3d/examples/ray_casting3.rs
+++ b/bevy_rapier3d/examples/ray_casting3.rs
@@ -2,7 +2,6 @@ use bevy::color::palettes::basic;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 use bevy_rapier3d::prelude::*;
-use rapier3d::prelude::QueryFilter;
 
 fn main() {
     App::new()
@@ -92,23 +91,18 @@ pub fn cast_ray(
             return Ok(());
         };
         let context = rapier_context.single()?;
-        let query_pipeline = context.query_pipeline(QueryFilter::only_dynamic());
-        // Then cast the ray.
-        let hit = context.cast_ray(
-            &query_pipeline,
-            ray.origin,
-            ray.direction.into(),
-            f32::MAX,
-            true,
-        );
+        context.with_query_pipeline(QueryFilter::only_dynamic(), |query_pipeline| {
+            // Then cast the ray.
+            let hit = query_pipeline.cast_ray(ray.origin, ray.direction.into(), f32::MAX, true);
 
-        if let Some((entity, _toi)) = hit {
-            // Color in blue the entity we just hit.
-            // Because of the query filter, only colliders attached to a dynamic body
-            // will get an event.
-            let color = basic::BLUE.into();
-            commands.entity(entity).insert(ColliderDebugColor(color));
-        }
+            if let Some((entity, _toi)) = hit {
+                // Color in blue the entity we just hit.
+                // Because of the query filter, only colliders attached to a dynamic body
+                // will get an event.
+                let color = basic::BLUE.into();
+                commands.entity(entity).insert(ColliderDebugColor(color));
+            }
+        });
     }
 
     Ok(())

--- a/bevy_rapier3d/examples/voxels3.rs
+++ b/bevy_rapier3d/examples/voxels3.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
-use rapier3d::{math::Isometry, prelude::VoxelPrimitiveGeometry};
+use rapier3d::math::Isometry;
 
 fn main() {
     App::new()
@@ -56,8 +56,7 @@ pub fn setup_physics(mut commands: Commands) {
             }
         }
     }
-    let collider =
-        Collider::voxels_from_points(VoxelPrimitiveGeometry::PseudoCube, voxel_size, &samples);
+    let collider = Collider::voxels_from_points(voxel_size, &samples);
     let ground_position = Vec3::new(voxel_size.x / 2f32, 0.0, voxel_size.z / 2f32);
     let floor_aabb = collider.raw.compute_aabb(&Isometry::identity());
     commands.spawn((Transform::from_translation(ground_position), collider));

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rapier3d = { features = ["profiler"], version = "0.25" }
+rapier3d = { features = ["profiler"], version = "0.27.0-beta.0" }
 bevy_rapier3d = { version = "0.30", path = "../bevy_rapier3d" }
 bevy = { version = "0.16.0", default-features = false }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,21 +1,19 @@
 [advisories]
 yanked = "deny"
-ignore = [
-    { id = "RUSTSEC-2024-0384", reason = "this is about instant crate, which is only used for benchmarks + an upstream fix is in the works." },
-]
 
 [licenses]
 allow = [
     "MIT-0",
     "MIT",
     "Apache-2.0",
-    "Unicode-DFS-2016",
     "Zlib",
     "CC0-1.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
     "Unicode-3.0",
+    "NCSA",
+    "Apache-2.0 WITH LLVM-exception",
 ]
 
 [[licenses.clarify]]

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,13 @@
 [advisories]
 yanked = "deny"
+ignore = [
+    # paste was announced as unmaintained with no explanation or replacement
+    # See: 
+    # - https://rustsec.org/advisories/RUSTSEC-2024-0436
+    # - https://github.com/bevyengine/bevy/pull/18209
+    # Bevy relies on this in multiple indirect ways, so ignoring it is the only feasible current solution
+    "RUSTSEC-2024-0436",
+]
 
 [licenses]
 allow = [

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -8,7 +8,7 @@ use {
 
 use rapier::{
     parry::transformation::voxelization::FillMode,
-    prelude::{FeatureId, Point, Ray, SharedShape, Vector, VoxelPrimitiveGeometry, Voxels, DIM},
+    prelude::{FeatureId, Point, Ray, SharedShape, Vector, Voxels, DIM},
 };
 
 use super::{get_snapped_scale, shape_views::*};
@@ -183,15 +183,10 @@ impl Collider {
     /// For initializing a voxels shape from a mesh to voxelize, see [`Self::voxelized_mesh`].
     /// For initializing multiple voxels shape from the convex decomposition of a mesh, see
     /// [`Self::voxelized_convex_decomposition`].
-    pub fn voxels(
-        primitive_geometry: VoxelPrimitiveGeometry,
-        voxel_size: Vect,
-        grid_coords: &[IVect],
-    ) -> Self {
+    pub fn voxels(voxel_size: Vect, grid_coordinates: &[IVect]) -> Self {
         let shape = Voxels::new(
-            primitive_geometry,
             voxel_size.into(),
-            &Self::ivec_array_from_point_int_array(grid_coords),
+            &Self::ivec_array_from_point_int_array(grid_coordinates),
         );
         SharedShape::new(shape).into()
     }
@@ -200,13 +195,8 @@ impl Collider {
     ///
     /// Each voxel has the size `voxel_size` and contains at least one point from `centers`.
     /// The `primitive_geometry` controls the behavior of collision detection at voxels boundaries.
-    pub fn voxels_from_points(
-        primitive_geometry: VoxelPrimitiveGeometry,
-        voxel_size: Vect,
-        points: &[Vect],
-    ) -> Self {
+    pub fn voxels_from_points(voxel_size: Vect, points: &[Vect]) -> Self {
         SharedShape::voxels_from_points(
-            primitive_geometry,
             voxel_size.into(),
             &Self::vec_array_from_point_float_array(points),
         )
@@ -216,32 +206,19 @@ impl Collider {
     /// Initializes a voxels shape obtained from the decomposition of the given trimesh (in 3D)
     /// or polyline (in 2D) into voxelized convex parts.
     pub fn voxelized_mesh(
-        primitive_geometry: VoxelPrimitiveGeometry,
         vertices: &[Vect],
         indices: &[[u32; DIM]],
         voxel_size: Real,
         fill_mode: FillMode,
     ) -> Self {
         let vertices = Self::vec_array_from_point_float_array(vertices);
-        SharedShape::voxelized_mesh(
-            primitive_geometry,
-            &vertices,
-            indices,
-            voxel_size,
-            fill_mode,
-        )
-        .into()
+        SharedShape::voxelized_mesh(&vertices, indices, voxel_size, fill_mode).into()
     }
 
     /// Initializes a compound shape obtained from the decomposition of the given trimesh (in 3D)
     /// or polyline (in 2D) into voxelized convex parts.
-    pub fn voxelized_convex_decomposition(
-        primitive_geometry: VoxelPrimitiveGeometry,
-        vertices: &[Vect],
-        indices: &[[u32; DIM]],
-    ) -> Vec<Self> {
+    pub fn voxelized_convex_decomposition(vertices: &[Vect], indices: &[[u32; DIM]]) -> Vec<Self> {
         Self::voxelized_convex_decomposition_with_params(
-            primitive_geometry,
             vertices,
             indices,
             &VHACDParameters::default(),
@@ -251,13 +228,11 @@ impl Collider {
     /// Initializes a compound shape obtained from the decomposition of the given trimesh (in 3D)
     /// or polyline (in 2D) into voxelized convex parts.
     pub fn voxelized_convex_decomposition_with_params(
-        primitive_geometry: VoxelPrimitiveGeometry,
         vertices: &[Vect],
         indices: &[[u32; DIM]],
         params: &VHACDParameters,
     ) -> Vec<Self> {
         SharedShape::voxelized_convex_decomposition_with_params(
-            primitive_geometry,
             &Self::vec_array_from_point_float_array(vertices),
             indices,
             params,

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -413,75 +413,75 @@ impl Collider {
     }
 
     /// Takes a strongly typed reference of this collider.
-    pub fn as_typed_shape(&self) -> ColliderView {
+    pub fn as_typed_shape(&self) -> ColliderView<'_> {
         self.raw.as_typed_shape().into()
     }
 
     /// Takes a strongly typed reference of the unscaled version of this collider.
-    pub fn as_unscaled_typed_shape(&self) -> ColliderView {
+    pub fn as_unscaled_typed_shape(&self) -> ColliderView<'_> {
         self.unscaled.as_typed_shape().into()
     }
 
     /// Downcast this collider to a ball, if it is one.
-    pub fn as_ball(&self) -> Option<BallView> {
+    pub fn as_ball(&self) -> Option<BallView<'_>> {
         self.raw.as_ball().map(|s| BallView { raw: s })
     }
 
     /// Downcast this collider to a cuboid, if it is one.
-    pub fn as_cuboid(&self) -> Option<CuboidView> {
+    pub fn as_cuboid(&self) -> Option<CuboidView<'_>> {
         self.raw.as_cuboid().map(|s| CuboidView { raw: s })
     }
 
     /// Downcast this collider to a capsule, if it is one.
-    pub fn as_capsule(&self) -> Option<CapsuleView> {
+    pub fn as_capsule(&self) -> Option<CapsuleView<'_>> {
         self.raw.as_capsule().map(|s| CapsuleView { raw: s })
     }
 
     /// Downcast this collider to a segment, if it is one.
-    pub fn as_segment(&self) -> Option<SegmentView> {
+    pub fn as_segment(&self) -> Option<SegmentView<'_>> {
         self.raw.as_segment().map(|s| SegmentView { raw: s })
     }
 
     /// Downcast this collider to a triangle, if it is one.
-    pub fn as_triangle(&self) -> Option<TriangleView> {
+    pub fn as_triangle(&self) -> Option<TriangleView<'_>> {
         self.raw.as_triangle().map(|s| TriangleView { raw: s })
     }
 
     /// Downcast this collider to a voxels, if it is one.
-    pub fn as_voxels(&self) -> Option<VoxelsView> {
+    pub fn as_voxels(&self) -> Option<VoxelsView<'_>> {
         self.raw.as_voxels().map(|s| VoxelsView { raw: s })
     }
 
     /// Downcast this collider to a triangle mesh, if it is one.
-    pub fn as_trimesh(&self) -> Option<TriMeshView> {
+    pub fn as_trimesh(&self) -> Option<TriMeshView<'_>> {
         self.raw.as_trimesh().map(|s| TriMeshView { raw: s })
     }
 
     /// Downcast this collider to a polyline, if it is one.
-    pub fn as_polyline(&self) -> Option<PolylineView> {
+    pub fn as_polyline(&self) -> Option<PolylineView<'_>> {
         self.raw.as_polyline().map(|s| PolylineView { raw: s })
     }
 
     /// Downcast this collider to a half-space, if it is one.
-    pub fn as_halfspace(&self) -> Option<HalfSpaceView> {
+    pub fn as_halfspace(&self) -> Option<HalfSpaceView<'_>> {
         self.raw.as_halfspace().map(|s| HalfSpaceView { raw: s })
     }
 
     /// Downcast this collider to a heightfield, if it is one.
-    pub fn as_heightfield(&self) -> Option<HeightFieldView> {
+    pub fn as_heightfield(&self) -> Option<HeightFieldView<'_>> {
         self.raw
             .as_heightfield()
             .map(|s| HeightFieldView { raw: s })
     }
 
     /// Downcast this collider to a compound shape, if it is one.
-    pub fn as_compound(&self) -> Option<CompoundView> {
+    pub fn as_compound(&self) -> Option<CompoundView<'_>> {
         self.raw.as_compound().map(|s| CompoundView { raw: s })
     }
 
     /// Downcast this collider to a convex polygon, if it is one.
     #[cfg(feature = "dim2")]
-    pub fn as_convex_polygon(&self) -> Option<ConvexPolygonView> {
+    pub fn as_convex_polygon(&self) -> Option<ConvexPolygonView<'_>> {
         self.raw
             .as_convex_polygon()
             .map(|s| ConvexPolygonView { raw: s })
@@ -489,7 +489,7 @@ impl Collider {
 
     /// Downcast this collider to a convex polyhedron, if it is one.
     #[cfg(feature = "dim3")]
-    pub fn as_convex_polyhedron(&self) -> Option<ConvexPolyhedronView> {
+    pub fn as_convex_polyhedron(&self) -> Option<ConvexPolyhedronView<'_>> {
         self.raw
             .as_convex_polyhedron()
             .map(|s| ConvexPolyhedronView { raw: s })
@@ -497,18 +497,18 @@ impl Collider {
 
     /// Downcast this collider to a cylinder, if it is one.
     #[cfg(feature = "dim3")]
-    pub fn as_cylinder(&self) -> Option<CylinderView> {
+    pub fn as_cylinder(&self) -> Option<CylinderView<'_>> {
         self.raw.as_cylinder().map(|s| CylinderView { raw: s })
     }
 
     /// Downcast this collider to a cone, if it is one.
     #[cfg(feature = "dim3")]
-    pub fn as_cone(&self) -> Option<ConeView> {
+    pub fn as_cone(&self) -> Option<ConeView<'_>> {
         self.raw.as_cone().map(|s| ConeView { raw: s })
     }
 
     /// Downcast this collider to a mutable ball, if it is one.
-    pub fn as_ball_mut(&mut self) -> Option<BallViewMut> {
+    pub fn as_ball_mut(&mut self) -> Option<BallViewMut<'_>> {
         self.raw
             .make_mut()
             .as_ball_mut()
@@ -516,7 +516,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable cuboid, if it is one.
-    pub fn as_cuboid_mut(&mut self) -> Option<CuboidViewMut> {
+    pub fn as_cuboid_mut(&mut self) -> Option<CuboidViewMut<'_>> {
         self.raw
             .make_mut()
             .as_cuboid_mut()
@@ -524,7 +524,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable capsule, if it is one.
-    pub fn as_capsule_mut(&mut self) -> Option<CapsuleViewMut> {
+    pub fn as_capsule_mut(&mut self) -> Option<CapsuleViewMut<'_>> {
         self.raw
             .make_mut()
             .as_capsule_mut()
@@ -532,7 +532,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable segment, if it is one.
-    pub fn as_segment_mut(&mut self) -> Option<SegmentViewMut> {
+    pub fn as_segment_mut(&mut self) -> Option<SegmentViewMut<'_>> {
         self.raw
             .make_mut()
             .as_segment_mut()
@@ -540,7 +540,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable triangle, if it is one.
-    pub fn as_triangle_mut(&mut self) -> Option<TriangleViewMut> {
+    pub fn as_triangle_mut(&mut self) -> Option<TriangleViewMut<'_>> {
         self.raw
             .make_mut()
             .as_triangle_mut()
@@ -548,7 +548,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable voxels, if it is one.
-    pub fn as_voxels_mut(&mut self) -> Option<VoxelsViewMut> {
+    pub fn as_voxels_mut(&mut self) -> Option<VoxelsViewMut<'_>> {
         self.raw
             .make_mut()
             .as_voxels_mut()
@@ -556,7 +556,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable triangle mesh, if it is one.
-    pub fn as_trimesh_mut(&mut self) -> Option<TriMeshViewMut> {
+    pub fn as_trimesh_mut(&mut self) -> Option<TriMeshViewMut<'_>> {
         self.raw
             .make_mut()
             .as_trimesh_mut()
@@ -564,7 +564,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable polyline, if it is one.
-    pub fn as_polyline_mut(&mut self) -> Option<PolylineViewMut> {
+    pub fn as_polyline_mut(&mut self) -> Option<PolylineViewMut<'_>> {
         self.raw
             .make_mut()
             .as_polyline_mut()
@@ -572,7 +572,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable half-space, if it is one.
-    pub fn as_halfspace_mut(&mut self) -> Option<HalfSpaceViewMut> {
+    pub fn as_halfspace_mut(&mut self) -> Option<HalfSpaceViewMut<'_>> {
         self.raw
             .make_mut()
             .as_halfspace_mut()
@@ -580,7 +580,7 @@ impl Collider {
     }
 
     /// Downcast this collider to a mutable heightfield, if it is one.
-    pub fn as_heightfield_mut(&mut self) -> Option<HeightFieldViewMut> {
+    pub fn as_heightfield_mut(&mut self) -> Option<HeightFieldViewMut<'_>> {
         self.raw
             .make_mut()
             .as_heightfield_mut()
@@ -612,7 +612,7 @@ impl Collider {
 
     /// Downcast this collider to a mutable cylinder, if it is one.
     #[cfg(feature = "dim3")]
-    pub fn as_cylinder_mut(&mut self) -> Option<CylinderViewMut> {
+    pub fn as_cylinder_mut(&mut self) -> Option<CylinderViewMut<'_>> {
         self.raw
             .make_mut()
             .as_cylinder_mut()
@@ -621,7 +621,7 @@ impl Collider {
 
     /// Downcast this collider to a mutable cone, if it is one.
     #[cfg(feature = "dim3")]
-    pub fn as_cone_mut(&mut self) -> Option<ConeViewMut> {
+    pub fn as_cone_mut(&mut self) -> Option<ConeViewMut<'_>> {
         self.raw
             .make_mut()
             .as_cone_mut()

--- a/src/geometry/shape_views/capsule.rs
+++ b/src/geometry/shape_views/capsule.rs
@@ -13,7 +13,7 @@ macro_rules! impl_ref_methods(
     ($View: ident) => {
         impl<'a> $View<'a> {
             /// The axis and endpoint of the capsule.
-            pub fn segment(&self) -> SegmentView {
+            pub fn segment(&self) -> SegmentView<'_> {
                 SegmentView {
                     raw: &self.raw.segment,
                 }

--- a/src/geometry/shape_views/collider_view.rs
+++ b/src/geometry/shape_views/collider_view.rs
@@ -279,13 +279,7 @@ impl<'a> ColliderView<'a> {
             },
             ColliderView::Segment(s) => SharedShape::new(s.raw.scaled(&scale.into())),
             ColliderView::Triangle(t) => SharedShape::new(t.raw.scaled(&scale.into())),
-            ColliderView::Voxels(cp) => match cp.raw.clone().scaled(&scale.into()) {
-                None => {
-                    log::error!("Failed to apply scale {scale} to Voxels shape.");
-                    SharedShape::ball(0.0)
-                }
-                Some(scaled) => SharedShape::new(scaled),
-            },
+            ColliderView::Voxels(cp) => SharedShape::new(cp.raw.clone().scaled(&scale.into())),
             ColliderView::RoundTriangle(t) => SharedShape::new(RoundShape {
                 border_radius: t.raw.border_radius,
                 inner_shape: t.raw.inner_shape.scaled(&scale.into()),

--- a/src/geometry/shape_views/compound.rs
+++ b/src/geometry/shape_views/compound.rs
@@ -12,7 +12,7 @@ pub struct CompoundView<'a> {
 impl CompoundView<'_> {
     /// The shapes of this compound shape.
     #[inline]
-    pub fn shapes(&self) -> impl ExactSizeIterator<Item = (Vect, Rot, ColliderView)> {
+    pub fn shapes(&self) -> impl ExactSizeIterator<Item = (Vect, Rot, ColliderView<'_>)> {
         self.raw.shapes().iter().map(|(pos, shape)| {
             let (tra, rot) = (*pos).into();
             (tra, rot, shape.as_typed_shape().into())

--- a/src/geometry/shape_views/round_shape.rs
+++ b/src/geometry/shape_views/round_shape.rs
@@ -32,7 +32,7 @@ macro_rules!  round_shape_view(
             }
 
             /// The underlying not-rounded shape.
-            pub fn inner_shape(&self) -> $ShapeView {
+            pub fn inner_shape(&self) -> $ShapeView<'_> {
                 $ShapeView {
                     raw: &self.raw.inner_shape,
                 }
@@ -57,7 +57,7 @@ macro_rules!  round_shape_view(
             }
 
             /// The underlying not-rounded shape.
-            pub fn inner_shape(&mut self) -> $ShapeViewMut {
+            pub fn inner_shape(&mut self) -> $ShapeViewMut<'_> {
                 $ShapeViewMut {
                     raw: &mut self.raw.inner_shape,
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 //!
 //! User documentation for `bevy_rapier` is on [the official Rapier site](https://rapier.rs/docs/).
 //!
-
 #![warn(missing_docs)]
 
 #[macro_use]

--- a/src/picking_backend/mod.rs
+++ b/src/picking_backend/mod.rs
@@ -133,7 +133,7 @@ pub fn update_hits(
             };
             let filter = crate::prelude::QueryFilter::default().predicate(&predicate);
             let mut picks = Vec::new();
-            crate::prelude::RapierQueryPipeline::with_query_filter_elts(
+            crate::prelude::RapierQueryPipeline::new_scoped(
                 &simulation.broad_phase,
                 colliders,
                 bodies,

--- a/src/picking_backend/mod.rs
+++ b/src/picking_backend/mod.rs
@@ -139,7 +139,7 @@ pub fn update_hits(
                         &colliders.colliders,
                         h,
                     )
-                    .map(&predicate)
+                    .map(predicate)
                     .unwrap_or(false)
                 };
             let filter = rapier::prelude::QueryFilter::default().predicate(&rapier_predicate);

--- a/src/pipeline/query_filter.rs
+++ b/src/pipeline/query_filter.rs
@@ -8,8 +8,6 @@ use crate::geometry::CollisionGroups;
 use crate::prelude::RapierRigidBodySet;
 
 /// A filter that describes what collider should be included or excluded from a scene query.
-///
-/// For testing manually check [`RapierRigidBodySet::with_query_filter`].
 #[derive(Copy, Clone, Default)]
 pub struct QueryFilter<'a> {
     /// Flags indicating what particular type of colliders should be excluded.

--- a/src/pipeline/query_filter.rs
+++ b/src/pipeline/query_filter.rs
@@ -4,9 +4,6 @@ pub use rapier::pipeline::QueryFilterFlags;
 
 use crate::geometry::CollisionGroups;
 
-#[cfg(doc)]
-use crate::prelude::RapierRigidBodySet;
-
 /// A filter that describes what collider should be included or excluded from a scene query.
 #[derive(Copy, Clone, Default)]
 pub struct QueryFilter<'a> {

--- a/src/plugin/configuration.rs
+++ b/src/plugin/configuration.rs
@@ -67,8 +67,6 @@ pub struct RapierConfiguration {
     pub gravity: Vect,
     /// Specifies if the physics simulation is active and update the physics world.
     pub physics_pipeline_active: bool,
-    /// Specifies if the query pipeline is active and update the query pipeline.
-    pub query_pipeline_active: bool,
     /// Specifies the number of subdivisions along each axes a shape should be subdivided
     /// if its scaled representation cannot be represented with the same shape type.
     ///
@@ -92,7 +90,6 @@ impl RapierConfiguration {
         Self {
             gravity: Vect::Y * -9.81 * length_unit,
             physics_pipeline_active: true,
-            query_pipeline_active: true,
             scaled_shape_subdivision: 10,
             force_update_from_transform_changes: false,
         }

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -163,7 +163,7 @@ impl RapierContextJoints {
 ///
 /// This wrapper is designed to be short lived, made whenever necessary.
 ///
-/// See [RapierQueryPipeline::with_query_filter_elts] to create one.
+/// See [RapierQueryPipeline::new_scoped] to create one.
 #[derive(Copy, Clone)]
 pub struct RapierQueryPipeline<'a> {
     /// The query pipeline, which performs scene queries (ray-casting, point projection, etc.)
@@ -182,7 +182,7 @@ pub fn to_rapier_query_filter_predicate(
 
 impl<'a> RapierQueryPipeline<'a> {
     /// Creates a temporary [RapierQueryPipeline] and passes it as a parameter to `scoped_fn`.
-    pub fn with_query_filter_elts<T>(
+    pub fn new_scoped<T>(
         broad_phase: &DefaultBroadPhase,
         colliders: &RapierContextColliders,
         rigid_bodies: &RapierRigidBodySet,

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use rapier::prelude::{
-    CCDSolver, ColliderHandle, ColliderSet, EventHandler, FeatureId, ImpulseJointHandle,
+    Aabb, CCDSolver, ColliderHandle, ColliderSet, EventHandler, FeatureId, ImpulseJointHandle,
     ImpulseJointSet, IntegrationParameters, IslandManager, MultibodyJointHandle, MultibodyJointSet,
     NarrowPhase, PhysicsHooks, PhysicsPipeline, QueryPipeline, QueryPipelineMut, Ray, Real,
     RigidBodyHandle, RigidBodySet, Shape,
@@ -364,7 +364,7 @@ impl<'a> RapierQueryPipeline<'a> {
         #[cfg(feature = "dim2")] aabb: bevy::math::bounding::Aabb2d,
         #[cfg(feature = "dim3")] aabb: bevy::math::bounding::Aabb3d,
     ) -> impl Iterator<Item = Entity> + 'a {
-        let scaled_aabb = rapier::prelude::Aabb {
+        let scaled_aabb = Aabb {
             mins: aabb.min.into(),
             maxs: aabb.max.into(),
         };

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -172,7 +172,7 @@ pub struct RapierQueryPipelineMut<'a> {
 
 impl RapierQueryPipelineMut<'_> {
     /// Downgrades the mutable reference to an immutable reference.
-    pub fn as_ref(&self) -> RapierQueryPipeline {
+    pub fn as_ref(&self) -> RapierQueryPipeline<'_> {
         RapierQueryPipeline {
             query_pipeline: self.query_pipeline.as_ref(),
         }
@@ -190,7 +190,6 @@ impl<'a> RapierQueryPipeline<'a> {
     /// * `solid`: if this is `true` an impact at time 0.0 (i.e. at the ray origin) is returned if
     ///   it starts inside of a shape. If this `false` then the ray will hit the shape's boundary
     ///   even if its starts inside of it.
-    #[expect(clippy::too_many_arguments)]
     pub fn cast_ray(
         &self,
         rapier_colliders: &RapierContextColliders,
@@ -216,7 +215,6 @@ impl<'a> RapierQueryPipeline<'a> {
     /// * `solid`: if this is `true` an impact at time 0.0 (i.e. at the ray origin) is returned if
     ///   it starts inside of a shape. If this `false` then the ray will hit the shape's boundary
     ///   even if its starts inside of it.
-    #[expect(clippy::too_many_arguments)]
     pub fn cast_ray_and_get_normal(
         &self,
         rapier_colliders: &RapierContextColliders,

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -156,7 +156,6 @@ impl RapierContextJoints {
 }
 
 /// Wrapper around [QueryPipeline] to provide bevy friendly methods.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone)]
 pub struct RapierQueryPipeline<'a> {
     /// The query pipeline, which performs scene queries (ray-casting, point projection, etc.)
@@ -164,7 +163,6 @@ pub struct RapierQueryPipeline<'a> {
 }
 
 /// Wrapper around [QueryPipeline] to provide bevy friendly methods.
-#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct RapierQueryPipelineMut<'a> {
     /// The query pipeline, which performs scene queries (ray-casting, point projection, etc.)
     pub query_pipeline: QueryPipelineMut<'a>,

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -9,20 +9,20 @@ use std::sync::RwLock;
 use rapier::prelude::{
     CCDSolver, ColliderHandle, ColliderSet, EventHandler, FeatureId, ImpulseJointHandle,
     ImpulseJointSet, IntegrationParameters, IslandManager, MultibodyJointHandle, MultibodyJointSet,
-    NarrowPhase, PhysicsHooks, PhysicsPipeline, QueryFilter as RapierQueryFilter, QueryPipeline,
-    Ray, Real, RigidBodyHandle, RigidBodySet,
+    NarrowPhase, PhysicsHooks, PhysicsPipeline, QueryPipeline, QueryPipelineMut, Ray, Real,
+    RigidBodyHandle, RigidBodySet, Shape,
 };
 
-use crate::geometry::{Collider, PointProjection, RayIntersection, ShapeCastHit};
+use crate::geometry::{PointProjection, RayIntersection, ShapeCastHit};
 use crate::math::{Rot, Vect};
-use crate::pipeline::{CollisionEvent, ContactForceEvent, EventQueue, QueryFilter};
+use crate::pipeline::{CollisionEvent, ContactForceEvent, EventQueue};
 use bevy::prelude::{Entity, EventWriter, GlobalTransform, Query};
 
 use crate::control::{CharacterCollision, MoveShapeOptions, MoveShapeOutput};
 use crate::dynamics::TransformInterpolation;
 use crate::parry::query::details::ShapeCastOptions;
 use crate::plugin::configuration::TimestepMode;
-use crate::prelude::{CollisionGroups, RapierRigidBodyHandle};
+use crate::prelude::RapierRigidBodyHandle;
 use rapier::control::CharacterAutostep;
 use rapier::geometry::DefaultBroadPhase;
 
@@ -155,23 +155,31 @@ impl RapierContextJoints {
     }
 }
 
-/// The query pipeline, which performs scene queries (ray-casting, point projection, etc.)
-///
-/// This should be attached on an entity with a [`RapierContext`]
+/// Wrapper around [QueryPipeline] to provide bevy friendly methods.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Component, Default, Clone)]
-pub struct RapierQueryPipeline {
+#[derive(Copy, Clone)]
+pub struct RapierQueryPipeline<'a> {
     /// The query pipeline, which performs scene queries (ray-casting, point projection, etc.)
-    pub query_pipeline: QueryPipeline,
+    pub query_pipeline: QueryPipeline<'a>,
 }
 
-impl RapierQueryPipeline {
-    /// Updates the state of the query pipeline, based on the collider positions known
-    /// from the last timestep or the last call to `self.propagate_modified_body_positions_to_colliders()`.
-    pub fn update_query_pipeline(&mut self, colliders: &RapierContextColliders) {
-        self.query_pipeline.update(&colliders.colliders);
-    }
+/// Wrapper around [QueryPipeline] to provide bevy friendly methods.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+pub struct RapierQueryPipelineMut<'a> {
+    /// The query pipeline, which performs scene queries (ray-casting, point projection, etc.)
+    pub query_pipeline: QueryPipelineMut<'a>,
+}
 
+impl RapierQueryPipelineMut<'_> {
+    /// Downgrades the mutable reference to an immutable reference.
+    pub fn as_ref(&self) -> RapierQueryPipeline {
+        RapierQueryPipeline {
+            query_pipeline: self.query_pipeline.as_ref(),
+        }
+    }
+}
+
+impl<'a> RapierQueryPipeline<'a> {
     /// Find the closest intersection between a ray and a set of collider.
     ///
     /// # Parameters
@@ -182,31 +190,18 @@ impl RapierQueryPipeline {
     /// * `solid`: if this is `true` an impact at time 0.0 (i.e. at the ray origin) is returned if
     ///   it starts inside of a shape. If this `false` then the ray will hit the shape's boundary
     ///   even if its starts inside of it.
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
     #[expect(clippy::too_many_arguments)]
     pub fn cast_ray(
         &self,
         rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
         ray_origin: Vect,
         ray_dir: Vect,
         max_toi: Real,
         solid: bool,
-        filter: QueryFilter,
     ) -> Option<(Entity, Real)> {
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
 
-        let (h, toi) =
-            rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-                self.query_pipeline.cast_ray(
-                    &rigidbody_set.bodies,
-                    &rapier_colliders.colliders,
-                    &ray,
-                    max_toi,
-                    solid,
-                    filter,
-                )
-            })?;
+        let (h, toi) = self.query_pipeline.cast_ray(&ray, max_toi, solid)?;
 
         rapier_colliders.collider_entity(h).map(|e| (e, toi))
     }
@@ -221,38 +216,27 @@ impl RapierQueryPipeline {
     /// * `solid`: if this is `true` an impact at time 0.0 (i.e. at the ray origin) is returned if
     ///   it starts inside of a shape. If this `false` then the ray will hit the shape's boundary
     ///   even if its starts inside of it.
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
     #[expect(clippy::too_many_arguments)]
     pub fn cast_ray_and_get_normal(
         &self,
         rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
         ray_origin: Vect,
         ray_dir: Vect,
         max_toi: Real,
         solid: bool,
-        filter: QueryFilter,
     ) -> Option<(Entity, RayIntersection)> {
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
 
-        let (h, result) =
-            rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-                self.query_pipeline.cast_ray_and_get_normal(
-                    &rigidbody_set.bodies,
-                    &rapier_colliders.colliders,
-                    &ray,
-                    max_toi,
-                    solid,
-                    filter,
-                )
-            })?;
+        let (h, result) = self
+            .query_pipeline
+            .cast_ray_and_get_normal(&ray, max_toi, solid)?;
 
         rapier_colliders
             .collider_entity(h)
             .map(|e| (e, RayIntersection::from_rapier(result, ray_origin, ray_dir)))
     }
 
-    /// Find the all intersections between a ray and a set of collider and passes them to a callback.
+    /// Iterates through all the colliders intersecting a given ray.
     ///
     /// # Parameters
     /// * `ray_origin`: the starting point of the ray to cast.
@@ -262,75 +246,46 @@ impl RapierQueryPipeline {
     /// * `solid`: if this is `true` an impact at time 0.0 (i.e. at the ray origin) is returned if
     ///   it starts inside of a shape. If this `false` then the ray will hit the shape's boundary
     ///   even if its starts inside of it.
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
-    /// * `callback`: function executed on each collider for which a ray intersection has been found.
-    ///   There is no guarantees on the order the results will be yielded. If this callback returns `false`,
-    ///   this method will exit early, ignore any further raycast.
     #[allow(clippy::too_many_arguments)]
-    pub fn intersections_with_ray(
-        &self,
-        rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
+    pub fn intersect_ray(
+        &'a self,
+        rapier_colliders: &'a RapierContextColliders,
         ray_origin: Vect,
         ray_dir: Vect,
         max_toi: Real,
         solid: bool,
-        filter: QueryFilter,
-        mut callback: impl FnMut(Entity, RayIntersection) -> bool,
-    ) {
+    ) -> impl Iterator<Item = (Entity, RayIntersection)> + 'a {
         let ray = Ray::new(ray_origin.into(), ray_dir.into());
-        let callback = |h, inter: rapier::prelude::RayIntersection| {
-            rapier_colliders
-                .collider_entity(h)
-                .map(|e| callback(e, RayIntersection::from_rapier(inter, ray_origin, ray_dir)))
-                .unwrap_or(true)
-        };
 
-        rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-            self.query_pipeline.intersections_with_ray(
-                &rigidbody_set.bodies,
-                &rapier_colliders.colliders,
-                &ray,
-                max_toi,
-                solid,
-                filter,
-                callback,
-            )
-        });
+        self.query_pipeline.intersect_ray(ray, max_toi, solid).map(
+            move |(collider_handle, _, intersection)| {
+                (
+                    rapier_colliders.collider_entity(collider_handle).unwrap(),
+                    RayIntersection::from_rapier(intersection, ray_origin, ray_dir),
+                )
+            },
+        )
     }
 
-    /// Gets the handle of up to one collider intersecting the given shape.
+    /// Retrieve all the colliders intersecting the given shape.
     ///
     /// # Parameters
     /// * `shape_pos` - The position of the shape used for the intersection test.
     /// * `shape` - The shape used for the intersection test.
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
-    pub fn intersection_with_shape(
-        &self,
-        rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
+    pub fn intersect_shape(
+        &'a self,
+        rapier_colliders: &'a RapierContextColliders,
         shape_pos: Vect,
         shape_rot: Rot,
-        shape: &Collider,
-        filter: QueryFilter,
-    ) -> Option<Entity> {
+        shape: &'a dyn Shape,
+    ) -> impl Iterator<Item = Entity> + 'a {
         let scaled_transform = (shape_pos, shape_rot).into();
-        let mut scaled_shape = shape.clone();
-        // TODO: how to set a good number of subdivisions, we don’t have access to the
-        //       RapierConfiguration::scaled_shape_subdivision here.
-        scaled_shape.set_scale(shape.scale, 20);
 
-        let h = rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-            self.query_pipeline.intersection_with_shape(
-                &rigidbody_set.bodies,
-                &rapier_colliders.colliders,
-                &scaled_transform,
-                &*scaled_shape.raw,
-                filter,
-            )
-        })?;
-
-        rapier_colliders.collider_entity(h)
+        self.query_pipeline
+            .intersect_shape(scaled_transform, shape)
+            .map(move |(collider_handle, _)| {
+                rapier_colliders.collider_entity(collider_handle).unwrap()
+            })
     }
 
     /// Find the projection of a point on the closest collider.
@@ -342,25 +297,16 @@ impl RapierQueryPipeline {
     ///   itself). If it is set to `false` the collider shapes are considered to be hollow
     ///   (if the point is located inside of an hollow shape, it is projected on the shape's
     ///   boundary).
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
     pub fn project_point(
         &self,
         rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
         point: Vect,
+        max_dist: Real,
         solid: bool,
-        filter: QueryFilter,
     ) -> Option<(Entity, PointProjection)> {
-        let (h, result) =
-            rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-                self.query_pipeline.project_point(
-                    &rigidbody_set.bodies,
-                    &rapier_colliders.colliders,
-                    &point.into(),
-                    solid,
-                    filter,
-                )
-            })?;
+        let (h, result) = self
+            .query_pipeline
+            .project_point(&point.into(), max_dist, solid)?;
 
         rapier_colliders
             .collider_entity(h)
@@ -371,36 +317,16 @@ impl RapierQueryPipeline {
     ///
     /// # Parameters
     /// * `point` - The point used for the containment test.
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
-    /// * `callback` - A function called with each collider with a shape containing the `point`.
-    ///   If this callback returns `false`, this method will exit early, ignore any
-    ///   further point projection.
-    pub fn intersections_with_point(
-        &self,
-        rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
+    pub fn intersect_point(
+        &'a self,
+        rapier_colliders: &'a RapierContextColliders,
         point: Vect,
-        filter: QueryFilter,
-        mut callback: impl FnMut(Entity) -> bool,
-    ) {
-        #[allow(clippy::redundant_closure)]
-        // False-positive, we can't move callback, closure becomes `FnOnce`
-        let callback = |h| {
-            rapier_colliders
-                .collider_entity(h)
-                .map(|e| callback(e))
-                .unwrap_or(true)
-        };
-
-        rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-            self.query_pipeline.intersections_with_point(
-                &rigidbody_set.bodies,
-                &rapier_colliders.colliders,
-                &point.into(),
-                filter,
-                callback,
-            )
-        });
+    ) -> impl Iterator<Item = Entity> + 'a {
+        self.query_pipeline
+            .intersect_point(point.into())
+            .map(move |(collider_handle, _)| {
+                rapier_colliders.collider_entity(collider_handle).unwrap()
+            })
     }
 
     /// Find the projection of a point on the closest collider.
@@ -414,51 +340,39 @@ impl RapierQueryPipeline {
     ///   itself). If it is set to `false` the collider shapes are considered to be hollow
     ///   (if the point is located inside of an hollow shape, it is projected on the shape's
     ///   boundary).
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
     pub fn project_point_and_get_feature(
         &self,
         rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
         point: Vect,
-        filter: QueryFilter,
     ) -> Option<(Entity, PointProjection, FeatureId)> {
-        let (h, proj, fid) =
-            rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-                self.query_pipeline.project_point_and_get_feature(
-                    &rigidbody_set.bodies,
-                    &rapier_colliders.colliders,
-                    &point.into(),
-                    filter,
-                )
-            })?;
+        let (h, proj, fid) = self
+            .query_pipeline
+            .project_point_and_get_feature(&point.into())?;
 
         rapier_colliders
             .collider_entity(h)
             .map(|e| (e, PointProjection::from_rapier(proj), fid))
     }
 
-    /// Finds all entities of all the colliders with an Aabb intersecting the given Aabb.
-    pub fn colliders_with_aabb_intersecting_aabb(
-        &self,
-        rapier_colliders: &RapierContextColliders,
+    /// Finds all handles of all the colliders with an [`Aabb`] intersecting the given [`Aabb`].
+    ///
+    /// Note that the collider AABB taken into account is the one currently stored in the query
+    /// pipeline’s BVH. It doesn’t recompute the latest collider AABB.
+    pub fn intersect_aabb_conservative(
+        &'a self,
+        rapier_colliders: &'a RapierContextColliders,
         #[cfg(feature = "dim2")] aabb: bevy::math::bounding::Aabb2d,
         #[cfg(feature = "dim3")] aabb: bevy::math::bounding::Aabb3d,
-        mut callback: impl FnMut(Entity) -> bool,
-    ) {
+    ) -> impl Iterator<Item = Entity> + 'a {
         let scaled_aabb = rapier::prelude::Aabb {
             mins: aabb.min.into(),
             maxs: aabb.max.into(),
         };
-        #[allow(clippy::redundant_closure)]
-        // False-positive, we can't move callback, closure becomes `FnOnce`
-        let callback = |h: &ColliderHandle| {
-            rapier_colliders
-                .collider_entity(*h)
-                .map(|e| callback(e))
-                .unwrap_or(true)
-        };
         self.query_pipeline
-            .colliders_with_aabb_intersecting_aabb(&scaled_aabb, callback);
+            .intersect_aabb_conservative(scaled_aabb)
+            .map(move |(collider_handle, _)| {
+                rapier_colliders.collider_entity(collider_handle).unwrap()
+            })
     }
 
     /// Casts a shape at a constant linear velocity and retrieve the first collider it hits.
@@ -481,37 +395,21 @@ impl RapierQueryPipeline {
     ///   would result in tunnelling. If it does not (i.e. we have a separating velocity along
     ///   that normal) then the nonlinear shape-casting will attempt to find another impact,
     ///   at a time `> start_time` that could result in tunnelling.
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
     #[allow(clippy::too_many_arguments)]
     pub fn cast_shape(
-        &self,
-        rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
+        &'a self,
+        rapier_colliders: &'a RapierContextColliders,
         shape_pos: Vect,
         shape_rot: Rot,
         shape_vel: Vect,
-        shape: &Collider,
+        shape: &dyn Shape,
         options: ShapeCastOptions,
-        filter: QueryFilter,
     ) -> Option<(Entity, ShapeCastHit)> {
         let scaled_transform = (shape_pos, shape_rot).into();
-        let mut scaled_shape = shape.clone();
-        // TODO: how to set a good number of subdivisions, we don’t have access to the
-        //       RapierConfiguration::scaled_shape_subdivision here.
-        scaled_shape.set_scale(shape.scale, 20);
 
         let (h, result) =
-            rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-                self.query_pipeline.cast_shape(
-                    &rigidbody_set.bodies,
-                    &rapier_colliders.colliders,
-                    &scaled_transform,
-                    &shape_vel.into(),
-                    &*scaled_shape.raw,
-                    options,
-                    filter,
-                )
-            })?;
+            self.query_pipeline
+                .cast_shape(&scaled_transform, &shape_vel.into(), shape, options)?;
 
         rapier_colliders.collider_entity(h).map(|e| {
             (
@@ -572,85 +470,6 @@ impl RapierQueryPipeline {
         self.collider_entity(h).map(|e| (e, result))
     }
      */
-
-    /// Retrieve all the colliders intersecting the given shape.
-    ///
-    /// # Parameters
-    /// * `shapePos` - The position of the shape to test.
-    /// * `shapeRot` - The orientation of the shape to test.
-    /// * `shape` - The shape to test.
-    /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
-    /// * `callback` - A function called with the entities of each collider intersecting the `shape`.
-    #[expect(clippy::too_many_arguments)]
-    pub fn intersections_with_shape(
-        &self,
-        rapier_colliders: &RapierContextColliders,
-        rigidbody_set: &RapierRigidBodySet,
-        shape_pos: Vect,
-        shape_rot: Rot,
-        shape: &Collider,
-        filter: QueryFilter,
-        mut callback: impl FnMut(Entity) -> bool,
-    ) {
-        let scaled_transform = (shape_pos, shape_rot).into();
-        let mut scaled_shape = shape.clone();
-        // TODO: how to set a good number of subdivisions, we don’t have access to the
-        //       RapierConfiguration::scaled_shape_subdivision here.
-        scaled_shape.set_scale(shape.scale, 20);
-
-        #[allow(clippy::redundant_closure)]
-        // False-positive, we can't move callback, closure becomes `FnOnce`
-        let callback = |h| {
-            rapier_colliders
-                .collider_entity(h)
-                .map(|e| callback(e))
-                .unwrap_or(true)
-        };
-
-        rigidbody_set.with_query_filter(rapier_colliders, filter, move |filter| {
-            self.query_pipeline.intersections_with_shape(
-                &rigidbody_set.bodies,
-                &rapier_colliders.colliders,
-                &scaled_transform,
-                &*scaled_shape.raw,
-                filter,
-                callback,
-            )
-        });
-    }
-    /// Without borrowing the [`RapierContext`], calls the closure `f` once
-    /// after converting the given [`QueryFilter`] into a raw [`RapierQueryFilter`].
-    pub fn with_query_filter_elts<T>(
-        entity2collider: &HashMap<Entity, ColliderHandle>,
-        entity2body: &HashMap<Entity, RigidBodyHandle>,
-        colliders: &ColliderSet,
-        filter: QueryFilter,
-        f: impl FnOnce(RapierQueryFilter) -> T,
-    ) -> T {
-        let mut rapier_filter = RapierQueryFilter {
-            flags: filter.flags,
-            groups: filter.groups.map(CollisionGroups::into),
-            exclude_collider: filter
-                .exclude_collider
-                .and_then(|c| entity2collider.get(&c).copied()),
-            exclude_rigid_body: filter
-                .exclude_rigid_body
-                .and_then(|b| entity2body.get(&b).copied()),
-            predicate: None,
-        };
-
-        if let Some(predicate) = filter.predicate {
-            let wrapped_predicate = |h: ColliderHandle, _: &rapier::geometry::Collider| {
-                RapierContextColliders::collider_entity_with_set(colliders, h)
-                    .map(predicate)
-                    .unwrap_or(false)
-            };
-            rapier_filter.predicate = Some(&wrapped_predicate);
-            f(rapier_filter)
-        } else {
-            f(rapier_filter)
-        }
-    }
 }
 
 /// The set of rigid-bodies part of the simulation.
@@ -671,22 +490,6 @@ pub struct RapierRigidBodySet {
 }
 
 impl RapierRigidBodySet {
-    /// Calls the closure `f` once after converting the given [`QueryFilter`] into a raw [`RapierQueryFilter`].
-    pub fn with_query_filter<T>(
-        &self,
-        colliders: &RapierContextColliders,
-        filter: QueryFilter,
-        f: impl FnOnce(RapierQueryFilter) -> T,
-    ) -> T {
-        RapierQueryPipeline::with_query_filter_elts(
-            &colliders.entity2collider,
-            &self.entity2body,
-            &colliders.colliders,
-            filter,
-            f,
-        )
-    }
-
     /// The map from entities to rigid-body handles.
     pub fn entity2body(&self) -> &HashMap<Entity, RigidBodyHandle> {
         &self.entity2body
@@ -740,7 +543,6 @@ impl RapierRigidBodySet {
     RapierContextColliders,
     RapierRigidBodySet,
     RapierContextJoints,
-    RapierQueryPipeline,
     SimulationToRenderTime
 )]
 pub struct RapierContextSimulation {
@@ -873,7 +675,6 @@ impl RapierContextSimulation {
                             &mut joints.impulse_joints,
                             &mut joints.multibody_joints,
                             &mut self.ccd_solver,
-                            None,
                             hooks,
                             event_handler,
                         );
@@ -905,7 +706,6 @@ impl RapierContextSimulation {
                         &mut joints.impulse_joints,
                         &mut joints.multibody_joints,
                         &mut self.ccd_solver,
-                        None,
                         hooks,
                         event_handler,
                     );
@@ -930,7 +730,6 @@ impl RapierContextSimulation {
                         &mut joints.impulse_joints,
                         &mut joints.multibody_joints,
                         &mut self.ccd_solver,
-                        None,
                         hooks,
                         event_handler,
                     );
@@ -976,28 +775,20 @@ impl RapierContextSimulation {
     /// * `shape_mass`: the mass of the shape to be considered by the impulse calculation if
     ///   `MoveShapeOptions::apply_impulse_to_dynamic_bodies` is set to true.
     /// * `options`: configures the behavior of the automatic sliding and climbing.
-    /// * `filter`: indicates what collider or rigid-body needs to be ignored by the obstacle detection.
     /// * `events`: callback run on each obstacle hit by the shape on its path.
     #[allow(clippy::too_many_arguments)]
     pub fn move_shape(
         &mut self,
         rapier_colliders: &RapierContextColliders,
-        rapier_query_pipeline: &RapierQueryPipeline,
-        rigidbody_set: &mut RapierRigidBodySet,
+        rapier_query_pipeline: &mut QueryPipelineMut,
         movement: Vect,
-        shape: &Collider,
+        shape: &dyn Shape,
         shape_translation: Vect,
         shape_rotation: Rot,
         shape_mass: Real,
         options: &MoveShapeOptions,
-        filter: QueryFilter,
         mut events: impl FnMut(CharacterCollision),
     ) -> MoveShapeOutput {
-        let mut scaled_shape = shape.clone();
-        // TODO: how to set a good number of subdivisions, we don’t have access to the
-        //       RapierConfiguration::scaled_shape_subdivision here.
-        scaled_shape.set_scale(shape.scale, 20);
-
         let up = options
             .up
             .try_into()
@@ -1024,52 +815,33 @@ impl RapierContextSimulation {
         //       the closure is ugly.
         let dt = self.integration_parameters.dt;
         let colliders = &rapier_colliders.colliders;
-        let bodies = &mut rigidbody_set.bodies;
-        let query_pipeline = &rapier_query_pipeline.query_pipeline;
         let collisions = &mut self.character_collisions_collector;
         collisions.clear();
 
-        let result = RapierQueryPipeline::with_query_filter_elts(
-            &rapier_colliders.entity2collider,
-            &rigidbody_set.entity2body,
-            &rapier_colliders.colliders,
-            filter,
-            move |filter| {
-                let result = controller.move_shape(
-                    dt,
-                    bodies,
-                    colliders,
-                    query_pipeline,
-                    (&scaled_shape).into(),
-                    &(shape_translation, shape_rotation).into(),
-                    movement.into(),
-                    filter,
-                    |c| {
-                        if let Some(collision) =
-                            CharacterCollision::from_raw_with_set(colliders, &c, true)
-                        {
-                            events(collision);
-                        }
-                        collisions.push(c);
-                    },
-                );
-
-                if options.apply_impulse_to_dynamic_bodies {
-                    controller.solve_character_collision_impulses(
-                        dt,
-                        bodies,
-                        colliders,
-                        query_pipeline,
-                        (&scaled_shape).into(),
-                        shape_mass,
-                        collisions.iter(),
-                        filter,
-                    )
+        let result = controller.move_shape(
+            dt,
+            &rapier_query_pipeline.as_ref(),
+            shape,
+            &(shape_translation, shape_rotation).into(),
+            movement.into(),
+            |c| {
+                if let Some(collision) = CharacterCollision::from_raw_with_set(colliders, &c, true)
+                {
+                    events(collision);
                 }
-
-                result
+                collisions.push(c);
             },
         );
+
+        if options.apply_impulse_to_dynamic_bodies {
+            controller.solve_character_collision_impulses(
+                dt,
+                rapier_query_pipeline,
+                shape,
+                shape_mass,
+                collisions.iter(),
+            )
+        };
 
         MoveShapeOutput {
             effective_translation: result.translation.into(),

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -338,8 +338,8 @@ mod query_pipeline {
             )
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_point`].
-        pub fn intersections_with_point(
+        /// Shortcut to [`RapierQueryPipeline::intersect_point`].
+        pub fn intersect_point(
             &self,
             query_pipeline: RapierQueryPipeline<'_>,
             point: Vect,
@@ -353,8 +353,8 @@ mod query_pipeline {
             }
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_ray`].
-        pub fn intersections_with_ray(
+        /// Shortcut to [`RapierQueryPipeline::intersect_ray`].
+        pub fn intersect_ray(
             &self,
             query_pipeline: RapierQueryPipeline<'_>,
             ray_origin: Vect,
@@ -373,8 +373,8 @@ mod query_pipeline {
             }
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_shape`].
-        pub fn intersections_with_shape(
+        /// Shortcut to [`RapierQueryPipeline::intersect_shape`].
+        pub fn intersect_shape(
             &self,
             query_pipeline: RapierQueryPipeline<'_>,
             shape_pos: Vect,
@@ -389,8 +389,8 @@ mod query_pipeline {
             }
         }
 
-        /// Shortcut to [`RapierQueryPipeline::colliders_with_aabb_intersecting_aabb`].
-        pub fn colliders_with_aabb_intersecting_aabb(
+        /// Shortcut to [`RapierQueryPipeline::intersect_aabb_conservative`].
+        pub fn intersect_aabb_conservative(
             &self,
             query_pipeline: RapierQueryPipeline<'_>,
             #[cfg(feature = "dim2")] aabb: bevy::math::bounding::Aabb2d,
@@ -467,8 +467,8 @@ mod query_pipeline {
             )
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_point`].
-        pub fn intersections_with_point(
+        /// Shortcut to [`RapierQueryPipeline::intersect_point`].
+        pub fn intersect_point(
             &self,
             query_pipeline: RapierQueryPipeline<'_>,
             point: Vect,
@@ -481,8 +481,8 @@ mod query_pipeline {
             }
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_ray`].
-        pub fn intersections_with_ray(
+        /// Shortcut to [`RapierQueryPipeline::intersect_ray`].
+        pub fn intersect_ray(
             &self,
             query_pipeline: RapierQueryPipeline<'_>,
             ray_origin: Vect,
@@ -500,8 +500,8 @@ mod query_pipeline {
             }
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_shape`].
-        pub fn intersections_with_shape(
+        /// Shortcut to [`RapierQueryPipeline::intersect_shape`].
+        pub fn intersect_shape(
             &self,
             query_pipeline: RapierQueryPipeline<'_>,
             shape_pos: Vect,
@@ -516,8 +516,8 @@ mod query_pipeline {
             }
         }
 
-        /// Shortcut to [`RapierQueryPipeline::colliders_with_aabb_intersecting_aabb`].
-        pub fn colliders_with_aabb_intersecting_aabb(
+        /// Shortcut to [`RapierQueryPipeline::intersect_aabb_conservative`].
+        pub fn intersect_aabb_conservative(
             &self,
             query_pipeline: RapierQueryPipeline<'_>,
             #[cfg(feature = "dim2")] aabb: bevy::math::bounding::Aabb2d,

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -289,13 +289,13 @@ mod query_pipeline {
     use super::*;
 
     impl RapierContext<'_> {
-        /// Shortcut to [RapierQueryPipeline::with_query_filter_elts].
+        /// Shortcut to [RapierQueryPipeline::new_scoped].
         pub fn with_query_pipeline<'a, T>(
             &'a self,
             filter: QueryFilter<'a>,
             scoped_fn: impl FnOnce(RapierQueryPipeline<'_>) -> T,
         ) -> T {
-            crate::prelude::RapierQueryPipeline::with_query_filter_elts(
+            crate::prelude::RapierQueryPipeline::new_scoped(
                 &self.simulation.broad_phase,
                 self.colliders,
                 self.rigidbody_set,
@@ -307,13 +307,13 @@ mod query_pipeline {
     }
 
     impl RapierContextMut<'_> {
-        /// Shortcut to [RapierQueryPipeline::with_query_filter_elts].
+        /// Shortcut to [RapierQueryPipeline::new_scoped].
         pub fn with_query_pipeline<'a, T>(
             &'a self,
             filter: QueryFilter<'a>,
             scoped_fn: impl FnOnce(RapierQueryPipeline<'_>) -> T,
         ) -> T {
-            crate::prelude::RapierQueryPipeline::with_query_filter_elts(
+            crate::prelude::RapierQueryPipeline::new_scoped(
                 &self.simulation.broad_phase,
                 &self.colliders,
                 &self.rigidbody_set,

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -323,7 +323,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::cast_ray_and_get_normal`].
         pub fn cast_ray_and_get_normal(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             ray_origin: Vect,
             ray_dir: Vect,
             max_toi: Real,
@@ -341,7 +341,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::intersect_point`].
         pub fn intersect_point(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             point: Vect,
             // FIXME: find a way to return an iterator?
             mut callback: impl FnMut(Entity) -> bool,
@@ -356,7 +356,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::intersect_ray`].
         pub fn intersect_ray(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             ray_origin: Vect,
             ray_dir: Vect,
             max_toi: Real,
@@ -376,7 +376,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::intersect_shape`].
         pub fn intersect_shape(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             shape_pos: Vect,
             shape_rot: Rot,
             shape: &dyn Shape,
@@ -392,7 +392,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::intersect_aabb_conservative`].
         pub fn intersect_aabb_conservative(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             #[cfg(feature = "dim2")] aabb: bevy::math::bounding::Aabb2d,
             #[cfg(feature = "dim3")] aabb: bevy::math::bounding::Aabb3d,
             mut callback: impl FnMut(Entity) -> bool,
@@ -407,7 +407,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::cast_shape`].
         pub fn cast_shape(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             shape_pos: Vect,
             shape_rot: Rot,
             shape_vel: Vect,
@@ -427,7 +427,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::project_point`].
         pub fn project_point(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             point: Vect,
             max_dist: Real,
             solid: bool,
@@ -440,7 +440,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::cast_ray`].
         pub fn cast_ray(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             ray_origin: Vect,
             ray_dir: Vect,
             max_toi: Real,
@@ -452,7 +452,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::cast_ray_and_get_normal`].
         pub fn cast_ray_and_get_normal(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             ray_origin: Vect,
             ray_dir: Vect,
             max_toi: Real,
@@ -470,7 +470,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::intersect_point`].
         pub fn intersect_point(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             point: Vect,
             mut callback: impl FnMut(Entity) -> bool,
         ) {
@@ -484,7 +484,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::intersect_ray`].
         pub fn intersect_ray(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             ray_origin: Vect,
             ray_dir: Vect,
             max_toi: Real,
@@ -503,7 +503,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::intersect_shape`].
         pub fn intersect_shape(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             shape_pos: Vect,
             shape_rot: Rot,
             shape: &dyn Shape,
@@ -519,7 +519,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::intersect_aabb_conservative`].
         pub fn intersect_aabb_conservative(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             #[cfg(feature = "dim2")] aabb: bevy::math::bounding::Aabb2d,
             #[cfg(feature = "dim3")] aabb: bevy::math::bounding::Aabb3d,
             mut callback: impl FnMut(Entity) -> bool,
@@ -534,7 +534,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::cast_shape`].
         pub fn cast_shape(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             shape_pos: Vect,
             shape_rot: Rot,
             shape_vel: Vect,
@@ -554,7 +554,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::project_point`].
         pub fn project_point(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             point: Vect,
             max_dist: Real,
             solid: bool,

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -141,10 +141,10 @@ mod simulation {
     use crate::plugin::TimestepMode;
     use crate::prelude::CollisionEvent;
     use crate::prelude::ContactForceEvent;
+    use crate::prelude::RapierQueryPipelineMut;
     use crate::prelude::RapierRigidBodyHandle;
     use crate::prelude::TransformInterpolation;
     use rapier::prelude::PhysicsHooks;
-    use rapier::prelude::QueryPipelineMut;
     use rapier::prelude::Shape;
 
     use super::*;
@@ -223,7 +223,7 @@ mod simulation {
         #[expect(clippy::too_many_arguments)]
         pub fn move_shape(
             &mut self,
-            query_pipeline_mut: &mut QueryPipelineMut<'_>,
+            query_pipeline_mut: &mut RapierQueryPipelineMut<'_>,
             movement: Vect,
             shape: &dyn Shape,
             shape_translation: Vect,

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -335,10 +335,10 @@ mod query_pipeline {
             })
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_point`].
+        /// Shortcut to [`RapierQueryPipeline::intersect_point`].
         ///
         /// Stops the query if `callback` returns false.
-        pub fn intersections_with_point(
+        pub fn intersect_point(
             &self,
             point: Vect,
             filter: QueryFilter,
@@ -353,10 +353,10 @@ mod query_pipeline {
             });
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_ray`].
+        /// Shortcut to [`RapierQueryPipeline::intersect_ray`].
         ///
         /// Stops the query if `callback` returns false.
-        pub fn intersections_with_ray(
+        pub fn intersect_ray(
             &self,
             ray_origin: Vect,
             ray_dir: Vect,
@@ -376,8 +376,8 @@ mod query_pipeline {
             });
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_shape`].
-        pub fn intersections_with_shape(
+        /// Shortcut to [`RapierQueryPipeline::intersect_shape`].
+        pub fn intersect_shape(
             &self,
             shape_pos: Vect,
             shape_rot: Rot,
@@ -394,8 +394,8 @@ mod query_pipeline {
             });
         }
 
-        /// Shortcut to [`RapierQueryPipeline::colliders_with_aabb_intersecting_aabb`].
-        pub fn colliders_with_aabb_intersecting_aabb(
+        /// Shortcut to [`RapierQueryPipeline::intersect_aabb_conservative`].
+        pub fn intersect_aabb_conservative(
             &self,
             #[cfg(feature = "dim2")] aabb: bevy::math::bounding::Aabb2d,
             #[cfg(feature = "dim3")] aabb: bevy::math::bounding::Aabb3d,
@@ -470,10 +470,10 @@ mod query_pipeline {
             })
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_point`].
+        /// Shortcut to [`RapierQueryPipeline::intersect_point`].
         ///
         /// Stops the query if `callback` returns false.
-        pub fn intersections_with_point(
+        pub fn intersect_point(
             &self,
             point: Vect,
             filter: QueryFilter,
@@ -488,10 +488,10 @@ mod query_pipeline {
             });
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_ray`].
+        /// Shortcut to [`RapierQueryPipeline::intersect_ray`].
         ///
         /// Stops the query if `callback` returns false.
-        pub fn intersections_with_ray(
+        pub fn intersect_ray(
             &self,
             ray_origin: Vect,
             ray_dir: Vect,
@@ -511,8 +511,8 @@ mod query_pipeline {
             });
         }
 
-        /// Shortcut to [`RapierQueryPipeline::intersections_with_shape`].
-        pub fn intersections_with_shape(
+        /// Shortcut to [`RapierQueryPipeline::intersect_shape`].
+        pub fn intersect_shape(
             &self,
             shape_pos: Vect,
             shape_rot: Rot,
@@ -529,8 +529,8 @@ mod query_pipeline {
             });
         }
 
-        /// Shortcut to [`RapierQueryPipeline::colliders_with_aabb_intersecting_aabb`].
-        pub fn colliders_with_aabb_intersecting_aabb(
+        /// Shortcut to [`RapierQueryPipeline::intersect_aabb_conservative`].
+        pub fn intersect_aabb_conservative(
             &self,
             #[cfg(feature = "dim2")] aabb: bevy::math::bounding::Aabb2d,
             #[cfg(feature = "dim3")] aabb: bevy::math::bounding::Aabb3d,

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -36,7 +36,7 @@ impl<'w, 's, T: query::QueryFilter + 'static> ReadRapierContext<'w, 's, T> {
     /// If the number of query items is not exactly one, a [`bevy::ecs::query::QuerySingleError`] is returned instead.
     ///
     /// You can also use the underlying query [`ReadRapierContext::rapier_context`] for finer grained queries.
-    pub fn single(&self) -> Result<RapierContext> {
+    pub fn single(&self) -> Result<RapierContext<'_>> {
         let (simulation, colliders, joints, rigidbody_set) = self.rapier_context.single()?;
         Ok(RapierContext {
             simulation,
@@ -90,7 +90,7 @@ impl<'w, 's, T: query::QueryFilter + 'static> WriteRapierContext<'w, 's, T> {
     /// If the number of query items is not exactly one, a [`bevy::ecs::query::QuerySingleError`] is returned instead.
     ///
     /// You can also use the underlying query [`WriteRapierContext::rapier_context`] for finer grained queries.
-    pub fn single(&self) -> Result<RapierContext> {
+    pub fn single(&self) -> Result<RapierContext<'_>> {
         let (simulation, colliders, joints, rigidbody_set) = self.rapier_context.single()?;
         Ok(RapierContext {
             simulation,
@@ -105,7 +105,7 @@ impl<'w, 's, T: query::QueryFilter + 'static> WriteRapierContext<'w, 's, T> {
     /// If the number of query items is not exactly one, a [`bevy::ecs::query::QuerySingleError`] is returned instead.
     ///
     /// You can also use the underlying query [`WriteRapierContext::rapier_context`] for finer grained queries.
-    pub fn single_mut(&mut self) -> Result<RapierContextMut> {
+    pub fn single_mut(&mut self) -> Result<RapierContextMut<'_>> {
         let (simulation, colliders, joints, rigidbody_set) = self.rapier_context.single_mut()?;
         Ok(RapierContextMut {
             simulation,
@@ -156,7 +156,7 @@ mod simulation {
             &self,
             collider1: Entity,
             collider2: Entity,
-        ) -> Option<ContactPairView> {
+        ) -> Option<ContactPairView<'_>> {
             self.simulation
                 .contact_pair(self.colliders, self.rigidbody_set, collider1, collider2)
         }
@@ -165,7 +165,7 @@ mod simulation {
         pub fn contact_pairs_with(
             &self,
             collider: Entity,
-        ) -> impl Iterator<Item = ContactPairView> {
+        ) -> impl Iterator<Item = ContactPairView<'_>> {
             self.simulation
                 .contact_pairs_with(self.colliders, self.rigidbody_set, collider)
         }
@@ -223,7 +223,7 @@ mod simulation {
         #[expect(clippy::too_many_arguments)]
         pub fn move_shape(
             &mut self,
-            mut query_pipeline_mut: &mut QueryPipelineMut<'_>,
+            query_pipeline_mut: &mut QueryPipelineMut<'_>,
             movement: Vect,
             shape: &dyn Shape,
             shape_translation: Vect,
@@ -234,7 +234,7 @@ mod simulation {
         ) -> MoveShapeOutput {
             self.simulation.move_shape(
                 &self.colliders,
-                &mut query_pipeline_mut,
+                query_pipeline_mut,
                 movement,
                 shape,
                 shape_translation,
@@ -250,7 +250,7 @@ mod simulation {
             &self,
             collider1: Entity,
             collider2: Entity,
-        ) -> Option<ContactPairView> {
+        ) -> Option<ContactPairView<'_>> {
             self.simulation
                 .contact_pair(&self.colliders, &self.rigidbody_set, collider1, collider2)
         }
@@ -259,7 +259,7 @@ mod simulation {
         pub fn contact_pairs_with(
             &self,
             collider: Entity,
-        ) -> impl Iterator<Item = ContactPairView> {
+        ) -> impl Iterator<Item = ContactPairView<'_>> {
             self.simulation
                 .contact_pairs_with(&self.colliders, &self.rigidbody_set, collider)
         }
@@ -311,7 +311,7 @@ mod query_pipeline {
         /// Shortcut to [`RapierQueryPipeline::cast_ray`].
         pub fn cast_ray(
             &self,
-            query_pipeline: RapierQueryPipeline<'_>,
+            query_pipeline: &RapierQueryPipeline<'_>,
             ray_origin: Vect,
             ray_dir: Vect,
             max_toi: Real,

--- a/src/plugin/narrow_phase.rs
+++ b/src/plugin/narrow_phase.rs
@@ -144,12 +144,12 @@ impl ContactManifoldView<'_> {
     }
 
     /// Retrieves the i-th point of this contact manifold.
-    pub fn point(&self, i: usize) -> Option<ContactView> {
+    pub fn point(&self, i: usize) -> Option<ContactView<'_>> {
         self.raw.points.get(i).map(|raw| ContactView { raw })
     }
 
     /// The contacts points.
-    pub fn points(&self) -> impl ExactSizeIterator<Item = ContactView> {
+    pub fn points(&self) -> impl ExactSizeIterator<Item = ContactView<'_>> {
         self.raw.points.iter().map(|raw| ContactView { raw })
     }
 
@@ -209,7 +209,7 @@ impl ContactManifoldView<'_> {
     }
 
     /// Gets the i-th solver contact.
-    pub fn solver_contact(&self, i: usize) -> Option<SolverContactView> {
+    pub fn solver_contact(&self, i: usize) -> Option<SolverContactView<'_>> {
         self.raw
             .data
             .solver_contacts
@@ -218,7 +218,7 @@ impl ContactManifoldView<'_> {
     }
 
     /// The contacts that will be seen by the constraints solver for computing forces.
-    pub fn solver_contacts(&self) -> impl ExactSizeIterator<Item = SolverContactView> {
+    pub fn solver_contacts(&self) -> impl ExactSizeIterator<Item = SolverContactView<'_>> {
         self.raw
             .data
             .solver_contacts
@@ -239,7 +239,7 @@ impl ContactManifoldView<'_> {
 
 impl ContactManifoldView<'_> {
     /// Returns the contact with the smallest distance (i.e. the largest penetration depth).
-    pub fn find_deepest_contact(&self) -> Option<ContactView> {
+    pub fn find_deepest_contact(&self) -> Option<ContactView<'_>> {
         self.raw
             .find_deepest_contact()
             .map(|raw| ContactView { raw })
@@ -362,7 +362,7 @@ impl ContactPairView<'_> {
     }
 
     /// Gets the i-th contact manifold.
-    pub fn manifold(&self, i: usize) -> Option<ContactManifoldView> {
+    pub fn manifold(&self, i: usize) -> Option<ContactManifoldView<'_>> {
         self.raw.manifolds.get(i).map(|raw| ContactManifoldView {
             rigidbody_set: self.rigidbody_set,
             raw,
@@ -370,7 +370,7 @@ impl ContactPairView<'_> {
     }
 
     /// Iterate through all the contact manifolds of this contact pair.
-    pub fn manifolds(&self) -> impl ExactSizeIterator<Item = ContactManifoldView> {
+    pub fn manifolds(&self) -> impl ExactSizeIterator<Item = ContactManifoldView<'_>> {
         self.raw.manifolds.iter().map(|raw| ContactManifoldView {
             rigidbody_set: self.rigidbody_set,
             raw,
@@ -389,7 +389,7 @@ impl ContactPairView<'_> {
     ///
     /// Returns a reference to the contact, as well as the contact manifold
     /// it is part of.
-    pub fn find_deepest_contact(&self) -> Option<(ContactManifoldView, ContactView)> {
+    pub fn find_deepest_contact(&self) -> Option<(ContactManifoldView<'_>, ContactView<'_>)> {
         self.raw.find_deepest_contact().map(|(manifold, contact)| {
             (
                 ContactManifoldView {

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -25,8 +25,7 @@ use bevy::ecs::system::{StaticSystemParam, SystemParamItem};
 use bevy::prelude::*;
 
 use super::context::{
-    RapierContextColliders, RapierContextJoints, RapierContextSimulation, RapierQueryPipeline,
-    RapierRigidBodySet,
+    RapierContextColliders, RapierContextJoints, RapierContextSimulation, RapierRigidBodySet,
 };
 
 /// System responsible for advancing the physics simulation, and updating the internal state
@@ -35,7 +34,6 @@ pub fn step_simulation<Hooks>(
     mut context: Query<(
         &mut RapierContextSimulation,
         &mut RapierContextColliders,
-        &mut RapierQueryPipeline,
         &mut RapierContextJoints,
         &mut RapierRigidBodySet,
         &RapierConfiguration,
@@ -56,7 +54,6 @@ pub fn step_simulation<Hooks>(
     for (
         mut context,
         mut context_colliders,
-        mut query_pipeline,
         mut joints,
         mut rigidbody_set,
         config,
@@ -81,10 +78,6 @@ pub fn step_simulation<Hooks>(
             );
         } else {
             rigidbody_set.propagate_modified_body_positions_to_colliders(context_colliders);
-        }
-
-        if config.query_pipeline_active {
-            query_pipeline.update_query_pipeline(context_colliders);
         }
         context.send_bevy_events(&mut collision_events, &mut contact_force_events);
     }


### PR DESCRIPTION
- https://github.com/dimforge/parry/pull/367 would be great to have before release, but that's an upstream bug which should be fixed by a patch release so I'll consider it non blocking.

Bevy specific breaking changes:
- `RapierQueryPipeline` is no longer a component.
  - Migration: Use `RapierContext` or retrieve the needed components to pass to `RapierQueryPipeline::new_scoped` and make your logic in a scoped function. This function allows capturing and returning information.
- a new `QueryPipelineMut`  to provide the same API as rapier. It's currently used for the character controller.