### PR TITLE
Update to Bevy 0.18.0

### DIFF
--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -64,7 +64,7 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.17.3", default-features = false, features = ["std"] }
+bevy = { version = "0.18.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.34.1", features = ["convert-glam030"] }
 rapier2d = "0.31.0"
 bitflags = "2.10.0"
@@ -72,7 +72,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.17.3", default-features = false, features = [
+bevy = { version = "0.18.0", default-features = false, features = [
     "x11",
     "bevy_state",
     "bevy_window",
@@ -86,15 +86,16 @@ bevy = { version = "0.17.3", default-features = false, features = [
     "bevy_sprite",
     "bevy_sprite_render",
     "bevy_gizmos",
+    "bevy_gizmos_render",
     "bevy_color",
     "bevy_camera",
 ] }
 oorandom = "11"
 approx = "0.5.1"
 glam = { version = "0.30.9", features = ["approx"] }
-bevy-inspector-egui = "0.35.0"
-bevy_egui = "0.38.0"
-bevy_mod_debugdump = "0.14.0"
+bevy-inspector-egui = "0.36.0"
+bevy_egui = "0.39.0"
+bevy_mod_debugdump = "0.15.0"
 serde_json = "1.0"
 
 [package.metadata.docs.rs]

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -13,12 +13,8 @@ mod player_movement2;
 mod rope_joint2;
 mod voxels2;
 
-use bevy::{
-    camera::visibility::RenderLayers,
-    ecs::world::error::{EntityDespawnError, EntityMutableFetchError},
-    prelude::*,
-};
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy::{camera::visibility::RenderLayers, ecs::world::error::EntityDespawnError, prelude::*};
+use bevy_egui::{egui, EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;
 
@@ -252,7 +248,7 @@ fn main() {
         )
         .add_systems(OnExit(Examples::None), init)
         .add_systems(
-            Update,
+            EguiPrimaryContextPass,
             (
                 ui_example_system,
                 change_example.run_if(resource_changed::<ExampleSelected>),
@@ -283,9 +279,7 @@ fn cleanup(world: &mut World) {
         .collect::<Vec<_>>();
 
     for r in remove {
-        if let Err(error @ EntityDespawnError(EntityMutableFetchError::AliasedMutability(_))) =
-            world.try_despawn(r)
-        {
+        if let Err(error @ EntityDespawnError(_)) = world.try_despawn(r) {
             warn!("Cleanup error: {error:?}");
         }
     }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -65,7 +65,7 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.17.3", default-features = false, features = ["std"] }
+bevy = { version = "0.18.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.34.1", features = ["convert-glam030"] }
 rapier3d = "0.31.0"
 bitflags = "2.10.0"
@@ -73,7 +73,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.17.3", default-features = false, features = [
+bevy = { version = "0.18.0", default-features = false, features = [
     "bevy_window",
     "x11",
     "tonemapping_luts",
@@ -83,12 +83,13 @@ bevy = { version = "0.17.3", default-features = false, features = [
     "bevy_ui",
     "default_font",
     "bevy_log",
+    "bevy_gizmos_render",
 ] }
 approx = "0.5.1"
 glam = { version = "0.30.9", features = ["approx"] }
-bevy-inspector-egui = "0.35.0"
-bevy_egui = "0.38.0"
-bevy_mod_debugdump = "0.14.0"
+bevy-inspector-egui = "0.36.0"
+bevy_egui = "0.39.0"
+bevy_mod_debugdump = "0.15.0"
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -13,12 +13,8 @@ mod ray_casting3;
 mod static_trimesh3;
 mod voxels3;
 
-use bevy::{
-    camera::visibility::RenderLayers,
-    ecs::world::error::{EntityDespawnError, EntityMutableFetchError},
-    prelude::*,
-};
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy::{camera::visibility::RenderLayers, ecs::world::error::EntityDespawnError, prelude::*};
+use bevy_egui::{egui, EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
 
@@ -244,7 +240,7 @@ fn main() {
         )
         .add_systems(OnExit(Examples::None), init)
         .add_systems(
-            Update,
+            EguiPrimaryContextPass,
             (
                 ui_example_system,
                 change_example.run_if(resource_changed::<ExampleSelected>),
@@ -274,9 +270,7 @@ fn cleanup(world: &mut World) {
         .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
         .collect::<Vec<_>>();
     for r in remove {
-        if let Err(error @ EntityDespawnError(EntityMutableFetchError::AliasedMutability(_))) =
-            world.try_despawn(r)
-        {
+        if let Err(error @ EntityDespawnError(_)) = world.try_despawn(r) {
             warn!("Cleanup error: {error:?}");
         }
     }

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 rapier3d = "0.31.0"
 bevy_rapier3d = { version = "0.32", path = "../bevy_rapier3d" }
-bevy = { version = "0.17.3", default-features = false }
+bevy = { version = "0.18.0", default-features = false }
 
 [dev-dependencies]
 divan = "0.1"

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.17.3"
+bevy = "0.18.0"
 bevy_rapier3d = { version = "0.32", path = "../bevy_rapier3d" }
 bevy_rapier2d = { version = "0.32", path = "../bevy_rapier2d" }
 


### PR DESCRIPTION
Contributing for the first time. Tried to update to bevy 0.18.0. Here are the changes:
- Updated Bevy to version 0.18.0 and other dependencies
- Made the cleanup warning generic because the previous match was removed from Bevy
- Made testbed examples' ui_example_systems run on EguiPrimaryContextPass instead of Update to prevent panics

Fixes #685