### PR TITLE
Update to Bevy 0.19.0 (WIP)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 members = ["bevy_rapier2d", "bevy_rapier3d", "bevy_rapier_benches3d", "ci"]
 resolver = "2"
 
+[workspace.dependencies]
+rapier2d = { git = "https://github.com/Buncys/rapier.git", rev = "ff6af7e3e0c55f5c331f02388f3d3d7b560aff0b" }
+rapier3d = { git = "https://github.com/Buncys/rapier.git", rev = "ff6af7e3e0c55f5c331f02388f3d3d7b560aff0b" }
+
 [profile.dev]
 # Use slightly better optimization by default, as examples otherwise seem laggy.
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ members = ["bevy_rapier2d", "bevy_rapier3d", "bevy_rapier_benches3d", "ci"]
 resolver = "2"
 
 [workspace.dependencies]
-rapier2d = { git = "https://github.com/Buncys/rapier.git", rev = "ff6af7e3e0c55f5c331f02388f3d3d7b560aff0b" }
-rapier3d = { git = "https://github.com/Buncys/rapier.git", rev = "ff6af7e3e0c55f5c331f02388f3d3d7b560aff0b" }
+rapier2d = "=0.33.0-alpha"
+rapier3d = "=0.33.0-alpha"
 
 [profile.dev]
 # Use slightly better optimization by default, as examples otherwise seem laggy.

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -64,7 +64,7 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.18.1", default-features = false, features = ["std"] }
+bevy = { version = "0.19.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.34.2", features = ["convert-glam030"] }
 rapier2d = "0.32.0"
 bitflags = "2.10.0"
@@ -72,7 +72,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.18.1", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
     "x11",
     "bevy_state",
     "bevy_window",
@@ -92,10 +92,10 @@ bevy = { version = "0.18.1", default-features = false, features = [
 ] }
 oorandom = "11"
 approx = "0.5.1"
-glam = { version = "0.30.9", features = ["approx"] }
-bevy-inspector-egui = "0.36.0"
-bevy_egui = "0.39.1"
-bevy_mod_debugdump = "0.15.0"
+glam = { version = "0.32.1", features = ["approx"] }
+bevy-inspector-egui = "0.37.0"
+bevy_egui = "0.40.0"
+bevy_mod_debugdump = "0.16.0"
 serde_json = "1.0"
 
 [package.metadata.docs.rs]

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -57,7 +57,7 @@ headless = []
 picking-backend = ["bevy/bevy_picking", "bevy/bevy_render"]
 async-collider = [
     "bevy/bevy_asset",
-    "bevy/bevy_scene",
+    "bevy/bevy_world_serialization",
     "bevy/bevy_render",
     "bevy/bevy_image",
 ]
@@ -65,8 +65,8 @@ to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
 bevy = { version = "0.19.0", default-features = false, features = ["std"] }
-nalgebra = { version = "0.34.2", features = ["convert-glam030"] }
-rapier2d = "0.32.0"
+nalgebra = { version = "0.34.2", features = ["convert-glam032"] }
+rapier2d = { workspace = true }
 bitflags = "2.10.0"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/bevy_rapier2d/examples/testbed2.rs
+++ b/bevy_rapier2d/examples/testbed2.rs
@@ -13,7 +13,11 @@ mod player_movement2;
 mod rope_joint2;
 mod voxels2;
 
-use bevy::{camera::visibility::RenderLayers, ecs::world::error::EntityDespawnError, prelude::*};
+use bevy::{
+    camera::visibility::RenderLayers,
+    ecs::{resource::IsResource, world::error::EntityDespawnError},
+    prelude::*,
+};
 use bevy_egui::{egui, EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier2d::prelude::*;
@@ -67,8 +71,13 @@ fn main() {
             EguiPlugin::default(),
             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(10.0),
             RapierDebugRenderPlugin::default(),
-            WorldInspectorPlugin::new(),
         ))
+        // `bevy-inspector-egui` unconditionally registers an `InspectorEguiImpl` for
+        // `GizmoConfigStore`, which panics unless the type has already been registered.
+        // Bevy 0.19 no longer registers it automatically, so do it here before adding
+        // the inspector plugin.
+        .register_type::<GizmoConfigStore>()
+        .add_plugins(WorldInspectorPlugin::new())
         .register_type::<Examples>()
         .register_type::<ExamplesRes>()
         .register_type::<ExampleSelected>()
@@ -261,11 +270,12 @@ fn main() {
 
 fn init(world: &mut World) {
     // save all entities that are in the world before setting up any example
-    // to be able to always return to this state when switching from one example to the other
+    // to be able to always return to this state when switching from one example to the other.
+    // Resource-backed entities (carrying `IsResource`) are excluded: in Bevy 0.19 resources are
+    // stored as entities, and despawning them in `cleanup` panics.
     world.resource_mut::<ExamplesRes>().entities_before = world
-        .query::<EntityRef>()
+        .query_filtered::<Entity, Without<IsResource>>()
         .iter(world)
-        .map(|e| e.id())
         .collect::<Vec<_>>();
 }
 
@@ -273,12 +283,17 @@ fn cleanup(world: &mut World) {
     let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
 
     let remove = world
-        .query::<EntityRef>()
+        .query_filtered::<Entity, Without<IsResource>>()
         .iter(world)
-        .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
+        .filter(|e| !keep_alive.contains(e))
         .collect::<Vec<_>>();
 
     for r in remove {
+        // The entity may already have been despawned as part of a parent's despawn cascade;
+        // skip it in that case to avoid a flood of spurious "invalid entity" warnings.
+        if !world.entities().contains(r) {
+            continue;
+        }
         if let Err(error @ EntityDespawnError(_)) = world.try_despawn(r) {
             warn!("Cleanup error: {error:?}");
         }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -58,7 +58,7 @@ headless = []
 picking-backend = ["bevy/bevy_picking", "bevy/bevy_render"]
 async-collider = [
     "bevy/bevy_asset",
-    "bevy/bevy_scene",
+    "bevy/bevy_world_serialization",
     "bevy/bevy_render",
     "bevy/bevy_image",
 ]
@@ -66,8 +66,8 @@ to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
 bevy = { version = "0.19.0", default-features = false, features = ["std"] }
-nalgebra = { version = "0.34.2", features = ["convert-glam030"] }
-rapier3d = "0.32.0"
+nalgebra = { version = "0.34.2", features = ["convert-glam032"] }
+rapier3d = { workspace = true }
 bitflags = "2.10.0"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -65,7 +65,7 @@ async-collider = [
 to-bevy-mesh = ["bevy/bevy_render", "bevy/bevy_asset"]
 
 [dependencies]
-bevy = { version = "0.18.1", default-features = false, features = ["std"] }
+bevy = { version = "0.19.0", default-features = false, features = ["std"] }
 nalgebra = { version = "0.34.2", features = ["convert-glam030"] }
 rapier3d = "0.32.0"
 bitflags = "2.10.0"
@@ -73,7 +73,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.18.1", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
     "bevy_window",
     "x11",
     "tonemapping_luts",
@@ -86,10 +86,10 @@ bevy = { version = "0.18.1", default-features = false, features = [
     "bevy_gizmos_render",
 ] }
 approx = "0.5.1"
-glam = { version = "0.30.9", features = ["approx"] }
-bevy-inspector-egui = "0.36.0"
-bevy_egui = "0.39.1"
-bevy_mod_debugdump = "0.15.0"
+glam = { version = "0.32.1", features = ["approx"] }
+bevy-inspector-egui = "0.37.0"
+bevy_egui = "0.40.0"
+bevy_mod_debugdump = "0.16.0"
 
 [package.metadata.docs.rs]
 # Enable all the features when building the docs on docs.rs

--- a/bevy_rapier3d/examples/rapier_to_bevy_mesh.rs
+++ b/bevy_rapier3d/examples/rapier_to_bevy_mesh.rs
@@ -44,7 +44,7 @@ pub fn setup_physics(
     // light
     commands.spawn((
         PointLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(4.0, 8.0, 8.0),

--- a/bevy_rapier3d/examples/testbed3.rs
+++ b/bevy_rapier3d/examples/testbed3.rs
@@ -13,7 +13,11 @@ mod ray_casting3;
 mod static_trimesh3;
 mod voxels3;
 
-use bevy::{camera::visibility::RenderLayers, ecs::world::error::EntityDespawnError, prelude::*};
+use bevy::{
+    camera::visibility::RenderLayers,
+    ecs::{resource::IsResource, world::error::EntityDespawnError},
+    prelude::*,
+};
 use bevy_egui::{egui, EguiContexts, EguiPlugin, EguiPrimaryContextPass};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
@@ -67,9 +71,13 @@ fn main() {
             EguiPlugin::default(),
             RapierPhysicsPlugin::<NoUserData>::default(),
             RapierDebugRenderPlugin::default(),
-            WorldInspectorPlugin::new(),
-            RapierPickingPlugin,
         ))
+        // `bevy-inspector-egui` unconditionally registers an `InspectorEguiImpl` for
+        // `GizmoConfigStore`, which panics unless the type has already been registered.
+        // Bevy 0.19 no longer registers it automatically, so do it here before adding
+        // the inspector plugin.
+        .register_type::<GizmoConfigStore>()
+        .add_plugins((WorldInspectorPlugin::new(), RapierPickingPlugin))
         .register_type::<Examples>()
         .register_type::<ExamplesRes>()
         .register_type::<ExampleSelected>()
@@ -253,11 +261,12 @@ fn main() {
 
 fn init(world: &mut World) {
     // save all entities that are in the world before setting up any example
-    // to be able to always return to this state when switching from one example to the other
+    // to be able to always return to this state when switching from one example to the other.
+    // Resource-backed entities (carrying `IsResource`) are excluded: in Bevy 0.19 resources are
+    // stored as entities, and despawning them in `cleanup` panics.
     world.resource_mut::<ExamplesRes>().entities_before = world
-        .query::<EntityRef>()
+        .query_filtered::<Entity, Without<IsResource>>()
         .iter(world)
-        .map(|e| e.id())
         .collect::<Vec<_>>();
 }
 
@@ -265,11 +274,16 @@ fn cleanup(world: &mut World) {
     let keep_alive = world.resource::<ExamplesRes>().entities_before.clone();
 
     let remove = world
-        .query::<EntityRef>()
+        .query_filtered::<Entity, Without<IsResource>>()
         .iter(world)
-        .filter_map(|e| (!keep_alive.contains(&e.id())).then_some(e.id()))
+        .filter(|e| !keep_alive.contains(e))
         .collect::<Vec<_>>();
     for r in remove {
+        // The entity may already have been despawned as part of a parent's despawn cascade;
+        // skip it in that case to avoid a flood of spurious "invalid entity" warnings.
+        if !world.entities().contains(r) {
+            continue;
+        }
         if let Err(error @ EntityDespawnError(_)) = world.try_despawn(r) {
             warn!("Cleanup error: {error:?}");
         }

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 rapier3d = "0.32.0"
 bevy_rapier3d = { version = "0.34", path = "../bevy_rapier3d" }
-bevy = { version = "0.18.1", default-features = false }
+bevy = { version = "0.19.0", default-features = false }
 
 [dev-dependencies]
 divan = "0.1"

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rapier3d = "0.32.0"
+rapier3d = { workspace = true }
 bevy_rapier3d = { version = "0.34", path = "../bevy_rapier3d" }
 bevy = { version = "0.19.0", default-features = false }
 

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.18.1"
+bevy = "0.19.0"
 bevy_rapier3d = { version = "0.34", path = "../bevy_rapier3d" }
 bevy_rapier2d = { version = "0.34", path = "../bevy_rapier2d" }
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,16 @@ ignore = [
     # - https://github.com/bevyengine/bevy/pull/18209
     # Bevy relies on this in multiple indirect ways, so ignoring it is the only feasible current solution
     "RUSTSEC-2024-0436",
+    # quick-xml advisories: pulled in transitively via bevy -> wayland-scanner, which
+    # pins quick-xml 0.39 and has no compatible upgrade to the patched >=0.41.0 yet.
+    # See: https://rustsec.org/advisories/RUSTSEC-2026-0194
+    "RUSTSEC-2026-0194",
+    # See: https://rustsec.org/advisories/RUSTSEC-2026-0195
+    "RUSTSEC-2026-0195",
+    # ttf-parser is unmaintained with no safe upgrade available; pulled in transitively
+    # via bevy -> ab_glyph -> owned_ttf_parser.
+    # See: https://rustsec.org/advisories/RUSTSEC-2026-0192
+    "RUSTSEC-2026-0192",
 ]
 
 [licenses]

--- a/src/picking_backend/mod.rs
+++ b/src/picking_backend/mod.rs
@@ -148,6 +148,7 @@ pub fn update_hits(
                             position: Some(bevy::math::Vec3::new(ray.origin.x, ray.origin.y, 0.0)),
                             normal: None,
                             depth: 0.0,
+                            extra: None,
                         };
                         picks.push((entity, hit_data));
                     }
@@ -163,6 +164,7 @@ pub fn update_hits(
                             position: Some(intersection.point),
                             normal: Some(intersection.normal),
                             depth: intersection.time_of_impact,
+                            extra: None,
                         };
                         picks.push((entity, hit_data));
                     }

--- a/src/plugin/plugin.rs
+++ b/src/plugin/plugin.rs
@@ -343,15 +343,17 @@ where
     fn finish(&self, _app: &mut App) {
         #[cfg(all(feature = "dim3", feature = "async-collider"))]
         {
-            use bevy::{asset::AssetPlugin, mesh::MeshPlugin, scene::ScenePlugin};
+            use bevy::{
+                asset::AssetPlugin, mesh::MeshPlugin, world_serialization::WorldSerializationPlugin,
+            };
             if !_app.is_plugin_added::<AssetPlugin>() {
                 _app.add_plugins(AssetPlugin::default());
             }
             if !_app.is_plugin_added::<MeshPlugin>() {
                 _app.add_plugins(MeshPlugin);
             }
-            if !_app.is_plugin_added::<ScenePlugin>() {
-                _app.add_plugins(ScenePlugin);
+            if !_app.is_plugin_added::<WorldSerializationPlugin>() {
+                _app.add_plugins(WorldSerializationPlugin);
             }
         }
     }

--- a/src/plugin/systems/collider.rs
+++ b/src/plugin/systems/collider.rs
@@ -19,7 +19,7 @@ use rapier::geometry::ColliderBuilder;
 #[cfg(all(feature = "dim3", feature = "async-collider"))]
 use {
     crate::prelude::{AsyncCollider, AsyncSceneCollider},
-    bevy::scene::SceneInstance,
+    bevy::world_serialization::WorldInstance,
 };
 
 #[cfg(feature = "dim2")]
@@ -533,8 +533,8 @@ pub fn init_async_colliders(
 pub fn init_async_scene_colliders(
     mut commands: Commands,
     meshes: Res<Assets<Mesh>>,
-    scene_spawner: Res<SceneSpawner>,
-    async_colliders: Query<(Entity, &SceneInstance, &AsyncSceneCollider)>,
+    scene_spawner: If<Res<WorldInstanceSpawner>>,
+    async_colliders: Query<(Entity, &WorldInstance, &AsyncSceneCollider)>,
     children: Query<&Children>,
     mesh_handles: Query<(&Name, &Mesh3d)>,
 ) {
@@ -600,10 +600,10 @@ pub mod test {
     #[cfg(all(feature = "dim3", feature = "async-collider"))]
     fn async_collider_initializes() {
         use super::*;
-        use bevy::{mesh::MeshPlugin, scene::ScenePlugin};
+        use bevy::{mesh::MeshPlugin, world_serialization::WorldSerializationPlugin};
 
         let mut app = App::new();
-        app.add_plugins((AssetPlugin::default(), MeshPlugin, ScenePlugin));
+        app.add_plugins((AssetPlugin::default(), MeshPlugin, WorldSerializationPlugin));
         app.add_systems(Update, init_async_colliders);
 
         app.finish();
@@ -633,10 +633,10 @@ pub mod test {
     #[cfg(all(feature = "dim3", feature = "async-collider"))]
     fn async_scene_collider_initializes() {
         use super::*;
-        use bevy::{mesh::MeshPlugin, scene::ScenePlugin};
+        use bevy::{mesh::MeshPlugin, world_serialization::WorldSerializationPlugin};
 
         let mut app = App::new();
-        app.add_plugins((AssetPlugin::default(), MeshPlugin, ScenePlugin));
+        app.add_plugins((AssetPlugin::default(), MeshPlugin, WorldSerializationPlugin));
         app.add_systems(PostUpdate, init_async_scene_colliders);
 
         let mut meshes = app.world_mut().resource_mut::<Assets<Mesh>>();
@@ -651,15 +651,15 @@ pub mod test {
             .spawn((Name::new("Capsule"), Mesh3d(capsule_handle)))
             .id();
 
-        let mut scenes = app.world_mut().resource_mut::<Assets<Scene>>();
-        let scene = scenes.add(Scene::new(World::new()));
+        let mut scenes = app.world_mut().resource_mut::<Assets<WorldAsset>>();
+        let scene = scenes.add(WorldAsset::new(World::new()));
 
         let mut named_shapes = bevy::platform::collections::HashMap::default();
         named_shapes.insert("Capsule".to_string(), None);
         let parent = app
             .world_mut()
             .spawn((
-                SceneRoot(scene),
+                WorldAssetRoot(scene),
                 AsyncSceneCollider {
                     named_shapes,
                     ..Default::default()

--- a/src/plugin/systems/remove.rs
+++ b/src/plugin/systems/remove.rs
@@ -13,7 +13,7 @@ use crate::plugin::context::{
 use crate::prelude::MassModifiedEvent;
 use crate::prelude::RigidBodyDisabled;
 use crate::prelude::Sensor;
-use bevy::ecs::query::QueryData;
+use bevy::ecs::query::IterQueryData;
 use bevy::prelude::*;
 
 /// System responsible for removing from Rapier the rigid-bodies/colliders/joints which had
@@ -242,7 +242,7 @@ pub fn sync_removals(
     // TODO: what about removing forces?
 }
 
-fn find_context<'a, TReturn, TQueryParams: QueryData>(
+fn find_context<'a, TReturn, TQueryParams: IterQueryData>(
     context_writer: &'a mut Query<TQueryParams>,
     item_finder: impl Fn(&mut TQueryParams::Item<'_, '_>) -> Option<TReturn>,
 ) -> Option<(TQueryParams::Item<'a, 'a>, TReturn)> {


### PR DESCRIPTION
This PR begins the update to Bevy 0.19.0.

## What has been done
- Updated `bevy` to `0.19.0`
- Updated `glam` to `0.32.1`
- Updated other dependencies to Bevy 0.19 compatible versions:
  - `bevy_inspector_egui` to `0.37.0`
  - `bevy_egui` to `0.40.0`
  - `bevy_mod_debugdump` to `0.16.0`

## Remaining blockers
The main issue is a **glam version conflict**:
- Bevy 0.19 depends on `glam 0.32.1`
- `glamx 0.1.3` (used by `rapier 0.32.0` and `parry 0.26.1`) depends on `glam 0.30.10`

## Update path
`glamx 0.2.0` matches `glam 0.32.1` perfectly.
However, the latest `rapier 0.33.0` and `parry 0.28.0` have already moved to `glamx 0.3.0` (which uses `glam 0.33`)

Once the version conflict is resolved, remaining Bevy 0.19 API changes will be addressed.

### Feedback is welcome.