### PR TITLE
Update to Bevy 0.17 and rapier 0.29 along with dependencies nalgebra, glam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
   - `RapierQueryPipeline` is no longer a component.
     - Migration: Use `RapierContext` or retrieve the needed components to pass to `RapierQueryPipeline::new_scoped` and make your logic in a scoped function. This function allows capturing and returning information.
-  - a new `QueryPipelineMut`  to provide the same API as rapier. It's currently used for the character controller.
+  - a new `QueryPipelineMut` to provide the same API as rapier. It's currently used for the character controller.
 
 ### Fix
 
@@ -74,28 +74,25 @@
 - Update bevy to 0.15.
 - `RapierContext`, `RapierConfiguration` and `SimulationToRenderTime` are now a `Component` instead of resources.
   - Rapier now supports multiple independent physics worlds, see example `multi_world3` for usage details.
-  - Migration guide:
-    - `ResMut<mut RapierContext>` -> `WriteDefaultRapierContext`
-    - `Res<RapierContext>` -> `ReadDefaultRapierContext`
-    - Access to `RapierConfiguration` and `SimulationToRenderTime` should query for it
-on the responsible entity owning the `RenderContext`.
+  - Migration guide: - `ResMut<mut RapierContext>` -> `WriteDefaultRapierContext` - `Res<RapierContext>` -> `ReadDefaultRapierContext` - Access to `RapierConfiguration` and `SimulationToRenderTime` should query for it
+    on the responsible entity owning the `RenderContext`.
   - If you are building a library on top of `bevy_rapier` and would want to support multiple independent physics worlds too,
-you can check out the details of [#545](https://github.com/dimforge/bevy_rapier/pull/545)
-to get more context and information.
+    you can check out the details of [#545](https://github.com/dimforge/bevy_rapier/pull/545)
+    to get more context and information.
 - `colliders_with_aabb_intersecting_aabb` now takes `bevy::math::bounding::Aabb3d` (or `[..]::Aabb2d` in 2D) as parameter.
   - it is now accessible with `headless` feature enabled.
 
 ### Fix
 
 - Fix a crash when using `TimestepMode::Interpolated` and removing colliders
-during a frame which would not run a simulation step.
+  during a frame which would not run a simulation step.
 
 ### Added
 
 - Added a `TriMeshFlags` parameter for `ComputedColliderShape`,
-its default value is `TriMeshFlags::MERGE_DUPLICATE_VERTICES`,
-which was its hardcoded behaviour.
-- Added a way to configure which colliders should be debug rendered: `global` parameter for both 
+  its default value is `TriMeshFlags::MERGE_DUPLICATE_VERTICES`,
+  which was its hardcoded behaviour.
+- Added a way to configure which colliders should be debug rendered: `global` parameter for both
   `RapierDebugColliderPlugin` and `DebugRenderContext`, as well as individual collider setup via
   a `ColliderDebug` component.
 
@@ -113,7 +110,7 @@ and new features. Please have a look at the
 - Renamed `has_any_active_contacts` to `has_any_active_contact` for better consistency with rapier.
 - `ColliderDebugColor`'s property is now a `bevy::color::Hsla`.
 - `ImpulseJoint::data` and `MultibodyJoint::data` are now a more detailed enum `TypedJoint` instead of a `GenericJoint`.
-You can still access its inner `GenericJoint` with `.as_ref()` or `as_mut()`.
+  You can still access its inner `GenericJoint` with `.as_ref()` or `as_mut()`.
 - `data` fields from all joints (`FixedJoint`, …) are now public, and their getters removed.
 
 ### Added
@@ -242,7 +239,7 @@ performance of the other parts of the simulation.
 - Fix typo by renaming `CuboidViewMut::sed_half_extents` to `set_half_extents`.
 - Properly scale parented collider’s offset based on changes on its `ColliderScale`.
 
-## 0.21.0  (07 March 2023)
+## 0.21.0 (07 March 2023)
 
 ### Modified
 
@@ -319,13 +316,13 @@ performance of the other parts of the simulation.
 ### Added
 
 - Add a **kinematic character controller** implementation. This feature is accessible in two different ways:
-    1. The first approach is to insert the `KinematicCharacterController` component to an entity. If the
-       `KinematicCharacterController::custom_shape` field is set, then this shape is used for the character control.
-       If this field is `None` then the `Collider` attached to the same entity as the character controller is used.
-       The character controller will be automatically updated when the `KinematicCharacterController::movement` is set.
-       The result position is written to the `Transform` of the character controller’s entity.
-    2. The second, lower level, approach, is to call `RapierContext::move_shape` to compute the possible movement
-       of a shape, taking obstacle and sliding into account.
+  1. The first approach is to insert the `KinematicCharacterController` component to an entity. If the
+     `KinematicCharacterController::custom_shape` field is set, then this shape is used for the character control.
+     If this field is `None` then the `Collider` attached to the same entity as the character controller is used.
+     The character controller will be automatically updated when the `KinematicCharacterController::movement` is set.
+     The result position is written to the `Transform` of the character controller’s entity.
+  2. The second, lower level, approach, is to call `RapierContext::move_shape` to compute the possible movement
+     of a shape, taking obstacle and sliding into account.
 - Add implementations of `Add`, `AddAssign`, `Sub`, `SubAssign` to `ExternalForce` and `ExternalImpulse`.
 - Add `ExternalForce::at_point` and `ExternalImpulse::at_point` to apply a force/impulse at a specific point
   of a rigid-body.
@@ -375,7 +372,7 @@ performance of the other parts of the simulation.
 - Add the `ColliderMassProperties::Mass` variant to let the user specify a collider’s mass directly (instead of its
   density).
   As a result the collider’s angular inertia tensor will be automatically be computed based on this mass and its shape.
-- Add the `ContactForceEvent` event. It can be read by a bevy system with the `EventReader<ContactForceEvent>`. This
+- Add the `ContactForceEvent` event. It can be read by a bevy system with the `MessageReader<ContactForceEvent>`. This
   event is useful to read contact forces. A `ContactForceEvent` is generated whenever the sum of the magnitudes of the
   forces applied by contacts between two colliders exceeds the value specified by the `ContactForceEventThreshold`
   component.
@@ -610,7 +607,6 @@ includes lots of new features. Refer to the Rapier changelogs for details.
 ### Changed
 
 - Rapier configuration
-    - Replaced `Gravity` and `RapierPhysicsScale` resources with a unique `RapierConfiguration` resource.
-    - Added an `physics_pipeline_active` attribute to `RapierConfiguration` allowing to pause the physic simulation.
-    - Added a `query_pipeline_active` attribute to `RapierConfiguration` allowing to pause the query pipeline update.
-
+  - Replaced `Gravity` and `RapierPhysicsScale` resources with a unique `RapierConfiguration` resource.
+  - Added an `physics_pipeline_active` attribute to `RapierConfiguration` allowing to pause the physic simulation.
+  - Added a `query_pipeline_active` attribute to `RapierConfiguration` allowing to pause the query pipeline update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md).
   - `RapierQueryPipeline` is no longer a component.
     - Migration: Use `RapierContext` or retrieve the needed components to pass to `RapierQueryPipeline::new_scoped` and make your logic in a scoped function. This function allows capturing and returning information.
-  - a new `QueryPipelineMut` to provide the same API as rapier. It's currently used for the character controller.
+  - a new `QueryPipelineMut`  to provide the same API as rapier. It's currently used for the character controller.
 
 ### Fix
 
@@ -74,25 +74,28 @@
 - Update bevy to 0.15.
 - `RapierContext`, `RapierConfiguration` and `SimulationToRenderTime` are now a `Component` instead of resources.
   - Rapier now supports multiple independent physics worlds, see example `multi_world3` for usage details.
-  - Migration guide: - `ResMut<mut RapierContext>` -> `WriteDefaultRapierContext` - `Res<RapierContext>` -> `ReadDefaultRapierContext` - Access to `RapierConfiguration` and `SimulationToRenderTime` should query for it
-    on the responsible entity owning the `RenderContext`.
+  - Migration guide:
+    - `ResMut<mut RapierContext>` -> `WriteDefaultRapierContext`
+    - `Res<RapierContext>` -> `ReadDefaultRapierContext`
+    - Access to `RapierConfiguration` and `SimulationToRenderTime` should query for it
+on the responsible entity owning the `RenderContext`.
   - If you are building a library on top of `bevy_rapier` and would want to support multiple independent physics worlds too,
-    you can check out the details of [#545](https://github.com/dimforge/bevy_rapier/pull/545)
-    to get more context and information.
+you can check out the details of [#545](https://github.com/dimforge/bevy_rapier/pull/545)
+to get more context and information.
 - `colliders_with_aabb_intersecting_aabb` now takes `bevy::math::bounding::Aabb3d` (or `[..]::Aabb2d` in 2D) as parameter.
   - it is now accessible with `headless` feature enabled.
 
 ### Fix
 
 - Fix a crash when using `TimestepMode::Interpolated` and removing colliders
-  during a frame which would not run a simulation step.
+during a frame which would not run a simulation step.
 
 ### Added
 
 - Added a `TriMeshFlags` parameter for `ComputedColliderShape`,
-  its default value is `TriMeshFlags::MERGE_DUPLICATE_VERTICES`,
-  which was its hardcoded behaviour.
-- Added a way to configure which colliders should be debug rendered: `global` parameter for both
+its default value is `TriMeshFlags::MERGE_DUPLICATE_VERTICES`,
+which was its hardcoded behaviour.
+- Added a way to configure which colliders should be debug rendered: `global` parameter for both 
   `RapierDebugColliderPlugin` and `DebugRenderContext`, as well as individual collider setup via
   a `ColliderDebug` component.
 
@@ -110,7 +113,7 @@ and new features. Please have a look at the
 - Renamed `has_any_active_contacts` to `has_any_active_contact` for better consistency with rapier.
 - `ColliderDebugColor`'s property is now a `bevy::color::Hsla`.
 - `ImpulseJoint::data` and `MultibodyJoint::data` are now a more detailed enum `TypedJoint` instead of a `GenericJoint`.
-  You can still access its inner `GenericJoint` with `.as_ref()` or `as_mut()`.
+You can still access its inner `GenericJoint` with `.as_ref()` or `as_mut()`.
 - `data` fields from all joints (`FixedJoint`, …) are now public, and their getters removed.
 
 ### Added
@@ -239,7 +242,7 @@ performance of the other parts of the simulation.
 - Fix typo by renaming `CuboidViewMut::sed_half_extents` to `set_half_extents`.
 - Properly scale parented collider’s offset based on changes on its `ColliderScale`.
 
-## 0.21.0 (07 March 2023)
+## 0.21.0  (07 March 2023)
 
 ### Modified
 
@@ -316,13 +319,13 @@ performance of the other parts of the simulation.
 ### Added
 
 - Add a **kinematic character controller** implementation. This feature is accessible in two different ways:
-  1. The first approach is to insert the `KinematicCharacterController` component to an entity. If the
-     `KinematicCharacterController::custom_shape` field is set, then this shape is used for the character control.
-     If this field is `None` then the `Collider` attached to the same entity as the character controller is used.
-     The character controller will be automatically updated when the `KinematicCharacterController::movement` is set.
-     The result position is written to the `Transform` of the character controller’s entity.
-  2. The second, lower level, approach, is to call `RapierContext::move_shape` to compute the possible movement
-     of a shape, taking obstacle and sliding into account.
+    1. The first approach is to insert the `KinematicCharacterController` component to an entity. If the
+       `KinematicCharacterController::custom_shape` field is set, then this shape is used for the character control.
+       If this field is `None` then the `Collider` attached to the same entity as the character controller is used.
+       The character controller will be automatically updated when the `KinematicCharacterController::movement` is set.
+       The result position is written to the `Transform` of the character controller’s entity.
+    2. The second, lower level, approach, is to call `RapierContext::move_shape` to compute the possible movement
+       of a shape, taking obstacle and sliding into account.
 - Add implementations of `Add`, `AddAssign`, `Sub`, `SubAssign` to `ExternalForce` and `ExternalImpulse`.
 - Add `ExternalForce::at_point` and `ExternalImpulse::at_point` to apply a force/impulse at a specific point
   of a rigid-body.
@@ -372,7 +375,7 @@ performance of the other parts of the simulation.
 - Add the `ColliderMassProperties::Mass` variant to let the user specify a collider’s mass directly (instead of its
   density).
   As a result the collider’s angular inertia tensor will be automatically be computed based on this mass and its shape.
-- Add the `ContactForceEvent` event. It can be read by a bevy system with the `MessageReader<ContactForceEvent>`. This
+- Add the `ContactForceEvent` event. It can be read by a bevy system with the `EventReader<ContactForceEvent>`. This
   event is useful to read contact forces. A `ContactForceEvent` is generated whenever the sum of the magnitudes of the
   forces applied by contacts between two colliders exceeds the value specified by the `ContactForceEventThreshold`
   component.
@@ -607,6 +610,7 @@ includes lots of new features. Refer to the Rapier changelogs for details.
 ### Changed
 
 - Rapier configuration
-  - Replaced `Gravity` and `RapierPhysicsScale` resources with a unique `RapierConfiguration` resource.
-  - Added an `physics_pipeline_active` attribute to `RapierConfiguration` allowing to pause the physic simulation.
-  - Added a `query_pipeline_active` attribute to `RapierConfiguration` allowing to pause the query pipeline update.
+    - Replaced `Gravity` and `RapierPhysicsScale` resources with a unique `RapierConfiguration` resource.
+    - Added an `physics_pipeline_active` attribute to `RapierConfiguration` allowing to pause the physic simulation.
+    - Added a `query_pipeline_active` attribute to `RapierConfiguration` allowing to pause the query pipeline update.
+

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -64,15 +64,15 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.16.0", default-features = false, features = ["std"] }
-nalgebra = { version = "0.33", features = ["convert-glam029"] }
-rapier2d = "0.27.0-beta.0"
+bevy = { version = "0.17.0", default-features = false, features = ["std"] }
+nalgebra = { version = "0.34.1", features = ["convert-glam030"] }
+rapier2d = "0.29.0"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.16.0", default-features = false, features = [
+bevy = { version = "0.17.0", default-features = false, features = [
     "x11",
     "bevy_state",
     "bevy_window",
@@ -81,7 +81,7 @@ bevy = { version = "0.16.0", default-features = false, features = [
 ] }
 oorandom = "11"
 approx = "0.5.1"
-glam = { version = "0.29", features = ["approx"] }
+glam = { version = "0.30.8", features = ["approx"] }
 bevy-inspector-egui = "0.31"
 bevy_egui = "0.34"
 bevy_mod_debugdump = "0.13"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -82,9 +82,9 @@ bevy = { version = "0.17.0", default-features = false, features = [
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.30.8", features = ["approx"] }
-bevy-inspector-egui = "0.31"
-bevy_egui = "0.34"
-bevy_mod_debugdump = "0.13"
+bevy-inspector-egui = "0.34"
+bevy_egui = "0.37.0"
+bevy_mod_debugdump = "0.14.0"
 serde_json = "1.0"
 
 [package.metadata.docs.rs]

--- a/bevy_rapier2d/examples/custom_system_setup2.rs
+++ b/bevy_rapier2d/examples/custom_system_setup2.rs
@@ -1,4 +1,4 @@
-use bevy::{diagnostic::FrameCount, prelude::*, transform::TransformSystem};
+use bevy::{diagnostic::FrameCount, prelude::*, transform::TransformSystems};
 use bevy_rapier2d::prelude::*;
 
 fn main() {
@@ -24,7 +24,7 @@ fn main() {
             PhysicsSet::Writeback,
         )
             .chain()
-            .before(TransformSystem::TransformPropagate),
+            .before(TransformSystems::Propagate),
     );
 
     app.add_systems(

--- a/bevy_rapier2d/examples/debugdump2.rs
+++ b/bevy_rapier2d/examples/debugdump2.rs
@@ -2,6 +2,7 @@
 //! run with:
 //! `cargo run --example debugdump2 > dump.dot && dot -Tsvg dump.dot > dump.svg`
 
+use bevy::app::PostUpdate;
 use bevy::prelude::*;
 use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
 use bevy_rapier2d::prelude::*;

--- a/bevy_rapier2d/examples/events2.rs
+++ b/bevy_rapier2d/examples/events2.rs
@@ -23,8 +23,8 @@ pub fn setup_graphics(mut commands: Commands) {
 }
 
 pub fn display_events(
-    mut collision_events: EventReader<CollisionEvent>,
-    mut contact_force_events: EventReader<ContactForceEvent>,
+    mut collision_events: MessageReader<CollisionEvent>,
+    mut contact_force_events: MessageReader<ContactForceEvent>,
 ) {
     for collision_event in collision_events.read() {
         println!("Received collision event: {collision_event:?}");

--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -6,7 +6,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
-                    resolution: WindowResolution::new(1000., 1000.),
+                    resolution: WindowResolution::new(1000, 1000),
                     title: "Player Movement Example".to_string(),
                     ..default()
                 }),

--- a/bevy_rapier2d/examples/serialization2.rs
+++ b/bevy_rapier2d/examples/serialization2.rs
@@ -35,6 +35,6 @@ pub fn print_physics(_context: ReadRapierContext) {
     panic!("Example 'serialization' should be run with '--features serde-serialize'.");
 }
 
-fn quit(mut exit_event: EventWriter<AppExit>) {
+fn quit(mut exit_event: MessageWriter<AppExit>) {
     exit_event.write(AppExit::Success);
 }

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -67,9 +67,7 @@ fn main() {
     app.init_resource::<ExamplesRes>()
         .add_plugins((
             DefaultPlugins,
-            EguiPlugin {
-                enable_multipass_for_primary_context: false,
-            },
+            EguiPlugin::default(),
             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
             RapierDebugRenderPlugin::default(),
             WorldInspectorPlugin::new(),
@@ -256,15 +254,19 @@ fn main() {
 fn init(world: &mut World) {
     //save all entities that are in the world before setting up any example
     // to be able to always return to this state when switching from one example to the other
-    world.resource_mut::<ExamplesRes>().entities_before =
-        world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+    world.resource_mut::<ExamplesRes>().entities_before = world
+        .query::<EntityRef>()
+        .iter(world)
+        .map(|e| e.id())
+        .collect::<Vec<_>>();
 }
 
 fn cleanup(world: &mut World) {
     let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
 
     let remove = world
-        .iter_entities()
+        .query::<EntityRef>()
+        .iter(world)
         .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
         .collect::<Vec<_>>();
 
@@ -290,7 +292,7 @@ fn ui_example_system(
     mut current_example: ResMut<ExampleSelected>,
     examples_available: Res<ExampleSet>,
 ) {
-    egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
+    egui::Window::new("Testbed").show(contexts.ctx_mut().unwrap(), |ui| {
         let mut changed = false;
         egui::ComboBox::from_label("example")
             .width(150.0)

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -86,9 +86,9 @@ bevy = { version = "0.17.0", default-features = false, features = [
 ] }
 approx = "0.5.1"
 glam = { version = "0.30.7", features = ["approx"] }
-bevy-inspector-egui = "0.31"
-bevy_egui = "0.34"
-bevy_mod_debugdump = "0.13"
+bevy-inspector-egui = "0.34"
+bevy_egui = "0.37.0"
+bevy_mod_debugdump = "0.14.0"
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -65,15 +65,15 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.16.0", default-features = false, features = ["std"] }
-nalgebra = { version = "0.33", features = ["convert-glam029"] }
-rapier3d = "0.27.0-beta.0"
+bevy = { version = "0.17.0", default-features = false, features = ["std"] }
+nalgebra = { version = "0.34.1", features = ["convert-glam030"] }
+rapier3d = "0.29.0"
 bitflags = "2.4"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.16.0", default-features = false, features = [
+bevy = { version = "0.17.0", default-features = false, features = [
     "bevy_window",
     "x11",
     "tonemapping_luts",
@@ -85,7 +85,7 @@ bevy = { version = "0.16.0", default-features = false, features = [
     "bevy_log",
 ] }
 approx = "0.5.1"
-glam = { version = "0.29", features = ["approx"] }
+glam = { version = "0.30.7", features = ["approx"] }
 bevy-inspector-egui = "0.31"
 bevy_egui = "0.34"
 bevy_mod_debugdump = "0.13"

--- a/bevy_rapier3d/examples/character_controller3.rs
+++ b/bevy_rapier3d/examples/character_controller3.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    input::{mouse::MouseMotion, InputSystem},
+    input::{mouse::MouseMotion, InputSystems},
     prelude::*,
 };
 use bevy_rapier3d::{control::KinematicCharacterController, prelude::*};
@@ -25,7 +25,7 @@ fn main() {
             RapierDebugRenderPlugin::default(),
         ))
         .add_systems(Startup, (setup_player, setup_map))
-        .add_systems(PreUpdate, handle_input.after(InputSystem))
+        .add_systems(PreUpdate, handle_input.after(InputSystems))
         .add_systems(Update, player_look)
         .add_systems(FixedUpdate, player_movement)
         .run();

--- a/bevy_rapier3d/examples/character_controller3.rs
+++ b/bevy_rapier3d/examples/character_controller3.rs
@@ -112,7 +112,7 @@ fn handle_input(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut movement: ResMut<MovementInput>,
     mut look: ResMut<LookInput>,
-    mut mouse_events: EventReader<MouseMotion>,
+    mut mouse_events: MessageReader<MouseMotion>,
 ) {
     if keyboard.pressed(KeyCode::KeyW) {
         movement.z -= 1.0;

--- a/bevy_rapier3d/examples/custom_system_setup3.rs
+++ b/bevy_rapier3d/examples/custom_system_setup3.rs
@@ -1,4 +1,4 @@
-use bevy::{diagnostic::FrameCount, prelude::*, transform::TransformSystem};
+use bevy::{diagnostic::FrameCount, prelude::*, transform::TransformSystems};
 use bevy_rapier3d::prelude::*;
 
 fn main() {
@@ -24,7 +24,7 @@ fn main() {
             PhysicsSet::Writeback,
         )
             .chain()
-            .before(TransformSystem::TransformPropagate),
+            .before(TransformSystems::Propagate),
     );
 
     app.add_systems(

--- a/bevy_rapier3d/examples/debugdump3.rs
+++ b/bevy_rapier3d/examples/debugdump3.rs
@@ -2,6 +2,7 @@
 //! run with:
 //! `cargo run --example debugdump3 > dump.dot && dot -Tsvg dump.dot > dump.svg`
 
+use bevy::app::PostUpdate;
 use bevy::prelude::*;
 use bevy_mod_debugdump::{schedule_graph, schedule_graph_dot};
 use bevy_rapier3d::prelude::*;

--- a/bevy_rapier3d/examples/despawn3.rs
+++ b/bevy_rapier3d/examples/despawn3.rs
@@ -95,7 +95,7 @@ pub fn despawn(
     mut despawn: ResMut<DespawnResource>,
     query: Query<Entity, With<Despawn>>,
 ) {
-    if despawn.timer.tick(time.delta()).finished() {
+    if despawn.timer.tick(time.delta()).is_finished() {
         for entity in &query {
             println!("Despawning ground entity");
             commands.entity(entity).despawn();

--- a/bevy_rapier3d/examples/events3.rs
+++ b/bevy_rapier3d/examples/events3.rs
@@ -26,8 +26,8 @@ pub fn setup_graphics(mut commands: Commands) {
 }
 
 pub fn display_events(
-    mut collision_events: EventReader<CollisionEvent>,
-    mut contact_force_events: EventReader<ContactForceEvent>,
+    mut collision_events: MessageReader<CollisionEvent>,
+    mut contact_force_events: MessageReader<ContactForceEvent>,
 ) {
     for collision_event in collision_events.read() {
         println!("Received collision event: {collision_event:?}");

--- a/bevy_rapier3d/examples/joints_despawn3.rs
+++ b/bevy_rapier3d/examples/joints_despawn3.rs
@@ -273,7 +273,7 @@ pub fn despawn(
     mut despawn: ResMut<DespawnResource>,
     query: Query<Entity, With<Despawn>>,
 ) {
-    if despawn.timer.tick(time.delta()).finished() {
+    if despawn.timer.tick(time.delta()).is_finished() {
         for entity in &query {
             println!("Despawning joint entity");
             commands.entity(entity).despawn();

--- a/bevy_rapier3d/examples/picking3.rs
+++ b/bevy_rapier3d/examples/picking3.rs
@@ -45,15 +45,13 @@ pub fn setup_physics(mut commands: Commands) {
             },
         ))
         .observe(on_click_spawn_cube)
+        .observe(|out: On<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
+            let mut text_color = texts.get_mut(out.event().entity).unwrap();
+            text_color.0 = Color::WHITE;
+        })
         .observe(
-            |out: Trigger<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
-                let mut text_color = texts.get_mut(out.target()).unwrap();
-                text_color.0 = Color::WHITE;
-            },
-        )
-        .observe(
-            |over: Trigger<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
-                let mut color = texts.get_mut(over.target()).unwrap();
+            |over: On<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
+                let mut color = texts.get_mut(over.event().entity).unwrap();
                 color.0 = bevy::color::palettes::tailwind::CYAN_400.into();
             },
         );
@@ -67,11 +65,7 @@ pub fn setup_physics(mut commands: Commands) {
     ));
 }
 
-fn on_click_spawn_cube(
-    _click: Trigger<Pointer<Click>>,
-    mut commands: Commands,
-    mut num: Local<usize>,
-) {
+fn on_click_spawn_cube(_click: On<Pointer<Click>>, mut commands: Commands, mut num: Local<usize>) {
     let rad = 0.25;
     let colors = [
         Hsla::hsl(220.0, 1.0, 0.3),
@@ -92,8 +86,8 @@ fn on_click_spawn_cube(
     *num += 1;
 }
 
-fn on_drag_rotate(drag: Trigger<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
-    if let Ok(mut transform) = transforms.get_mut(drag.target()) {
+fn on_drag_rotate(drag: On<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
+    if let Ok(mut transform) = transforms.get_mut(drag.event().entity) {
         transform.rotate_y(drag.delta.x * 0.02);
         transform.rotate_x(drag.delta.y * 0.02);
     }

--- a/bevy_rapier3d/examples/rapier_context_component.rs
+++ b/bevy_rapier3d/examples/rapier_context_component.rs
@@ -19,7 +19,7 @@ fn main() {
 /// Demonstrates how to access a more specific component of [`RapierContext`]
 fn display_nb_colliders(
     query_context: Query<&RapierContextColliders, With<DefaultRapierContext>>,
-    mut exit: EventWriter<AppExit>,
+    mut exit: MessageWriter<AppExit>,
 ) -> Result<()> {
     let nb_colliders = query_context.single()?.colliders.len();
     println!("There are {nb_colliders} colliders.");

--- a/bevy_rapier3d/examples/static_trimesh3.rs
+++ b/bevy_rapier3d/examples/static_trimesh3.rs
@@ -123,7 +123,7 @@ pub fn ball_spawner(mut commands: Commands, time: Res<Time>, mut ball_state: Res
         return;
     }
 
-    if ball_state.timer.tick(time.delta()).finished() {
+    if ball_state.timer.tick(time.delta()).is_finished() {
         // Spawn a ball near the top of the ramp.
         let ramp_size = ramp_size();
         let rad = 0.3;

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -69,6 +69,7 @@ fn main() {
             DefaultPlugins,
             EguiPlugin {
                 enable_multipass_for_primary_context: false,
+                ..Default::default()
             },
             RapierPhysicsPlugin::<NoUserData>::default(),
             RapierDebugRenderPlugin::default(),
@@ -248,15 +249,19 @@ fn main() {
 fn init(world: &mut World) {
     //save all entities that are in the world before setting up any example
     // to be able to always return to this state when switching from one example to the other
-    world.resource_mut::<ExamplesRes>().entities_before =
-        world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+    world.resource_mut::<ExamplesRes>().entities_before = world
+        .query::<EntityRef>()
+        .iter(world)
+        .map(|e| e.id())
+        .collect::<Vec<_>>();
 }
 
 fn cleanup(world: &mut World) {
     let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
 
     let remove = world
-        .iter_entities()
+        .query::<EntityRef>()
+        .iter(world)
         .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
         .collect::<Vec<_>>();
     for r in remove {
@@ -281,7 +286,7 @@ fn ui_example_system(
     mut current_example: ResMut<ExampleSelected>,
     examples_available: Res<ExampleSet>,
 ) {
-    egui::Window::new("Testbed").show(contexts.ctx_mut(), |ui| {
+    egui::Window::new("Testbed").show(contexts.ctx_mut().unwrap(), |ui| {
         let mut changed = false;
         egui::ComboBox::from_label("example")
             .width(150.0)

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rapier3d = { features = ["profiler"], version = "0.27.0-beta.0" }
+rapier3d = { features = ["profiler"], version = "0.29.0" }
 bevy_rapier3d = { version = "0.31", path = "../bevy_rapier3d" }
-bevy = { version = "0.16.0", default-features = false }
+bevy = { version = "0.17.0", default-features = false }
 
 [dev-dependencies]
 divan = "0.1"

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.16.0"
+bevy = "0.17.0"
 bevy_rapier3d = { version = "0.31", path = "../bevy_rapier3d" }
 bevy_rapier2d = { version = "0.31", path = "../bevy_rapier2d" }
 

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -202,7 +202,7 @@ impl std::ops::Deref for ReadMassProperties {
 }
 
 /// Entity that likely had their mass properties changed this frame.
-#[derive(Deref, Copy, Clone, Debug, PartialEq, Event)]
+#[derive(Deref, Copy, Clone, Debug, PartialEq, Event, Message)]
 pub struct MassModifiedEvent(pub Entity);
 
 impl From<Entity> for MassModifiedEvent {

--- a/src/geometry/collider_impl.rs
+++ b/src/geometry/collider_impl.rs
@@ -2,8 +2,8 @@
 use na::DVector;
 #[cfg(all(feature = "dim3", feature = "async-collider"))]
 use {
+    bevy::mesh::{Indices, VertexAttributeValues},
     bevy::prelude::*,
-    bevy::render::mesh::{Indices, VertexAttributeValues},
 };
 
 use rapier::{

--- a/src/geometry/to_bevy_mesh.rs
+++ b/src/geometry/to_bevy_mesh.rs
@@ -5,15 +5,15 @@ use crate::rapier::prelude::Ball;
 #[cfg(feature = "dim3")]
 use crate::rapier::prelude::{Cone, Cylinder};
 #[cfg(feature = "dim2")]
-use bevy::render::mesh::{Capsule2dMeshBuilder, CircleMeshBuilder};
+use bevy::mesh::{Capsule2dMeshBuilder, CircleMeshBuilder};
 #[cfg(feature = "dim3")]
-use bevy::render::mesh::{
+use bevy::mesh::{
     Capsule3dMeshBuilder, ConeMeshBuilder, CylinderMeshBuilder, PlaneMeshBuilder, SphereMeshBuilder,
 };
 use bevy::{
     asset::RenderAssetUsages,
+    mesh::Indices,
     prelude::{Mesh, MeshBuilder},
-    render::mesh::Indices,
 };
 
 use rapier::prelude::{Capsule, TypedShape};
@@ -65,7 +65,7 @@ pub fn typed_shape_to_mesh(typed_shape: &TypedShape) -> Option<Mesh> {
                 let (vtx, idx) = _voxels.to_outline();
 
                 let mesh = Mesh::new(
-                    bevy::render::mesh::PrimitiveTopology::TriangleList,
+                    bevy::mesh::PrimitiveTopology::TriangleList,
                     RenderAssetUsages::default(),
                 )
                 .with_inserted_indices(Indices::U32(idx.into_iter().flatten().collect()));
@@ -94,7 +94,7 @@ pub fn typed_shape_to_mesh(typed_shape: &TypedShape) -> Option<Mesh> {
             let vertices: Vec<_> = vertices.iter().map(|pos| [pos.x, pos.y, pos.z]).collect();
             let indices = tri_mesh.indices();
             let mesh = Mesh::new(
-                bevy::render::mesh::PrimitiveTopology::TriangleList,
+                bevy::mesh::PrimitiveTopology::TriangleList,
                 RenderAssetUsages::default(),
             )
             .with_inserted_indices(Indices::U32(indices.iter().cloned().flatten().collect()));
@@ -126,7 +126,7 @@ pub fn typed_shape_to_mesh(typed_shape: &TypedShape) -> Option<Mesh> {
                 let (vtx, idx) = _height_field.to_trimesh();
 
                 let mesh = Mesh::new(
-                    bevy::render::mesh::PrimitiveTopology::TriangleList,
+                    bevy::mesh::PrimitiveTopology::TriangleList,
                     RenderAssetUsages::default(),
                 )
                 .with_inserted_indices(Indices::U32(idx.into_iter().flatten().collect()));
@@ -164,7 +164,7 @@ pub fn typed_shape_to_mesh(typed_shape: &TypedShape) -> Option<Mesh> {
                 .flat_map(|i| vec![0, i, i + 1])
                 .collect::<Vec<u32>>();
             let mesh = Mesh::new(
-                bevy::render::mesh::PrimitiveTopology::TriangleList,
+                bevy::mesh::PrimitiveTopology::TriangleList,
                 RenderAssetUsages::default(),
             )
             .with_inserted_indices(Indices::U32(indices));
@@ -179,7 +179,7 @@ pub fn typed_shape_to_mesh(typed_shape: &TypedShape) -> Option<Mesh> {
                 .flat_map(|i| vec![0, i, i + 1])
                 .collect::<Vec<u32>>();
             let mesh = Mesh::new(
-                bevy::render::mesh::PrimitiveTopology::TriangleList,
+                bevy::mesh::PrimitiveTopology::TriangleList,
                 RenderAssetUsages::default(),
             )
             .with_inserted_indices(Indices::U32(indices));
@@ -243,7 +243,7 @@ impl TryFrom<&Collider> for Mesh {
 /// Trait to convert a parry shape to a [`MeshBuilder`].
 pub trait ToMeshBuilder {
     /// Specific [`MeshBuilder`] being returned.
-    type MeshBuilder: bevy::render::prelude::MeshBuilder;
+    type MeshBuilder: bevy::mesh::prelude::MeshBuilder;
     /// Returns a dedicated [`MeshBuilder`].
     fn mesh_builder(&self) -> Self::MeshBuilder;
 }
@@ -262,10 +262,7 @@ impl ToMeshBuilder for &Ball {
     type MeshBuilder = SphereMeshBuilder;
 
     fn mesh_builder(&self) -> Self::MeshBuilder {
-        SphereMeshBuilder::new(
-            self.radius,
-            bevy::render::mesh::SphereKind::Ico { subdivisions: 1 },
-        )
+        SphereMeshBuilder::new(self.radius, bevy::mesh::SphereKind::Ico { subdivisions: 1 })
     }
 }
 
@@ -286,7 +283,7 @@ impl ToMeshBuilder for &Capsule {
     type MeshBuilder = Capsule2dMeshBuilder;
 
     fn mesh_builder(&self) -> Self::MeshBuilder {
-        bevy::render::mesh::Capsule2dMeshBuilder::new(self.radius, self.height(), 10)
+        bevy::mesh::Capsule2dMeshBuilder::new(self.radius, self.height(), 10)
     }
 }
 
@@ -295,7 +292,7 @@ impl ToMeshBuilder for &Capsule {
     type MeshBuilder = Capsule3dMeshBuilder;
 
     fn mesh_builder(&self) -> Self::MeshBuilder {
-        bevy::render::mesh::Capsule3dMeshBuilder::new(self.radius, self.height(), 10, 10)
+        bevy::mesh::Capsule3dMeshBuilder::new(self.radius, self.height(), 10, 10)
     }
 }
 #[cfg(feature = "dim3")]
@@ -303,7 +300,7 @@ impl ToMeshBuilder for &Cone {
     type MeshBuilder = ConeMeshBuilder;
 
     fn mesh_builder(&self) -> Self::MeshBuilder {
-        bevy::render::mesh::ConeMeshBuilder::new(self.radius, self.half_height * 2.0, 16)
+        bevy::mesh::ConeMeshBuilder::new(self.radius, self.half_height * 2.0, 16)
     }
 }
 
@@ -312,6 +309,6 @@ impl ToMeshBuilder for &Cylinder {
     type MeshBuilder = CylinderMeshBuilder;
 
     fn mesh_builder(&self) -> Self::MeshBuilder {
-        bevy::render::mesh::CylinderMeshBuilder::new(self.radius, self.half_height * 2.0, 16)
+        bevy::mesh::CylinderMeshBuilder::new(self.radius, self.half_height * 2.0, 16)
     }
 }

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -1,4 +1,5 @@
 use crate::math::{Real, Vect};
+use bevy::ecs::message::Message;
 use bevy::prelude::{Entity, Event};
 use rapier::dynamics::RigidBodySet;
 use rapier::geometry::{
@@ -16,7 +17,7 @@ use crate::prelude::{ActiveEvents, ContactForceEventThreshold};
 ///
 /// This will only get triggered if the entity has the
 /// [`ActiveEvents::COLLISION_EVENTS`] flag enabled.
-#[derive(Event, Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Event, Copy, Clone, Debug, PartialEq, Eq, Message)]
 pub enum CollisionEvent {
     /// Event occurring when two colliders start colliding
     Started(Entity, Entity, CollisionEventFlags),
@@ -29,7 +30,7 @@ pub enum CollisionEvent {
 ///
 /// This will only get triggered if the entity has the
 /// [`ActiveEvents::CONTACT_FORCE_EVENTS`] flag enabled.
-#[derive(Event, Copy, Clone, Debug, PartialEq)]
+#[derive(Event, Copy, Clone, Debug, PartialEq, Message)]
 pub struct ContactForceEvent {
     /// The first collider involved in the contact.
     pub collider1: Entity,
@@ -162,7 +163,7 @@ mod test {
             }
         }
         pub fn save_events<E: Event + Clone>(
-            mut events: EventReader<E>,
+            mut events: MessageReader<E>,
             mut saver: ResMut<EventsSaver<E>>,
         ) {
             for event in events.read() {

--- a/src/pipeline/events.rs
+++ b/src/pipeline/events.rs
@@ -152,17 +152,17 @@ mod test {
         use bevy::prelude::*;
 
         #[derive(Resource, Reflect)]
-        pub struct EventsSaver<E: Event> {
+        pub struct EventsSaver<E: Message> {
             pub events: Vec<E>,
         }
-        impl<E: Event> Default for EventsSaver<E> {
+        impl<E: Message> Default for EventsSaver<E> {
             fn default() -> Self {
                 Self {
                     events: Default::default(),
                 }
             }
         }
-        pub fn save_events<E: Event + Clone>(
+        pub fn save_events<E: Message + Clone>(
             mut events: MessageReader<E>,
             mut saver: ResMut<EventsSaver<E>>,
         ) {

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -17,7 +17,7 @@ use rapier::prelude::{
 use crate::geometry::{PointProjection, RayIntersection, ShapeCastHit};
 use crate::math::{Rot, Vect};
 use crate::pipeline::{CollisionEvent, ContactForceEvent, EventQueue};
-use bevy::prelude::{Entity, EventWriter, GlobalTransform, Query};
+use bevy::prelude::{Entity, GlobalTransform, Query};
 
 use crate::control::{CharacterCollision, MoveShapeOptions, MoveShapeOutput};
 use crate::dynamics::TransformInterpolation;
@@ -223,7 +223,7 @@ impl<'a> RapierQueryPipelineMut<'a> {
     }
 
     /// Downgrades the mutable reference to an immutable reference.
-    pub fn as_ref(&self) -> RapierQueryPipeline {
+    pub fn as_ref(&self) -> RapierQueryPipeline<'_> {
         RapierQueryPipeline {
             query_pipeline: self.query_pipeline.as_ref(),
         }
@@ -700,8 +700,8 @@ impl RapierContextSimulation {
         gravity: Vect,
         timestep_mode: TimestepMode,
         events: Option<(
-            &EventWriter<CollisionEvent>,
-            &EventWriter<ContactForceEvent>,
+            &MessageWriter<CollisionEvent>,
+            &MessageWriter<ContactForceEvent>,
         )>,
         hooks: &dyn PhysicsHooks,
         time: &Time,
@@ -848,8 +848,8 @@ impl RapierContextSimulation {
     /// that are stored in the events list
     pub fn send_bevy_events(
         &mut self,
-        collision_event_writer: &mut EventWriter<CollisionEvent>,
-        contact_force_event_writer: &mut EventWriter<ContactForceEvent>,
+        collision_event_writer: &mut MessageWriter<CollisionEvent>,
+        contact_force_event_writer: &mut MessageWriter<ContactForceEvent>,
     ) {
         for collision_event in self.collision_events_to_send.drain(..) {
             collision_event_writer.write(collision_event);

--- a/src/plugin/context/systemparams/rapier_context_systemparam.rs
+++ b/src/plugin/context/systemparams/rapier_context_systemparam.rs
@@ -195,8 +195,8 @@ mod simulation {
             gravity: Vect,
             timestep_mode: TimestepMode,
             events: Option<(
-                &EventWriter<CollisionEvent>,
-                &EventWriter<ContactForceEvent>,
+                &MessageWriter<CollisionEvent>,
+                &MessageWriter<ContactForceEvent>,
             )>,
             hooks: &dyn PhysicsHooks,
             time: &Time,

--- a/src/plugin/narrow_phase.rs
+++ b/src/plugin/narrow_phase.rs
@@ -333,7 +333,7 @@ impl SolverContactView<'_> {
     }
     /// Whether or not this contact existed during the last timestep.
     pub fn is_new(&self) -> bool {
-        self.raw.is_new
+        self.raw.is_new == 1.0
     }
 }
 

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -443,7 +443,7 @@ pub fn setup_rapier_configuration(
 mod test {
 
     use bevy::{
-        ecs::schedule::Stepping,
+        ecs::schedule::{NodeId, Stepping},
         prelude::Component,
         time::{TimePlugin, TimeUpdateStrategy},
     };
@@ -510,7 +510,7 @@ mod test {
                         .unwrap()
                         .systems()
                         .unwrap()
-                        .find(|s| s.0 == cursor.1)
+                        .find(|s| NodeId::System(s.0) == cursor.1)
                         .unwrap();
                     println!(
                         "next system: {}",
@@ -610,22 +610,16 @@ mod test {
             // render + physics
             app.update();
 
-            let context = app
-                .world_mut()
-                .query::<RapierContext>()
-                .single(app.world())
-                .unwrap();
+            let mut context_query = app.world_mut().query::<RapierContext>();
+            let context = context_query.single(app.world()).unwrap();
             assert_eq!(context.rigidbody_set.entity2body.len(), 1);
 
             // render only + remove entities
             app.update();
             // Fixed Update hasn´t run yet, so it's a risk of not having caught the bevy removed event, which will be cleaned next frame.
 
-            let context = app
-                .world_mut()
-                .query::<RapierContext>()
-                .single(app.world())
-                .unwrap();
+            let mut context_query = app.world_mut().query::<RapierContext>();
+            let context = context_query.single(app.world()).unwrap();
 
             println!("{:?}", &context.rigidbody_set.entity2body);
             assert_eq!(context.rigidbody_set.entity2body.len(), 0);
@@ -693,11 +687,8 @@ mod test {
             for _ in 0..100 {
                 app.update();
             }
-            let context = app
-                .world_mut()
-                .query::<RapierContext>()
-                .single(app.world())
-                .unwrap();
+            let mut context_query = app.world_mut().query::<RapierContext>();
+            let context = context_query.single(app.world()).unwrap();
 
             println!("{:#?}", &context.rigidbody_set.bodies);
         }
@@ -761,11 +752,8 @@ mod test {
                 .unwrap();
             approx::assert_relative_eq!(collider.scale, Vect::splat(0.1), epsilon = 1.0e-5);
 
-            let context = app
-                .world_mut()
-                .query::<RapierContext>()
-                .single(app.world())
-                .unwrap();
+            let mut context_query = app.world_mut().query::<RapierContext>();
+            let context = context_query.single(app.world()).unwrap();
             let physics_ball_radius = context
                 .colliders
                 .colliders

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -600,7 +600,7 @@ pub mod test {
     #[cfg(all(feature = "dim3", feature = "async-collider"))]
     fn async_collider_initializes() {
         use super::*;
-        use bevy::{render::mesh::MeshPlugin, scene::ScenePlugin};
+        use bevy::{mesh::MeshPlugin, scene::ScenePlugin};
 
         let mut app = App::new();
         app.add_plugins((AssetPlugin::default(), MeshPlugin, ScenePlugin));
@@ -633,7 +633,7 @@ pub mod test {
     #[cfg(all(feature = "dim3", feature = "async-collider"))]
     fn async_scene_collider_initializes() {
         use super::*;
-        use bevy::{render::mesh::MeshPlugin, scene::ScenePlugin};
+        use bevy::{mesh::MeshPlugin, scene::ScenePlugin};
 
         let mut app = App::new();
         app.add_plugins((AssetPlugin::default(), MeshPlugin, ScenePlugin));

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -141,7 +141,7 @@ pub fn apply_collider_user_changes(
         Changed<ColliderMassProperties>,
     >,
 
-    mut mass_modified: EventWriter<MassModifiedEvent>,
+    mut mass_modified: MessageWriter<MassModifiedEvent>,
 ) {
     for (rapier_entity, handle, transform) in changed_collider_transforms.iter() {
         let (rigidbody_set, mut context_colliders) = context
@@ -568,7 +568,7 @@ pub fn init_async_scene_colliders(
 /// Adds entity to [`CollidingEntities`] on starting collision and removes from it when the
 /// collision ends.
 pub fn update_colliding_entities(
-    mut collision_events: EventReader<CollisionEvent>,
+    mut collision_events: MessageReader<CollisionEvent>,
     mut colliding_entities: Query<&mut CollidingEntities>,
 ) {
     for event in collision_events.read() {

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -86,7 +86,7 @@ pub fn step_simulation<Hooks>(
 #[cfg(test)]
 #[allow(missing_docs)]
 pub mod tests {
-    use bevy::{ecs::event::Events, time::TimePlugin};
+    use bevy::time::TimePlugin;
     use rapier::geometry::CollisionEventFlags;
     use std::f32::consts::PI;
 
@@ -100,7 +100,7 @@ pub mod tests {
     #[test]
     fn colliding_entities_updates() {
         let mut app = App::new();
-        app.add_event::<CollisionEvent>()
+        app.add_message::<CollisionEvent>()
             .add_systems(Update, update_colliding_entities);
 
         let entity1 = app.world_mut().spawn(CollidingEntities::default()).id();
@@ -110,7 +110,7 @@ pub mod tests {
             .world_mut()
             .get_resource_mut::<Messages<CollisionEvent>>()
             .unwrap();
-        collision_events.send(CollisionEvent::Started(
+        collision_events.write(CollisionEvent::Started(
             entity1,
             entity2,
             CollisionEventFlags::SENSOR,
@@ -154,7 +154,7 @@ pub mod tests {
             .world_mut()
             .get_resource_mut::<Messages<CollisionEvent>>()
             .unwrap();
-        collision_events.send(CollisionEvent::Stopped(
+        collision_events.write(CollisionEvent::Stopped(
             entity1,
             entity2,
             CollisionEventFlags::SENSOR,

--- a/src/plugin/systems/mod.rs
+++ b/src/plugin/systems/mod.rs
@@ -42,8 +42,8 @@ pub fn step_simulation<Hooks>(
     timestep_mode: Res<TimestepMode>,
     hooks: StaticSystemParam<Hooks>,
     time: Res<Time>,
-    mut collision_events: EventWriter<CollisionEvent>,
-    mut contact_force_events: EventWriter<ContactForceEvent>,
+    mut collision_events: MessageWriter<CollisionEvent>,
+    mut contact_force_events: MessageWriter<ContactForceEvent>,
     mut interpolation_query: Query<(&RapierRigidBodyHandle, &mut TransformInterpolation)>,
 ) where
     Hooks: 'static + BevyPhysicsHooks,
@@ -108,7 +108,7 @@ pub mod tests {
 
         let mut collision_events = app
             .world_mut()
-            .get_resource_mut::<Events<CollisionEvent>>()
+            .get_resource_mut::<Messages<CollisionEvent>>()
             .unwrap();
         collision_events.send(CollisionEvent::Started(
             entity1,
@@ -152,7 +152,7 @@ pub mod tests {
 
         let mut collision_events = app
             .world_mut()
-            .get_resource_mut::<Events<CollisionEvent>>()
+            .get_resource_mut::<Messages<CollisionEvent>>()
             .unwrap();
         collision_events.send(CollisionEvent::Stopped(
             entity1,

--- a/src/plugin/systems/remove.rs
+++ b/src/plugin/systems/remove.rs
@@ -43,7 +43,7 @@ pub fn sync_removals(
     mut removed_rigid_body_disabled: RemovedComponents<RigidBodyDisabled>,
     mut removed_colliders_disabled: RemovedComponents<ColliderDisabled>,
 
-    mut mass_modified: EventWriter<MassModifiedEvent>,
+    mut mass_modified: MessageWriter<MassModifiedEvent>,
 ) {
     /*
      * Rigid-bodies removal detection.
@@ -219,9 +219,9 @@ pub fn sync_removals(
 
 fn find_context<'a, TReturn, TQueryParams: QueryData>(
     context_writer: &'a mut Query<TQueryParams>,
-    item_finder: impl Fn(&mut TQueryParams::Item<'_>) -> Option<TReturn>,
-) -> Option<(TQueryParams::Item<'a>, TReturn)> {
-    let ret: Option<(TQueryParams::Item<'_>, TReturn)> = context_writer
+    item_finder: impl Fn(&mut TQueryParams::Item<'_, '_>) -> Option<TReturn>,
+) -> Option<(TQueryParams::Item<'a, 'a>, TReturn)> {
+    let ret: Option<(TQueryParams::Item<'_, '_>, TReturn)> = context_writer
         .iter_mut()
         .find_map(|mut context| item_finder(&mut context).map(|handle| (context, handle)));
     ret

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -136,7 +136,7 @@ pub fn apply_rigid_body_user_changes(
             Changed<AdditionalSolverIterations>,
         >,
     ),
-    mut mass_modified: EventWriter<MassModifiedEvent>,
+    mut mass_modified: MessageWriter<MassModifiedEvent>,
 ) {
     // Deal with sleeping first, because other changes may then wake-up the
     // rigid-body again.
@@ -588,7 +588,7 @@ pub fn init_rigid_bodies(
         builder = builder.enabled(disabled.is_none());
 
         if let Some(transform) = transform {
-            builder = builder.position(utils::transform_to_iso(&transform.compute_transform()));
+            builder = builder.pose(utils::transform_to_iso(&transform.compute_transform()));
         }
 
         #[allow(clippy::useless_conversion)] // Need to convert if dim3 enabled

--- a/src/plugin/systems/writeback.rs
+++ b/src/plugin/systems/writeback.rs
@@ -12,7 +12,7 @@ pub fn writeback_mass_properties(
     config: Query<&RapierConfiguration>,
 
     mut mass_props: Query<&mut ReadMassProperties>,
-    mut mass_modified: EventReader<MassModifiedEvent>,
+    mut mass_modified: MessageReader<MassModifiedEvent>,
 ) {
     for entity in mass_modified.read() {
         let link = link

--- a/src/reflect/mod.rs
+++ b/src/reflect/mod.rs
@@ -1,7 +1,31 @@
 use crate::math::Real;
 use bevy::reflect::reflect_remote;
+#[cfg(feature = "dim3")]
+use rapier::dynamics::FrictionModel;
 use rapier::dynamics::IntegrationParameters;
-use std::num::NonZeroUsize;
+
+/// Friction models used for all contact constraints between two rigid-bodies.
+///
+/// This selection does not apply to multibodies that always rely on the [`FrictionModel::Coulomb`].
+#[cfg(feature = "dim3")]
+#[reflect_remote(FrictionModel)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+pub enum FrictionModelWrapper {
+    /// A simplified friction model significantly faster to solve than [`Self::Coulomb`]
+    /// but less accurate.
+    ///
+    /// Instead of solving one Coulomb friction constraint per contact in a contact manifold,
+    /// this approximation only solves one Coulomb friction constraint per group of 4 contacts
+    /// in a contact manifold, plus one "twist" constraint. The "twist" constraint is purely
+    /// rotational and aims to eliminate angular movement in the manifold’s tangent plane.
+    #[default]
+    Simplified,
+    /// The coulomb friction model.
+    ///
+    /// This results in one Coulomb friction constraint per contact point.
+    Coulomb,
+}
 
 #[reflect_remote(IntegrationParameters)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -86,9 +110,7 @@ pub struct IntegrationParametersWrapper {
     /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
     pub normalized_prediction_distance: Real,
     /// The number of solver iterations run by the constraints solver for calculating forces (default: `4`).
-    pub num_solver_iterations: NonZeroUsize,
-    /// Number of addition friction resolution iteration run during the last solver sub-step (default: `0`).
-    pub num_additional_friction_iterations: usize,
+    pub num_solver_iterations: usize,
     /// Number of internal Project Gauss Seidel (PGS) iterations run at each solver iteration (default: `1`).
     pub num_internal_pgs_iterations: usize,
     /// The number of stabilization iterations run at each solver iterations (default: `2`).
@@ -97,4 +119,8 @@ pub struct IntegrationParametersWrapper {
     pub min_island_size: usize,
     /// Maximum number of substeps performed by the  solver (default: `1`).
     pub max_ccd_substeps: usize,
+    /// The friction model used by the solver (default: `FrictionModel::Rigid`).
+    #[cfg(feature = "dim3")]
+    #[reflect(remote = FrictionModelWrapper)]
+    pub friction_model: FrictionModel,
 }

--- a/src/reflect/mod.rs
+++ b/src/reflect/mod.rs
@@ -27,6 +27,102 @@ pub enum FrictionModelWrapper {
     Coulomb,
 }
 
+#[cfg(not(feature = "dim3"))]
+#[reflect_remote(IntegrationParameters)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+/// Parameters for a time-step of the physics engine.
+pub struct IntegrationParametersWrapper {
+    /// The timestep length (default: `1.0 / 60.0`).
+    pub dt: Real,
+    /// Minimum timestep size when using CCD with multiple substeps (default: `1.0 / 60.0 / 100.0`).
+    ///
+    /// When CCD with multiple substeps is enabled, the timestep is subdivided
+    /// into smaller pieces. This timestep subdivision won't generate timestep
+    /// lengths smaller than `min_ccd_dt`.
+    ///
+    /// Setting this to a large value will reduce the opportunity to performing
+    /// CCD substepping, resulting in potentially more time dropped by the
+    /// motion-clamping mechanism. Setting this to an very small value may lead
+    /// to numerical instabilities.
+    pub min_ccd_dt: Real,
+
+    /// > 0: the damping ratio used by the springs for contact constraint stabilization.
+    ///
+    /// Larger values make the constraints more compliant (allowing more visible
+    /// penetrations before stabilization).
+    /// (default `5.0`).
+    pub contact_damping_ratio: Real,
+
+    /// > 0: the natural frequency used by the springs for contact constraint regularization.
+    ///
+    /// Increasing this value will make it so that penetrations get fixed more quickly at the
+    /// expense of potential jitter effects due to overshooting. In order to make the simulation
+    /// look stiffer, it is recommended to increase the [`Self::contact_damping_ratio`] instead of this
+    /// value.
+    /// (default: `30.0`).
+    pub contact_natural_frequency: Real,
+
+    /// > 0: the natural frequency used by the springs for joint constraint regularization.
+    ///
+    /// Increasing this value will make it so that penetrations get fixed more quickly.
+    /// (default: `1.0e6`).
+    pub joint_natural_frequency: Real,
+
+    /// The fraction of critical damping applied to the joint for constraints regularization.
+    ///
+    /// Larger values make the constraints more compliant (allowing more joint
+    /// drift before stabilization).
+    /// (default `1.0`).
+    pub joint_damping_ratio: Real,
+
+    /// The coefficient in `[0, 1]` applied to warmstart impulses, i.e., impulses that are used as the
+    /// initial solution (instead of 0) at the next simulation step.
+    ///
+    /// This should generally be set to 1.
+    ///
+    /// (default `1.0`).
+    pub warmstart_coefficient: Real,
+
+    /// The approximate size of most dynamic objects in the scene.
+    ///
+    /// This value is used internally to estimate some length-based tolerance. In particular, the
+    /// values [`IntegrationParameters::allowed_linear_error`],
+    /// [`IntegrationParameters::max_corrective_velocity`],
+    /// [`IntegrationParameters::prediction_distance`], [`RigidBodyActivation::normalized_linear_threshold`]
+    /// are scaled by this value implicitly.
+    ///
+    /// This value can be understood as the number of units-per-meter in your physical world compared
+    /// to a human-sized world in meter. For example, in a 2d game, if your typical object size is 100
+    /// pixels, set the [`Self::length_unit`] parameter to 100.0. The physics engine will interpret
+    /// it as if 100 pixels is equivalent to 1 meter in its various internal threshold.
+    /// (default `1.0`).
+    pub length_unit: Real,
+
+    /// Amount of penetration the engine won’t attempt to correct (default: `0.001m`).
+    ///
+    /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
+    pub normalized_allowed_linear_error: Real,
+    /// Maximum amount of penetration the solver will attempt to resolve in one timestep (default: `10.0`).
+    ///
+    /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
+    pub normalized_max_corrective_velocity: Real,
+    /// The maximal distance separating two objects that will generate predictive contacts (default: `0.002m`).
+    ///
+    /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
+    pub normalized_prediction_distance: Real,
+    /// The number of solver iterations run by the constraints solver for calculating forces (default: `4`).
+    pub num_solver_iterations: usize,
+    /// Number of internal Project Gauss Seidel (PGS) iterations run at each solver iteration (default: `1`).
+    pub num_internal_pgs_iterations: usize,
+    /// The number of stabilization iterations run at each solver iterations (default: `2`).
+    pub num_internal_stabilization_iterations: usize,
+    /// Minimum number of dynamic bodies in each active island (default: `128`).
+    pub min_island_size: usize,
+    /// Maximum number of substeps performed by the  solver (default: `1`).
+    pub max_ccd_substeps: usize,
+}
+
+#[cfg(feature = "dim3")]
 #[reflect_remote(IntegrationParameters)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 /// Parameters for a time-step of the physics engine.
@@ -120,7 +216,6 @@ pub struct IntegrationParametersWrapper {
     /// Maximum number of substeps performed by the  solver (default: `1`).
     pub max_ccd_substeps: usize,
     /// The friction model used by the solver (default: `FrictionModel::Rigid`).
-    #[cfg(feature = "dim3")]
     #[reflect(remote = FrictionModelWrapper)]
     pub friction_model: FrictionModel,
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2,7 +2,7 @@ use crate::plugin::context::{
     RapierContextColliders, RapierContextJoints, RapierContextSimulation, RapierRigidBodySet,
 };
 use bevy::prelude::*;
-use bevy::transform::TransformSystem;
+use bevy::transform::TransformSystems;
 use rapier::math::{Point, Real};
 use rapier::pipeline::{DebugRenderBackend, DebugRenderObject, DebugRenderPipeline};
 pub use rapier::pipeline::{DebugRenderMode, DebugRenderStyle};
@@ -118,7 +118,7 @@ impl Plugin for RapierDebugRenderPlugin {
         })
         .add_systems(
             PostUpdate,
-            debug_render_scene.after(TransformSystem::TransformPropagate),
+            debug_render_scene.after(TransformSystems::Propagate),
         );
     }
 }


### PR DESCRIPTION
Hey!

First time contributor. I don't quite know what I'm doing (no this is not in any way a vibecoded PR) but I was starting on a Bevy 0.17 project and needed bevy rapier for 0.17. I thought "how hard could it be" so I worked my way through updating all dependencies and making the necessary changes to get it to compile (including changing depreciations) and now everything seems to work fine (all tests pass). I fully understand if this migration needs changes, but it worked for me and in the meantime it works as a stopgap for anyone who wants a commit they can pin to.

Best wishes