### PR TITLE
Update to rapier 0.35.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Clippy for bevy_rapier3d
         run: cargo clippy --verbose -p bevy_rapier3d --examples
       - name: Clippy for bevy_rapier2d (debug-render, simd, serde)
-        run: cargo clippy --verbose -p bevy_rapier2d --features debug-render-2d,simd-stable,serde-serialize,picking-backend
+        run: cargo clippy --verbose -p bevy_rapier2d --features debug-render-2d,simd8,serde-serialize,picking-backend
       - name: Clippy for bevy_rapier3d (debug-render, simd, serde)
-        run: cargo clippy --verbose -p bevy_rapier3d --features debug-render-3d,simd-stable,serde-serialize,picking-backend
+        run: cargo clippy --verbose -p bevy_rapier3d --features debug-render-3d,simd8,serde-serialize,picking-backend
       - name: Test for bevy_rapier2d
         run: cargo test --verbose -p bevy_rapier2d
       - name: Test for bevy_rapier3d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Modified
+
+- Update from rapier `0.33.0-alpha` to rapier `0.35.0-glamx0.2`.
+  See [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md) for details.
+  - Removed the `simd-stable` and `simd-nightly` features: SIMD is now always enabled in rapier.
+    The new `simd8` feature widens the solver’s SIMD from 4 to 8 lanes (f32 only, incompatible
+    with `enhanced-determinism`).
+  - `SolverContactView::{friction, restitution}` now read from the contact manifold data (rapier
+    stores them per-manifold), and `SolverContactView::point` is reconstructed from the body-local
+    contact anchors; the public API is preserved.
+  - Custom event handlers assigned to `RapierContextSimulation` must now be `Send + Sync`.
+- Known issue: the `enhanced-determinism` feature currently fails to compile with bevy, because
+  parry enables `glam/scalar-math` which removes the serde impls of `glam::BVec3A`/`BVec4A` that
+  `bevy_reflect` requires unconditionally.
+
 ## v0.35.0 (12 July 2026)
 
 ### Modified

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ members = ["bevy_rapier2d", "bevy_rapier3d", "bevy_rapier_benches3d", "ci"]
 resolver = "2"
 
 [workspace.dependencies]
-rapier2d = "=0.33.0-alpha"
-rapier3d = "=0.33.0-alpha"
+rapier2d = "=0.35.0-glamx0.2"
+rapier3d = "=0.35.0-glamx0.2"
 
 [profile.dev]
 # Use slightly better optimization by default, as examples otherwise seem laggy.

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier2d"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier2d"

--- a/bevy_rapier2d/Cargo.toml
+++ b/bevy_rapier2d/Cargo.toml
@@ -49,8 +49,7 @@ debug-render-3d = [
 rapier-debug-render = ["rapier2d/debug-render"]
 
 parallel = ["rapier2d/parallel"]
-simd-stable = ["rapier2d/simd-stable"]
-simd-nightly = ["rapier2d/simd-nightly"]
+simd8 = ["rapier2d/simd8"]
 serde-serialize = ["rapier2d/serde-serialize", "bevy/serialize", "serde"]
 enhanced-determinism = ["rapier2d/enhanced-determinism"]
 headless = []
@@ -104,10 +103,12 @@ features = ["debug-render-2d", "serde-serialize"]
 
 [package.metadata.cargo-all-features]
 
-denylist = ["simd-nightly"]
+# `enhanced-determinism` enables `glam/scalar-math` (through parry), which removes the serde
+# impls of `glam::BVec3A`/`BVec4A` that `bevy_reflect` requires unconditionally.
+denylist = ["enhanced-determinism"]
 
 # Features "dim2" and "dim3" are incompatible, so skip permutations including them
-skip_feature_sets = [["enhanced-determinism", "simd-stable"]]
+skip_feature_sets = [["enhanced-determinism", "simd8"]]
 
 always_include_features = ["dim2"]
 

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_rapier3d"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust, official Bevy plugin."
 documentation = "http://docs.rs/bevy_rapier3d"

--- a/bevy_rapier3d/Cargo.toml
+++ b/bevy_rapier3d/Cargo.toml
@@ -50,8 +50,7 @@ debug-render-3d = [
 rapier-debug-render = ["rapier3d/debug-render"]
 
 parallel = ["rapier3d/parallel"]
-simd-stable = ["rapier3d/simd-stable"]
-simd-nightly = ["rapier3d/simd-nightly"]
+simd8 = ["rapier3d/simd8"]
 serde-serialize = ["rapier3d/serde-serialize", "bevy/serialize", "serde"]
 enhanced-determinism = ["rapier3d/enhanced-determinism"]
 headless = []
@@ -97,10 +96,12 @@ features = ["debug-render-3d", "serde-serialize", "async-collider"]
 
 [package.metadata.cargo-all-features]
 
-denylist = ["simd-nightly"]
+# `enhanced-determinism` enables `glam/scalar-math` (through parry), which removes the serde
+# impls of `glam::BVec3A`/`BVec4A` that `bevy_reflect` requires unconditionally.
+denylist = ["enhanced-determinism"]
 
 # Features "dim2" and "dim3" are incompatible, so skip permutations including them
-skip_feature_sets = [["enhanced-determinism", "simd-stable"]]
+skip_feature_sets = [["enhanced-determinism", "simd8"]]
 
 always_include_features = ["dim3"]
 

--- a/bevy_rapier_benches3d/Cargo.toml
+++ b/bevy_rapier_benches3d/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 rapier3d = { workspace = true }
-bevy_rapier3d = { version = "0.35", path = "../bevy_rapier3d" }
+bevy_rapier3d = { version = "0.36", path = "../bevy_rapier3d" }
 bevy = { version = "0.19.0", default-features = false }
 
 [dev-dependencies]

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 bevy = "0.19.0"
-bevy_rapier3d = { version = "0.35", path = "../bevy_rapier3d" }
-bevy_rapier2d = { version = "0.35", path = "../bevy_rapier2d" }
+bevy_rapier3d = { version = "0.36", path = "../bevy_rapier3d" }
+bevy_rapier2d = { version = "0.36", path = "../bevy_rapier2d" }
 
 [[bin]]
 name = "ambiguity_detection"

--- a/src/plugin/context/mod.rs
+++ b/src/plugin/context/mod.rs
@@ -432,16 +432,13 @@ impl<'a> RapierQueryPipeline<'a> {
     ///
     /// # Parameters
     /// * `point` - The point to project.
-    /// * `solid` - If this is set to `true` then the collider shapes are considered to
-    ///   be plain (if the point is located inside of a plain shape, its projection is the point
-    ///   itself). If it is set to `false` the collider shapes are considered to be hollow
-    ///   (if the point is located inside of an hollow shape, it is projected on the shape's
-    ///   boundary).
     pub fn project_point_and_get_feature(
         &self,
         point: Vect,
     ) -> Option<(Entity, PointProjection, FeatureId)> {
-        let (h, proj, fid) = self.query_pipeline.project_point_and_get_feature(point)?;
+        let (h, proj, fid) = self
+            .query_pipeline
+            .project_point_and_get_feature(point, Real::MAX)?;
 
         Some((
             self.collider_entity(h),
@@ -622,8 +619,8 @@ impl RapierRigidBodySet {
         let impulse_joint = joints.impulse_joints.get(*joint_handle)?;
         let revolute_joint = impulse_joint.data.as_revolute()?;
 
-        let rb1 = &self.bodies[impulse_joint.body1];
-        let rb2 = &self.bodies[impulse_joint.body2];
+        let rb1 = &self.bodies[impulse_joint.body1()];
+        let rb2 = &self.bodies[impulse_joint.body2()];
         Some(revolute_joint.angle(rb1.rotation(), rb2.rotation()))
     }
 }
@@ -658,7 +655,7 @@ pub struct RapierContextSimulation {
     /// The integration parameters, controlling various low-level coefficient of the simulation.
     pub integration_parameters: IntegrationParameters,
     #[cfg_attr(feature = "serde-serialize", serde(skip))]
-    pub(crate) event_handler: Option<Box<dyn EventHandler>>,
+    pub(crate) event_handler: Option<Box<dyn EventHandler + Send + Sync>>,
     // This maps the handles of colliders that have been deleted since the last
     // physics update, to the entity they was attached to.
     /// NOTE: this map is needed to handle despawning.
@@ -725,6 +722,7 @@ impl RapierContextSimulation {
         let event_handler = self
             .event_handler
             .as_deref()
+            .map(|h| h as &dyn EventHandler)
             .or_else(|| event_queue.as_ref().map(|q| q as &dyn EventHandler))
             .unwrap_or(&() as &dyn EventHandler);
 

--- a/src/plugin/narrow_phase.rs
+++ b/src/plugin/narrow_phase.rs
@@ -1,7 +1,10 @@
 use crate::math::{Real, Vect};
 use crate::plugin::context::{RapierContextColliders, RapierContextSimulation, RapierRigidBodySet};
 use bevy::prelude::*;
-use rapier::geometry::{Contact, ContactManifold, ContactPair, SolverContact, SolverFlags};
+use rapier::geometry::{
+    Contact, ContactManifold, ContactManifoldData, ContactPair, SolverContact, SolverFlags,
+    NEW_CONTACT_BIT,
+};
 
 impl RapierContextSimulation {
     /// All the contact pairs involving the non-sensor collider attached to the given entity.
@@ -214,7 +217,11 @@ impl ContactManifoldView<'_> {
             .data
             .solver_contacts
             .get(i)
-            .map(|raw| SolverContactView { raw })
+            .map(|raw| SolverContactView {
+                rigidbody_set: self.rigidbody_set,
+                manifold_data: &self.raw.data,
+                raw,
+            })
     }
 
     /// The contacts that will be seen by the constraints solver for computing forces.
@@ -223,7 +230,11 @@ impl ContactManifoldView<'_> {
             .data
             .solver_contacts
             .iter()
-            .map(|raw| SolverContactView { raw })
+            .map(|raw| SolverContactView {
+                rigidbody_set: self.rigidbody_set,
+                manifold_data: &self.raw.data,
+                raw,
+            })
     }
 
     /// The relative dominance of the bodies involved in this contact manifold.
@@ -302,6 +313,9 @@ impl ContactView<'_> {
 
 /// Read-only access to the properties of a single solver contact.
 pub struct SolverContactView<'a> {
+    rigidbody_set: &'a RapierRigidBodySet,
+    /// The data of the contact manifold this solver contact is part of.
+    pub manifold_data: &'a ContactManifoldData,
     /// The raw solver contact from Rapier.
     pub raw: &'a SolverContact,
 }
@@ -309,7 +323,10 @@ pub struct SolverContactView<'a> {
 impl SolverContactView<'_> {
     /// The world-space contact point.
     pub fn point(&self) -> Vect {
-        self.raw.point
+        let (p1, p2) = self
+            .manifold_data
+            .solver_contact_world_points(self.raw, &self.rigidbody_set.bodies);
+        (p1 + p2) / 2.0
     }
     /// The distance between the two original contacts points along the contact normal.
     /// If negative, this is measures the penetration depth.
@@ -318,11 +335,11 @@ impl SolverContactView<'_> {
     }
     /// The effective friction coefficient at this contact point.
     pub fn friction(&self) -> Real {
-        self.raw.friction
+        self.manifold_data.friction
     }
     /// The effective restitution coefficient at this contact point.
     pub fn restitution(&self) -> Real {
-        self.raw.restitution
+        self.manifold_data.restitution
     }
     /// The desired tangent relative velocity at the contact point.
     ///
@@ -333,7 +350,7 @@ impl SolverContactView<'_> {
     }
     /// Whether or not this contact existed during the last timestep.
     pub fn is_new(&self) -> bool {
-        self.raw.is_new == 1.0
+        self.raw.contact_id[0] & NEW_CONTACT_BIT != 0
     }
 }
 

--- a/src/reflect/mod.rs
+++ b/src/reflect/mod.rs
@@ -66,6 +66,14 @@ pub struct IntegrationParametersWrapper {
     #[reflect(remote = SpringCoefficientsWrapper)]
     pub contact_softness: SpringCoefficients<Real>,
 
+    /// Softness coefficients for contact constraints where one side is a fixed body.
+    ///
+    /// Stiffer than [`IntegrationParameters::contact_softness`] by default so bodies are
+    /// held firmly against static walls/floors; set equal to
+    /// [`IntegrationParameters::contact_softness`] to disable.
+    #[reflect(remote = SpringCoefficientsWrapper)]
+    pub static_contact_softness: SpringCoefficients<Real>,
+
     /// The coefficient in `[0, 1]` applied to warmstart impulses, i.e., impulses that are used as the
     /// initial solution (instead of 0) at the next simulation step.
     ///
@@ -101,16 +109,34 @@ pub struct IntegrationParametersWrapper {
     ///
     /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
     pub normalized_prediction_distance: Real,
+    /// Maximum linear velocity a body may have after each solver substep (default: `400.0` m/s).
+    ///
+    /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
+    pub normalized_max_linear_velocity: Real,
     /// The number of solver iterations run by the constraints solver for calculating forces (default: `4`).
     pub num_solver_iterations: usize,
     /// Number of internal Project Gauss Seidel (PGS) iterations run at each solver iteration (default: `1`).
     pub num_internal_pgs_iterations: usize,
     /// The number of stabilization iterations run at each solver iterations (default: `1`).
     pub num_internal_stabilization_iterations: usize,
-    /// Minimum number of dynamic bodies in each active island (default: `128`).
-    pub min_island_size: usize,
     /// Maximum number of substeps performed by the  solver (default: `1`).
     pub max_ccd_substeps: usize,
+    /// If enabled, contact manifolds of a collider pair sharing (nearly) the same normal are
+    /// merged into one "cluster" manifold before constraint generation (default: `true`, 3D only).
+    pub contact_clustering: bool,
+    /// If enabled, a contact pair that barely moved since its last full narrow-phase update
+    /// skips contact determination and keeps its existing contact points (default: `true`).
+    pub contact_recycling: bool,
+    /// Maximum relative-pose drift below which a contact pair may be recycled instead of fully
+    /// updated (default: `0.05`). Only used when contact recycling is enabled.
+    ///
+    /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
+    pub normalized_contact_recycle_distance: Real,
+    /// If `false`, friction is only solved during the unbiased (relax) pass of each substep
+    /// instead of both passes (default: `false`).
+    pub friction_in_bias_pass: bool,
+    /// If enabled, impulse-joint constraints are warm-started like contacts (default: `false`).
+    pub warmstart_joints: bool,
 }
 
 // These structs are duplicated in their entirety due to [`FrictionModel`] not being available in 2D, and `bevy::reflect_remote` not supporting conditional fields.
@@ -137,6 +163,14 @@ pub struct IntegrationParametersWrapper {
     #[reflect(remote = SpringCoefficientsWrapper)]
     pub contact_softness: SpringCoefficients<Real>,
 
+    /// Softness coefficients for contact constraints where one side is a fixed body.
+    ///
+    /// Stiffer than [`IntegrationParameters::contact_softness`] by default so bodies are
+    /// held firmly against static walls/floors; set equal to
+    /// [`IntegrationParameters::contact_softness`] to disable.
+    #[reflect(remote = SpringCoefficientsWrapper)]
+    pub static_contact_softness: SpringCoefficients<Real>,
+
     /// The coefficient in `[0, 1]` applied to warmstart impulses, i.e., impulses that are used as the
     /// initial solution (instead of 0) at the next simulation step.
     ///
@@ -172,16 +206,34 @@ pub struct IntegrationParametersWrapper {
     ///
     /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
     pub normalized_prediction_distance: Real,
+    /// Maximum linear velocity a body may have after each solver substep (default: `400.0` m/s).
+    ///
+    /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
+    pub normalized_max_linear_velocity: Real,
     /// The number of solver iterations run by the constraints solver for calculating forces (default: `4`).
     pub num_solver_iterations: usize,
     /// Number of internal Project Gauss Seidel (PGS) iterations run at each solver iteration (default: `1`).
     pub num_internal_pgs_iterations: usize,
     /// The number of stabilization iterations run at each solver iterations (default: `1`).
     pub num_internal_stabilization_iterations: usize,
-    /// Minimum number of dynamic bodies in each active island (default: `128`).
-    pub min_island_size: usize,
     /// Maximum number of substeps performed by the  solver (default: `1`).
     pub max_ccd_substeps: usize,
+    /// If enabled, contact manifolds of a collider pair sharing (nearly) the same normal are
+    /// merged into one "cluster" manifold before constraint generation (default: `true`, 3D only).
+    pub contact_clustering: bool,
+    /// If enabled, a contact pair that barely moved since its last full narrow-phase update
+    /// skips contact determination and keeps its existing contact points (default: `true`).
+    pub contact_recycling: bool,
+    /// Maximum relative-pose drift below which a contact pair may be recycled instead of fully
+    /// updated (default: `0.05`). Only used when contact recycling is enabled.
+    ///
+    /// This value is implicitly scaled by [`IntegrationParameters::length_unit`].
+    pub normalized_contact_recycle_distance: Real,
+    /// If `false`, friction is only solved during the unbiased (relax) pass of each substep
+    /// instead of both passes (default: `false`).
+    pub friction_in_bias_pass: bool,
+    /// If enabled, impulse-joint constraints are warm-started like contacts (default: `false`).
+    pub warmstart_joints: bool,
     /// Friction models used for all contact constraints between two rigid-bodies.
     #[reflect(remote = FrictionModelWrapper)]
     pub friction_model: FrictionModel,


### PR DESCRIPTION
This updates the rapier dependency to 0.35.0, bring massive performance improvements.

This actually uses a special version of rapier: `0.35.0-glamx0.2` which is essentially the same as `0.35.0` but with its glamx dependency pinned to `0.2` instead of the latest `0.3`. That way, `bevy_rapier` can be compatible with bevy 0.19 which still depends on an outdated version of `glam`. We will switch to the "normal" rapier version `0.35.0` when bevy 0.20 gets released with the latest `glam`.

You can see more there: https://github.com/dimforge/rapier/pull/973

I’m attaching the summary on performance improvements below (copied from the Rapier PR) for visibility.

-----

The graphs show performance comparisons of various 2D and 3D physics engines in single-thread and multi-thread mode. The benchmarks are run on a Macbook Pro M4 Max. The general trends are that the new rapier is:
- about 50% (single-thread) or 300% (multi-thread) faster than the previous version.
- about on-par-to-slightly-faster than Box3D (especially on single-threaded simulations).
- about on-par-to-slightly-slower than Box2D (especially on multi-threaded simulations).
- about 150% (single-thread) or 280% (multi-thread) faster than Avian.
- about 50% (single-thread) or 100% (multi-thread) faster than Jolt. It is also significantly more stable on stacks than Jolt.

<img width="2160" height="864" alt="3d_balls" src="https://github.com/user-attachments/assets/ec7fc709-1820-4585-9fdf-8471a52b7960" />
<img width="2160" height="864" alt="3d_boxes" src="https://github.com/user-attachments/assets/1e829cc1-2a3b-4c93-a57e-2668446e1317" />
<img width="2160" height="864" alt="3d_capsules" src="https://github.com/user-attachments/assets/4fea4cb9-b9f2-4a17-9f0e-c7c51b62abdc" />
<img width="2160" height="864" alt="3d_convex_hulls" src="https://github.com/user-attachments/assets/dfdbf6e8-6cfa-4820-a81e-62d06bdd9b1c" />
<img width="2160" height="864" alt="3d_joint_grid" src="https://github.com/user-attachments/assets/8e9a3977-b4d4-4c00-9c58-707109376079" />
<img width="2160" height="864" alt="3d_large_pyramid" src="https://github.com/user-attachments/assets/c053ab9a-a001-4357-bf06-f2140631e4f7" />
<img width="2160" height="864" alt="3d_many_pyramids" src="https://github.com/user-attachments/assets/8ae94963-068b-40f6-a396-6309dffd2d15" />
<img width="2160" height="864" alt="3d_ragdolls" src="https://github.com/user-attachments/assets/5a97da62-9495-4077-af3c-38868a658bc0" />

<img width="2160" height="864" alt="2d_balls" src="https://github.com/user-attachments/assets/8f0463b7-febb-4e55-bb08-ef173f1119eb" />
<img width="2160" height="864" alt="2d_boxes" src="https://github.com/user-attachments/assets/6319f538-3ff7-43e0-9af6-37aca5b1b881" />
<img width="2160" height="864" alt="2d_capsules" src="https://github.com/user-attachments/assets/88469750-106a-48ad-9c35-a321e70387a0" />
<img width="2160" height="864" alt="2d_convex_polygons" src="https://github.com/user-attachments/assets/090343b2-0209-4e37-88d8-4cb191b9097a" />
<img width="2160" height="864" alt="2d_joint_grid" src="https://github.com/user-attachments/assets/03969f4c-f6d4-48a6-8932-aaf35ec8f0c7" />
<img width="2160" height="864" alt="2d_large_pyramid" src="https://github.com/user-attachments/assets/b86ce88b-76d0-42ae-84e3-a556a37f8338" />
<img width="2160" height="864" alt="2d_many_pyramids" src="https://github.com/user-attachments/assets/f82f4de7-0778-4dff-8268-fff5e75bb3a4" />
<img width="2160" height="864" alt="2d_ragdolls" src="https://github.com/user-attachments/assets/69f74710-c535-4a19-8020-480f7f270349" />
