### PR TITLE
Rename `Velocity` fields

### DIFF
--- a/bevy_rapier2d/examples/player_movement2.rs
+++ b/bevy_rapier2d/examples/player_movement2.rs
@@ -71,6 +71,6 @@ pub fn player_movement(
 
         // Update the velocity on the rigid_body_component,
         // the bevy_rapier plugin will update the Sprite transform.
-        rb_vels.linvel = move_delta * player.0;
+        rb_vels.linear = move_delta * player.0;
     }
 }

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -87,53 +87,53 @@ impl From<RigidBodyType> for RigidBody {
 #[reflect(Component, Default, PartialEq)]
 pub struct Velocity {
     /// The linear velocity of the [`RigidBody`].
-    pub linvel: Vect,
+    pub linear: Vect,
     /// The angular velocity of the [`RigidBody`] in radian per second.
     #[cfg(feature = "dim2")]
-    pub angvel: f32,
+    pub angular: f32,
     /// The angular velocity of the [`RigidBody`].
     #[cfg(feature = "dim3")]
-    pub angvel: Vect,
+    pub angular: Vect,
 }
 
 impl Velocity {
     /// Initialize a velocity set to zero.
     pub const fn zero() -> Self {
         Self {
-            linvel: Vect::ZERO,
+            linear: Vect::ZERO,
             #[cfg(feature = "dim2")]
-            angvel: 0.0,
+            angular: 0.0,
             #[cfg(feature = "dim3")]
-            angvel: Vect::ZERO,
+            angular: Vect::ZERO,
         }
     }
 
     /// Initialize a velocity with the given linear velocity, and an angular velocity of zero.
-    pub const fn linear(linvel: Vect) -> Self {
+    pub const fn linear(linear: Vect) -> Self {
         Self {
-            linvel,
+            linear,
             #[cfg(feature = "dim2")]
-            angvel: 0.0,
+            angular: 0.0,
             #[cfg(feature = "dim3")]
-            angvel: Vect::ZERO,
+            angular: Vect::ZERO,
         }
     }
 
     /// Initialize a velocity with the given angular velocity, and a linear velocity of zero.
     #[cfg(feature = "dim2")]
-    pub const fn angular(angvel: f32) -> Self {
+    pub const fn angular(angular: f32) -> Self {
         Self {
-            linvel: Vect::ZERO,
-            angvel,
+            linear: Vect::ZERO,
+            angular,
         }
     }
 
     /// Initialize a velocity with the given angular velocity, and a linear velocity of zero.
     #[cfg(feature = "dim3")]
-    pub const fn angular(angvel: Vect) -> Self {
+    pub const fn angular(angular: Vect) -> Self {
         Self {
-            linvel: Vect::ZERO,
-            angvel,
+            linear: Vect::ZERO,
+            angular,
         }
     }
 
@@ -144,10 +144,10 @@ impl Velocity {
     /// - `center_of_mass`: the center-of-mass (world-space) of the [`RigidBody`] the velocity belongs to.
     pub fn linear_velocity_at_point(&self, point: Vect, center_of_mass: Vect) -> Vect {
         #[cfg(feature = "dim2")]
-        return self.linvel + self.angvel * (point - center_of_mass).perp();
+        return self.linear + self.angular * (point - center_of_mass).perp();
 
         #[cfg(feature = "dim3")]
-        return self.linvel + self.angvel.cross(point - center_of_mass);
+        return self.linear + self.angular.cross(point - center_of_mass);
     }
 }
 

--- a/src/plugin/systems/rigid_body.rs
+++ b/src/plugin/systems/rigid_body.rs
@@ -264,9 +264,9 @@ pub fn apply_rigid_body_user_changes(
             .expect(RAPIER_CONTEXT_EXPECT_ERROR)
             .into_inner();
         if let Some(rb) = rigidbody_set.bodies.get_mut(handle.0) {
-            rb.set_linvel(velocity.linvel, true);
+            rb.set_linvel(velocity.linear, true);
             #[allow(clippy::useless_conversion)] // Need to convert if dim3 enabled
-            rb.set_angvel(velocity.angvel.into(), true);
+            rb.set_angvel(velocity.angular.into(), true);
         }
     }
 
@@ -532,11 +532,11 @@ pub fn writeback_rigid_bodies(
 
             if let Some(velocity) = &mut velocity {
                 let new_vel = Velocity {
-                    linvel: rb.linvel(),
+                    linear: rb.linvel(),
                     #[cfg(feature = "dim3")]
-                    angvel: rb.angvel(),
+                    angular: rb.angvel(),
                     #[cfg(feature = "dim2")]
-                    angvel: rb.angvel(),
+                    angular: rb.angvel(),
                 };
 
                 // NOTE: we write the new value only if there was an
@@ -593,7 +593,7 @@ pub fn init_rigid_bodies(
 
         #[allow(clippy::useless_conversion)] // Need to convert if dim3 enabled
         if let Some(vel) = vel {
-            builder = builder.linvel(vel.linvel.into()).angvel(vel.angvel.into());
+            builder = builder.linvel(vel.linear.into()).angvel(vel.angular.into());
         }
 
         if let Some(locked_axes) = locked_axes {


### PR DESCRIPTION
Renamed `linvel` to `linear` and `angvel` to `angular`.
Fixes #505