### PR TITLE
sync_removals: skip removal events when a fresh handle is live

### DIFF
--- a/src/plugin/systems/multiple_rapier_contexts.rs
+++ b/src/plugin/systems/multiple_rapier_contexts.rs
@@ -131,10 +131,16 @@ fn bubble_down_context_change(
 #[cfg(test)]
 mod test {
     use crate::plugin::{
-        context::{RapierContextEntityLink, RapierContextSimulation},
+        context::{
+            DefaultRapierContext, RapierContextEntityLink, RapierContextSimulation,
+            RapierRigidBodySet,
+        },
         NoUserData, PhysicsSet, RapierPhysicsPlugin,
     };
-    use crate::prelude::{ActiveEvents, Collider, ContactForceEventThreshold, RigidBody, Sensor};
+    use crate::prelude::{
+        ActiveEvents, Collider, ContactForceEventThreshold, RapierColliderHandle,
+        RapierRigidBodyHandle, RigidBody, Sensor,
+    };
     use bevy::prelude::*;
     use bevy::time::{TimePlugin, TimeUpdateStrategy};
     use rapier::math::Real;
@@ -226,6 +232,143 @@ mod test {
                         Marker::<'R'>,
                     ));
                 });
+        }
+    }
+
+    /// Regression test for `sync_removals` deleting a freshly-reinserted body when an entity is
+    /// migrated between Rapier contexts in `.in_fixed_schedule()` mode.
+    ///
+    /// When the schedule is not `PostUpdate`, `RapierPhysicsPlugin` registers `sync_removals` in
+    /// both the configured schedule's `SyncBackend` chain *and* in `PostUpdate` as a safety net
+    /// for events that would otherwise be missed. Each registration owns an independent
+    /// `RemovedComponents<RapierRigidBodyHandle>` cursor, so both copies process the same removal
+    /// event. Without a guard, the PostUpdate copy walks all contexts via `find_context` after
+    /// `init_rigid_bodies` has reinserted the body in the new context, finds the freshly-created
+    /// `entity2body` entry, and deletes it — leaving the entity with a live
+    /// `RapierRigidBodyHandle` component and no body in any rapier set.
+    ///
+    /// This test reproduces that pattern (link swap + handle removal) and asserts the body lives
+    /// in the new context after a few app updates.
+    #[test]
+    pub fn body_survives_context_migration_via_handle_swap() {
+        let mut app = App::new();
+        app.add_plugins((
+            TransformPlugin,
+            TimePlugin,
+            RapierPhysicsPlugin::<NoUserData>::default().in_fixed_schedule(),
+        ));
+        app.insert_resource(TimeUpdateStrategy::ManualDuration(
+            std::time::Duration::from_secs_f32(1.0 / 60.0),
+        ));
+        app.insert_resource(Time::<Fixed>::from_hz(60.0));
+        app.add_systems(Startup, setup_body);
+        app.finish();
+
+        // Run a few frames so the default context is created, `setup_body` runs, and the body is
+        // registered in the default context's `entity2body`.
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let body_entity = app
+            .world_mut()
+            .query_filtered::<Entity, With<MigrationTarget>>()
+            .single(app.world())
+            .expect("body entity exists");
+        let default_ctx_entity = app
+            .world_mut()
+            .query_filtered::<Entity, With<DefaultRapierContext>>()
+            .single(app.world())
+            .expect("default context exists");
+
+        assert!(
+            app.world()
+                .entity(default_ctx_entity)
+                .get::<RapierRigidBodySet>()
+                .unwrap()
+                .entity2body()
+                .contains_key(&body_entity),
+            "pre-migration: body must be registered in the default context",
+        );
+
+        // Spawn a second context. `setup_rapier_configuration` will attach `RapierConfiguration`
+        // on the next update.
+        let new_ctx_entity = app
+            .world_mut()
+            .spawn(RapierContextSimulation::default())
+            .id();
+        app.update();
+
+        // Migrate: swap the entity's `RapierContextEntityLink` and drop its handles. This is the
+        // exact pattern that triggered the dual-`sync_removals` deletion bug.
+        {
+            let world = app.world_mut();
+            let mut entity_mut = world.entity_mut(body_entity);
+            entity_mut.insert(RapierContextEntityLink(new_ctx_entity));
+            entity_mut.remove::<RapierRigidBodyHandle>();
+            entity_mut.remove::<RapierColliderHandle>();
+        }
+
+        // Run enough frames so both `sync_removals` copies process the removal event and
+        // `init_rigid_bodies` / `init_colliders` re-create the body in the new context.
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let world = app.world();
+        let new_set = world
+            .entity(new_ctx_entity)
+            .get::<RapierRigidBodySet>()
+            .unwrap();
+        let default_set = world
+            .entity(default_ctx_entity)
+            .get::<RapierRigidBodySet>()
+            .unwrap();
+
+        assert!(
+            new_set.entity2body().contains_key(&body_entity),
+            "body must live in the new context after migration; \
+             a stale removal event must not delete the freshly-reinserted body",
+        );
+        assert!(
+            !default_set.entity2body().contains_key(&body_entity),
+            "body must no longer be registered in the original context",
+        );
+
+        let handle = world
+            .entity(body_entity)
+            .get::<RapierRigidBodyHandle>()
+            .expect("entity must have a fresh `RapierRigidBodyHandle`");
+        let mapped = new_set
+            .entity2body()
+            .get(&body_entity)
+            .expect("new context's `entity2body` must contain the migrated entity");
+        assert_eq!(
+            handle.0, *mapped,
+            "the entity's `RapierRigidBodyHandle` component must reference the new context's body",
+        );
+
+        return;
+
+        #[derive(Component)]
+        pub struct MigrationTarget;
+
+        #[cfg(feature = "dim3")]
+        fn cuboid(hx: Real, hy: Real, hz: Real) -> Collider {
+            Collider::cuboid(hx, hy, hz)
+        }
+        #[cfg(feature = "dim2")]
+        fn cuboid(hx: Real, hy: Real, _hz: Real) -> Collider {
+            Collider::cuboid(hx, hy)
+        }
+
+        pub fn setup_body(mut commands: Commands) {
+            commands.spawn((
+                Transform::from_xyz(0.0, 0.0, 0.0),
+                RigidBody::Dynamic,
+                cuboid(0.5, 0.5, 0.5),
+                MigrationTarget,
+            ));
         }
     }
 }

--- a/src/plugin/systems/remove.rs
+++ b/src/plugin/systems/remove.rs
@@ -38,6 +38,15 @@ pub fn sync_removals(
         Entity,
         (With<RapierMultibodyJointHandle>, Without<MultibodyJoint>),
     >,
+    // Live handles after removal events were emitted. If the entity still has a current handle, a
+    // fresh body/collider was inserted (e.g. after a context migration) and the stale removal
+    // event must not delete that new instance.
+    live_handles: Query<(
+        Has<RapierRigidBodyHandle>,
+        Has<RapierColliderHandle>,
+        Has<RapierImpulseJointHandle>,
+        Has<RapierMultibodyJointHandle>,
+    )>,
 
     mut removed_sensors: RemovedComponents<Sensor>,
     mut removed_rigid_body_disabled: RemovedComponents<RigidBodyDisabled>,
@@ -49,6 +58,11 @@ pub fn sync_removals(
      * Rigid-bodies removal detection.
      */
     for entity in removed_bodies.read() {
+        // The entity already has a fresh handle (e.g. reinserted by `init_rigid_bodies` after a
+        // context migration), so this stale removal event must not delete the new body.
+        if live_handles.get(entity).map(|(b, ..)| b).unwrap_or(false) {
+            continue;
+        }
         let Some(((mut context, mut context_colliders, mut joints, mut rigidbody_set), handle)) =
             find_context(&mut context_writer, |res| res.3.entity2body.remove(&entity))
         else {
@@ -91,6 +105,13 @@ pub fn sync_removals(
      * Collider removal detection.
      */
     for entity in removed_colliders.read() {
+        if live_handles
+            .get(entity)
+            .map(|(_, c, ..)| c)
+            .unwrap_or(false)
+        {
+            continue;
+        }
         let Some(((mut context, mut context_colliders, _, mut rigidbody_set), handle)) =
             find_context(&mut context_writer, |res| {
                 res.1.entity2collider.remove(&entity)
@@ -139,6 +160,13 @@ pub fn sync_removals(
      * Impulse joint removal detection.
      */
     for entity in removed_impulse_joints.read() {
+        if live_handles
+            .get(entity)
+            .map(|(_, _, j, _)| j)
+            .unwrap_or(false)
+        {
+            continue;
+        }
         let Some(((_, _, mut joints, _), handle)) = find_context(&mut context_writer, |res| {
             res.2.entity2impulse_joint.remove(&entity)
         }) else {
@@ -160,6 +188,13 @@ pub fn sync_removals(
      * Multibody joint removal detection.
      */
     for entity in removed_multibody_joints.read() {
+        if live_handles
+            .get(entity)
+            .map(|(.., m)| m)
+            .unwrap_or(false)
+        {
+            continue;
+        }
         let Some(((_, _, mut joints, _), handle)) = find_context(&mut context_writer, |res| {
             res.2.entity2multibody_joint.remove(&entity)
         }) else {


### PR DESCRIPTION
**Summary**
Fix sync_removals deleting a freshly-reinserted Rapier body/collider/joint when an entity is migrated between RapierContextSimulations.

**Background**
When RapierPhysicsPlugin runs in a non-PostUpdate schedule (e.g. .in_fixed_schedule()), sync_removals is registered twice:

- once inside PhysicsSet::SyncBackend in the configured schedule, and
- once in PostUpdate as a safety net for events that would otherwise be missed (see the comment above the second registration in plugin.rs).

Each registration owns an independent RemovedComponents<RapierRigidBodyHandle> cursor, so both copies see the same removal event.

**The bug**
A common cross-context migration pattern is to atomically swap an entity's RapierContextEntityLink and remove its RapierRigidBodyHandle / RapierColliderHandle. Between the two sync_removals runs, init_rigid_bodies / init_colliders correctly create a fresh body/collider in the new context's entity2body / entity2collider. The PostUpdate copy then re-reads the original removal event, walks all contexts via find_context, finds the entity in the new context's map, and deletes the freshly-inserted instance — leaving the entity with a live handle component but no body/collider in any rapier set, so it stops being integrated.

**Fix**
Add a live_handles query and short-circuit each removal-event loop when the entity still has the corresponding handle component. A live handle means a fresh instance was inserted after the original removal (init_rigid_bodies / init_colliders / init_joints), and that instance must not be deleted by the stale event. The orphan-handling paths and the standard "user removed handle and meant it" path are unchanged.

Applied to bodies, colliders, impulse joints, and multibody joints for parity.

**Test**
Adds body_survives_context_migration_via_handle_swap in multiple_rapier_contexts::test. It runs the plugin in .in_fixed_schedule() mode (so both sync_removals registrations are live), spawns a RigidBody::Dynamic body, spawns a second RapierContextSimulation, performs the link-swap + handle-removal pattern, and asserts that after a few app updates the body lives in the new context's entity2body, is gone from the original context, and that the freshly-attached RapierRigidBodyHandle matches the new context's mapping.

Confirmed the test fails with the expected assertion message when the fix is reverted. Full bevy_rapier2d and bevy_rapier3d --lib suites pass on the branch.

